### PR TITLE
feat(character-system): Multi-system sheets + XP/challenges/rewards integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7378,6 +7378,7 @@ dependencies = [
  "mockall",
  "neo4rs",
  "rand 0.8.5",
+ "regex-lite",
  "reqwest",
  "serde",
  "serde_json",

--- a/crates/domain/src/character_sheet.rs
+++ b/crates/domain/src/character_sheet.rs
@@ -1,0 +1,556 @@
+//! Character Sheet Schema Types for Game System Rendering
+//!
+//! This module defines the schema types for dynamic character sheet rendering.
+//! The engine sends these schemas to the client, which renders the appropriate
+//! fields without needing system-specific knowledge.
+//!
+//! # Distinction from sheet_template.rs
+//!
+//! - `sheet_template.rs`: Stored templates for world-specific character sheets
+//! - `character_sheet.rs` (this): Game system schemas for engine-driven rendering
+//!
+//! # Design Philosophy
+//!
+//! - **Engine-driven rendering**: The engine knows about game systems, the client just displays
+//! - **Field-level granularity**: Each field has a type, validation, and display hints
+//! - **Calculated fields**: Some fields derive from others (e.g., ability modifiers)
+//! - **Sections**: Fields are grouped into logical sections for UI layout
+
+use serde::{Deserialize, Serialize};
+
+// =============================================================================
+// Character Sheet Schema
+// =============================================================================
+
+/// Complete schema for rendering a character sheet.
+///
+/// Sent by the engine to describe what fields/sections a character sheet
+/// should display for a given game system.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CharacterSheetSchema {
+    /// Game system ID (e.g., "dnd5e", "pf2e", "blades")
+    pub system_id: String,
+    /// Human-readable system name
+    pub system_name: String,
+    /// Ordered list of sections to display
+    pub sections: Vec<SchemaSection>,
+    /// Character creation steps (if applicable)
+    #[serde(default)]
+    pub creation_steps: Vec<CreationStep>,
+}
+
+/// A section of the character sheet (e.g., "Ability Scores", "Skills", "Combat").
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SchemaSection {
+    /// Unique section identifier
+    pub id: String,
+    /// Display label for the section header
+    pub label: String,
+    /// Type of section (affects layout)
+    pub section_type: SectionType,
+    /// Fields within this section
+    pub fields: Vec<FieldDefinition>,
+    /// Whether this section is collapsible
+    #[serde(default)]
+    pub collapsible: bool,
+    /// Whether collapsed by default
+    #[serde(default)]
+    pub collapsed_default: bool,
+    /// Help text for the section
+    #[serde(default)]
+    pub description: Option<String>,
+}
+
+/// Type of section, affects rendering layout.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SectionType {
+    /// Ability scores / attributes (grid layout)
+    AbilityScores,
+    /// Skills (list with checkboxes for proficiency)
+    Skills,
+    /// Combat stats (AC, HP, speed, etc.)
+    Combat,
+    /// Spellcasting section
+    Spellcasting,
+    /// Resources (stress, fate points, etc.)
+    Resources,
+    /// Inventory/equipment
+    Inventory,
+    /// Character info (name, background, etc.)
+    Identity,
+    /// Features and abilities
+    Features,
+    /// Progress clocks (Blades in the Dark)
+    Clocks,
+    /// Moves (PbtA)
+    Moves,
+    /// Free-form section
+    Custom,
+    /// Unknown for forward compatibility
+    #[serde(other)]
+    Unknown,
+}
+
+// =============================================================================
+// Field Definitions
+// =============================================================================
+
+/// Definition of a single field in the character sheet.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FieldDefinition {
+    /// Unique field identifier (matches stat/property name)
+    pub id: String,
+    /// Display label
+    pub label: String,
+    /// Field data type and rendering hints
+    pub field_type: SchemaFieldType,
+    /// Whether this field can be edited by players
+    #[serde(default = "default_true")]
+    pub editable: bool,
+    /// Whether this field is required
+    #[serde(default)]
+    pub required: bool,
+    /// If this is a calculated field, the formula reference
+    #[serde(default)]
+    pub derived_from: Option<DerivedField>,
+    /// Validation rules
+    #[serde(default)]
+    pub validation: Option<FieldValidation>,
+    /// Layout hints
+    #[serde(default)]
+    pub layout: FieldLayout,
+    /// Help text / tooltip
+    #[serde(default)]
+    pub description: Option<String>,
+    /// Placeholder text for empty fields
+    #[serde(default)]
+    pub placeholder: Option<String>,
+}
+
+fn default_true() -> bool {
+    true
+}
+
+/// Type of field data and how to render it.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case", tag = "type")]
+pub enum SchemaFieldType {
+    /// Plain text input
+    Text {
+        #[serde(default)]
+        multiline: bool,
+        #[serde(default)]
+        max_length: Option<usize>,
+    },
+    /// Integer number
+    Integer {
+        #[serde(default)]
+        min: Option<i32>,
+        #[serde(default)]
+        max: Option<i32>,
+        /// If true, display as +/- modifier
+        #[serde(default)]
+        show_modifier: bool,
+    },
+    /// D&D-style ability score with modifier display
+    AbilityScore {
+        #[serde(default)]
+        min: Option<i32>,
+        #[serde(default)]
+        max: Option<i32>,
+    },
+    /// Skill with proficiency level
+    Skill {
+        /// The ability this skill is based on
+        ability: String,
+        /// Available proficiency levels
+        proficiency_levels: Vec<ProficiencyOption>,
+    },
+    /// Saving throw
+    SavingThrow {
+        /// The ability for this save
+        ability: String,
+    },
+    /// Boolean checkbox
+    Boolean {
+        /// Label for checked state
+        #[serde(default)]
+        checked_label: Option<String>,
+        /// Label for unchecked state
+        #[serde(default)]
+        unchecked_label: Option<String>,
+    },
+    /// Selection from options
+    Select {
+        options: Vec<SchemaSelectOption>,
+        #[serde(default)]
+        allow_custom: bool,
+    },
+    /// Multiple selection
+    MultiSelect {
+        options: Vec<SchemaSelectOption>,
+        #[serde(default)]
+        max_selections: Option<usize>,
+    },
+    /// HP / resource bar
+    ResourceBar {
+        /// ID of the max value field
+        max_field: String,
+        /// Color theme
+        #[serde(default)]
+        color: ResourceColor,
+    },
+    /// Dice pool (Blades, WoD)
+    DicePool {
+        /// Maximum dice in pool
+        max_dice: u8,
+        /// Die type (d6, d10, etc.)
+        die_type: u8,
+    },
+    /// Ladder rating (FATE)
+    LadderRating {
+        /// Minimum rating value
+        min: i32,
+        /// Maximum rating value
+        max: i32,
+        /// Rating labels
+        labels: Vec<LadderLabel>,
+    },
+    /// Percentile skill (CoC)
+    PercentileSkill {
+        /// Whether to show half/fifth values
+        #[serde(default)]
+        show_derived: bool,
+    },
+    /// Progress clock (Blades)
+    Clock {
+        /// Number of segments
+        segments: u8,
+    },
+    /// Harm/condition track
+    ConditionTrack {
+        /// Levels of the track
+        levels: Vec<ConditionLevel>,
+    },
+    /// Reference to another entity (class, race, etc.)
+    EntityRef {
+        /// Type of entity being referenced
+        entity_type: EntityRefType,
+    },
+    /// Tags/keywords list
+    Tags,
+    /// Unknown for forward compatibility
+    #[serde(other)]
+    Unknown,
+}
+
+/// Option for select fields.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SchemaSelectOption {
+    /// Internal value
+    pub value: String,
+    /// Display label
+    pub label: String,
+    /// Optional description
+    #[serde(default)]
+    pub description: Option<String>,
+}
+
+/// Proficiency option for skills.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ProficiencyOption {
+    /// Internal value
+    pub value: String,
+    /// Display label
+    pub label: String,
+    /// Multiplier for proficiency bonus
+    pub multiplier: f32,
+}
+
+/// Label for ladder ratings.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LadderLabel {
+    pub value: i32,
+    pub label: String,
+}
+
+/// Level in a condition/harm track.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ConditionLevel {
+    pub level: u8,
+    pub label: String,
+    #[serde(default)]
+    pub effect: Option<String>,
+}
+
+/// Color theme for resource bars.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ResourceColor {
+    #[default]
+    Red,
+    Blue,
+    Green,
+    Purple,
+    Orange,
+    Gray,
+}
+
+/// Type of entity reference.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EntityRefType {
+    Class,
+    Race,
+    Background,
+    Playbook,
+    Archetype,
+    Occupation,
+    Custom,
+}
+
+// =============================================================================
+// Derived Fields
+// =============================================================================
+
+/// Specification for a calculated/derived field.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DerivedField {
+    /// Type of derivation
+    pub derivation_type: DerivationType,
+    /// Fields this depends on
+    pub dependencies: Vec<String>,
+    /// Optional display format
+    #[serde(default)]
+    pub display_format: Option<String>,
+}
+
+/// How a field is derived.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DerivationType {
+    /// D&D-style ability modifier: floor((score - 10) / 2)
+    AbilityModifier,
+    /// Proficiency bonus from level
+    ProficiencyBonus,
+    /// Skill modifier (ability + proficiency)
+    SkillModifier,
+    /// Save modifier (ability + proficiency if proficient)
+    SaveModifier,
+    /// Spell save DC (8 + prof + stat mod)
+    SpellSaveDc,
+    /// Spell attack (prof + stat mod)
+    SpellAttack,
+    /// Sum of dependent fields
+    Sum,
+    /// Maximum of dependent fields
+    Max,
+    /// Half of dependent field (rounded down)
+    HalfDown,
+    /// Fifth of dependent field (CoC)
+    Fifth,
+    /// Custom formula (evaluated server-side)
+    Custom,
+}
+
+// =============================================================================
+// Validation
+// =============================================================================
+
+/// Validation rules for a field.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FieldValidation {
+    /// Minimum value (for numeric)
+    #[serde(default)]
+    pub min: Option<i32>,
+    /// Maximum value (for numeric)
+    #[serde(default)]
+    pub max: Option<i32>,
+    /// Regex pattern (for text)
+    #[serde(default)]
+    pub pattern: Option<String>,
+    /// Error message for validation failure
+    #[serde(default)]
+    pub error_message: Option<String>,
+}
+
+// =============================================================================
+// Layout
+// =============================================================================
+
+/// Layout hints for field rendering.
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FieldLayout {
+    /// Width of field (1-12 grid columns)
+    #[serde(default)]
+    pub width: Option<u8>,
+    /// Whether to start a new row before this field
+    #[serde(default)]
+    pub new_row: bool,
+    /// CSS class to apply
+    #[serde(default)]
+    pub css_class: Option<String>,
+    /// Display order (lower = first)
+    #[serde(default)]
+    pub order: Option<i32>,
+}
+
+// =============================================================================
+// Character Creation
+// =============================================================================
+
+/// A step in the character creation process.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CreationStep {
+    /// Step identifier
+    pub id: String,
+    /// Step display name
+    pub label: String,
+    /// Step description
+    pub description: String,
+    /// Sections included in this step
+    pub section_ids: Vec<String>,
+    /// Order of this step
+    pub order: u8,
+    /// Whether this step is required
+    #[serde(default = "default_true")]
+    pub required: bool,
+}
+
+// =============================================================================
+// Character Data Exchange
+// =============================================================================
+
+/// Character sheet response with schema and values for rendering.
+///
+/// Combines the schema with the character's current values.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CharacterSheetResponse {
+    /// Character ID
+    pub character_id: String,
+    /// Character name
+    pub name: String,
+    /// The schema to use for rendering
+    pub schema: CharacterSheetSchema,
+    /// Current field values (field_id -> value)
+    pub values: std::collections::HashMap<String, serde_json::Value>,
+    /// Calculated/derived values (field_id -> calculated value)
+    pub calculated: std::collections::HashMap<String, serde_json::Value>,
+}
+
+/// Update to a character sheet field.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FieldUpdate {
+    /// Field ID being updated
+    pub field_id: String,
+    /// New value
+    pub value: serde_json::Value,
+}
+
+/// Response after updating a field.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FieldUpdateResponse {
+    /// Whether the update was successful
+    pub success: bool,
+    /// Updated calculated values (if any derived fields changed)
+    #[serde(default)]
+    pub updated_calculated: std::collections::HashMap<String, serde_json::Value>,
+    /// Validation errors (if any)
+    #[serde(default)]
+    pub errors: Vec<ValidationError>,
+}
+
+/// Validation error for a field.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ValidationError {
+    /// Field ID with the error
+    pub field_id: String,
+    /// Error message
+    pub message: String,
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_field_type_serialization() {
+        let field = SchemaFieldType::AbilityScore {
+            min: Some(1),
+            max: Some(30),
+        };
+        let json = serde_json::to_string(&field).unwrap();
+        assert!(json.contains("ability_score"));
+
+        let parsed: SchemaFieldType = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed, field);
+    }
+
+    #[test]
+    fn test_section_type_serialization() {
+        let section = SectionType::AbilityScores;
+        let json = serde_json::to_string(&section).unwrap();
+        assert_eq!(json, "\"ability_scores\"");
+    }
+
+    #[test]
+    fn test_character_sheet_schema() {
+        let schema = CharacterSheetSchema {
+            system_id: "dnd5e".to_string(),
+            system_name: "D&D 5th Edition".to_string(),
+            sections: vec![SchemaSection {
+                id: "abilities".to_string(),
+                label: "Ability Scores".to_string(),
+                section_type: SectionType::AbilityScores,
+                fields: vec![FieldDefinition {
+                    id: "STR".to_string(),
+                    label: "Strength".to_string(),
+                    field_type: SchemaFieldType::AbilityScore {
+                        min: Some(1),
+                        max: Some(30),
+                    },
+                    editable: true,
+                    required: true,
+                    derived_from: None,
+                    validation: Some(FieldValidation {
+                        min: Some(1),
+                        max: Some(30),
+                        pattern: None,
+                        error_message: Some("Must be between 1 and 30".to_string()),
+                    }),
+                    layout: FieldLayout::default(),
+                    description: Some("Physical power and carrying capacity".to_string()),
+                    placeholder: None,
+                }],
+                collapsible: false,
+                collapsed_default: false,
+                description: None,
+            }],
+            creation_steps: vec![],
+        };
+
+        let json = serde_json::to_string_pretty(&schema).unwrap();
+        assert!(json.contains("dnd5e"));
+        assert!(json.contains("Strength"));
+    }
+}

--- a/crates/domain/src/character_sheet.rs
+++ b/crates/domain/src/character_sheet.rs
@@ -87,6 +87,10 @@ pub enum SectionType {
     Clocks,
     /// Moves (PbtA)
     Moves,
+    /// Active modifiers/conditions
+    Modifiers,
+    /// Experience/advancement tracking
+    Advancement,
     /// Free-form section
     Custom,
     /// Unknown for forward compatibility
@@ -243,6 +247,19 @@ pub enum SchemaFieldType {
     },
     /// Tags/keywords list
     Tags,
+    /// XP progress bar showing current XP vs next level threshold
+    XpProgress {
+        /// Field ID for current XP
+        current_field: String,
+        /// Field ID for XP needed for next level (derived)
+        next_level_field: String,
+    },
+    /// List of active stat modifiers (conditions, effects, etc.)
+    ModifierList {
+        /// Which stat this modifier list is for (None = all modifiers)
+        #[serde(default)]
+        filter_stat: Option<String>,
+    },
     /// Unknown for forward compatibility
     #[serde(other)]
     Unknown,

--- a/crates/domain/src/entities/challenge.rs
+++ b/crates/domain/src/entities/challenge.rs
@@ -52,6 +52,10 @@ pub struct Challenge {
     pub is_favorite: bool,
     /// Tags for filtering
     pub tags: Vec<String>,
+    /// The stat to check for this challenge (e.g., "STR", "DEX", "ATHLETICS_MOD")
+    /// If None, the modifier will be 0 unless provided by the client.
+    #[serde(default)]
+    pub check_stat: Option<String>,
 }
 
 impl Challenge {
@@ -73,7 +77,14 @@ impl Challenge {
             order: 0,
             is_favorite: false,
             tags: Vec::new(),
+            check_stat: None,
         }
+    }
+
+    /// Set the stat to check for this challenge.
+    pub fn with_check_stat(mut self, stat: impl Into<String>) -> Self {
+        self.check_stat = Some(stat.into());
+        self
     }
 
     pub fn with_description(mut self, description: impl Into<String>) -> Self {

--- a/crates/domain/src/entities/character_content.rs
+++ b/crates/domain/src/entities/character_content.rs
@@ -1,0 +1,429 @@
+//! Character content - spells, feats, and features owned by a character.
+//!
+//! These structs represent the character's personal collection of abilities,
+//! including tracking of uses, preparation states, and choices made.
+
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+/// A character's spellcasting data.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct CharacterSpells {
+    /// Cantrips the character knows
+    #[serde(default)]
+    pub cantrips: Vec<String>,
+    /// Spells the character knows (for known-spell casters)
+    #[serde(default)]
+    pub known: Vec<KnownSpell>,
+    /// Currently prepared spells (spell IDs)
+    #[serde(default)]
+    pub prepared: Vec<String>,
+    /// Spell slots by level (1-9)
+    #[serde(default)]
+    pub slots: HashMap<u8, SpellSlotPool>,
+    /// Pact magic slots (for warlocks and similar)
+    pub pact_slots: Option<SpellSlotPool>,
+    /// Primary spellcasting ability (e.g., "INT", "WIS", "CHA")
+    pub spellcasting_ability: Option<String>,
+}
+
+impl CharacterSpells {
+    /// Create empty spellcasting data.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Add a cantrip.
+    pub fn add_cantrip(&mut self, spell_id: impl Into<String>) {
+        let id = spell_id.into();
+        if !self.cantrips.contains(&id) {
+            self.cantrips.push(id);
+        }
+    }
+
+    /// Learn a spell.
+    pub fn learn_spell(&mut self, spell_id: impl Into<String>, source: impl Into<String>) {
+        let spell = KnownSpell {
+            spell_id: spell_id.into(),
+            source: source.into(),
+            notes: None,
+        };
+        if !self.known.iter().any(|s| s.spell_id == spell.spell_id) {
+            self.known.push(spell);
+        }
+    }
+
+    /// Prepare a spell (must already be known for prepared casters).
+    pub fn prepare_spell(&mut self, spell_id: impl Into<String>) {
+        let id = spell_id.into();
+        if !self.prepared.contains(&id) {
+            self.prepared.push(id);
+        }
+    }
+
+    /// Unprepare a spell.
+    pub fn unprepare_spell(&mut self, spell_id: &str) {
+        self.prepared.retain(|id| id != spell_id);
+    }
+
+    /// Use a spell slot of a given level.
+    pub fn use_slot(&mut self, level: u8) -> bool {
+        if let Some(pool) = self.slots.get_mut(&level) {
+            if pool.current > 0 {
+                pool.current -= 1;
+                return true;
+            }
+        }
+        false
+    }
+
+    /// Restore all spell slots (e.g., after a long rest).
+    pub fn restore_all_slots(&mut self) {
+        for pool in self.slots.values_mut() {
+            pool.current = pool.max;
+        }
+        if let Some(pact) = &mut self.pact_slots {
+            pact.current = pact.max;
+        }
+    }
+
+    /// Restore slots up to a certain level (e.g., Arcane Recovery).
+    pub fn restore_slots_up_to(&mut self, max_level: u8, total_levels: u8) {
+        let mut remaining = total_levels;
+        for level in (1..=max_level).rev() {
+            if remaining == 0 {
+                break;
+            }
+            if let Some(pool) = self.slots.get_mut(&level) {
+                let can_restore = (pool.max - pool.current).min(remaining / level);
+                pool.current += can_restore;
+                remaining -= can_restore * level;
+            }
+        }
+    }
+}
+
+/// A spell that the character knows.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct KnownSpell {
+    /// ID of the spell
+    pub spell_id: String,
+    /// How the spell was learned (e.g., "class", "feat", "item")
+    pub source: String,
+    /// Optional notes about this spell
+    pub notes: Option<String>,
+}
+
+/// A pool of spell slots at a given level.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct SpellSlotPool {
+    /// Currently available slots
+    pub current: u8,
+    /// Maximum slots
+    pub max: u8,
+}
+
+impl SpellSlotPool {
+    /// Create a new spell slot pool.
+    pub fn new(max: u8) -> Self {
+        Self { current: max, max }
+    }
+
+    /// Create an empty pool.
+    pub fn empty(max: u8) -> Self {
+        Self { current: 0, max }
+    }
+
+    /// Check if any slots are available.
+    pub fn has_slots(&self) -> bool {
+        self.current > 0
+    }
+}
+
+/// A character's acquired feats.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct CharacterFeats {
+    /// Feats the character has acquired
+    #[serde(default)]
+    pub feats: Vec<AcquiredFeat>,
+}
+
+impl CharacterFeats {
+    /// Create empty feat collection.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Acquire a feat.
+    pub fn acquire(&mut self, feat_id: impl Into<String>, level: Option<u8>) {
+        let feat = AcquiredFeat {
+            feat_id: feat_id.into(),
+            acquired_at_level: level,
+            choices: HashMap::new(),
+            notes: None,
+        };
+        self.feats.push(feat);
+    }
+
+    /// Check if the character has a specific feat.
+    pub fn has_feat(&self, feat_id: &str) -> bool {
+        self.feats.iter().any(|f| f.feat_id == feat_id)
+    }
+
+    /// Get a mutable reference to an acquired feat.
+    pub fn get_mut(&mut self, feat_id: &str) -> Option<&mut AcquiredFeat> {
+        self.feats.iter_mut().find(|f| f.feat_id == feat_id)
+    }
+}
+
+/// A feat that the character has acquired.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct AcquiredFeat {
+    /// ID of the feat
+    pub feat_id: String,
+    /// Level at which the feat was acquired
+    pub acquired_at_level: Option<u8>,
+    /// Choices made when acquiring the feat (e.g., stat to increase)
+    #[serde(default)]
+    pub choices: HashMap<String, String>,
+    /// Optional notes about this feat
+    pub notes: Option<String>,
+}
+
+/// A character's active class features.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct CharacterFeatures {
+    /// Active features with their current state
+    #[serde(default)]
+    pub features: Vec<ActiveFeature>,
+}
+
+impl CharacterFeatures {
+    /// Create empty feature collection.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Add a feature.
+    pub fn add(&mut self, feature_id: impl Into<String>) {
+        let feature = ActiveFeature {
+            feature_id: feature_id.into(),
+            uses_remaining: None,
+            uses_max: None,
+            choices: HashMap::new(),
+        };
+        self.features.push(feature);
+    }
+
+    /// Add a feature with limited uses.
+    pub fn add_with_uses(&mut self, feature_id: impl Into<String>, max_uses: u8) {
+        let feature = ActiveFeature {
+            feature_id: feature_id.into(),
+            uses_remaining: Some(max_uses),
+            uses_max: Some(max_uses),
+            choices: HashMap::new(),
+        };
+        self.features.push(feature);
+    }
+
+    /// Get a mutable reference to a feature.
+    pub fn get_mut(&mut self, feature_id: &str) -> Option<&mut ActiveFeature> {
+        self.features.iter_mut().find(|f| f.feature_id == feature_id)
+    }
+
+    /// Use a feature (if it has limited uses).
+    pub fn use_feature(&mut self, feature_id: &str) -> bool {
+        if let Some(feature) = self.get_mut(feature_id) {
+            if let Some(uses) = &mut feature.uses_remaining {
+                if *uses > 0 {
+                    *uses -= 1;
+                    return true;
+                }
+                return false;
+            }
+            // No uses tracking = unlimited uses
+            return true;
+        }
+        false
+    }
+
+    /// Restore all feature uses (e.g., after a rest).
+    pub fn restore_all_uses(&mut self) {
+        for feature in &mut self.features {
+            if let (Some(remaining), Some(max)) = (&mut feature.uses_remaining, feature.uses_max) {
+                *remaining = max;
+            }
+        }
+    }
+}
+
+/// A class feature that the character has active.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct ActiveFeature {
+    /// ID of the feature
+    pub feature_id: String,
+    /// Current uses remaining (if tracked)
+    pub uses_remaining: Option<u8>,
+    /// Maximum uses (if tracked)
+    pub uses_max: Option<u8>,
+    /// Choices made for this feature
+    #[serde(default)]
+    pub choices: HashMap<String, String>,
+}
+
+/// Character identity information (race, class, background).
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct CharacterIdentity {
+    /// Race/ancestry ID
+    pub race: Option<String>,
+    /// Subrace/heritage ID
+    pub subrace: Option<String>,
+    /// Class levels
+    #[serde(default)]
+    pub classes: Vec<ClassLevel>,
+    /// Background ID
+    pub background: Option<String>,
+    /// Alignment (for systems that use it)
+    pub alignment: Option<String>,
+    /// Total character level (sum of all class levels)
+    #[serde(default)]
+    pub total_level: u8,
+}
+
+impl CharacterIdentity {
+    /// Create empty identity.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Set the race.
+    pub fn with_race(mut self, race: impl Into<String>) -> Self {
+        self.race = Some(race.into());
+        self
+    }
+
+    /// Add a class level.
+    pub fn add_class(&mut self, class_id: impl Into<String>, levels: u8) {
+        let id = class_id.into();
+        if let Some(existing) = self.classes.iter_mut().find(|c| c.class_id == id) {
+            existing.level += levels;
+        } else {
+            self.classes.push(ClassLevel {
+                class_id: id,
+                subclass: None,
+                level: levels,
+            });
+        }
+        self.total_level = self.classes.iter().map(|c| c.level).sum();
+    }
+
+    /// Get level in a specific class.
+    pub fn class_level(&self, class_id: &str) -> u8 {
+        self.classes
+            .iter()
+            .find(|c| c.class_id == class_id)
+            .map(|c| c.level)
+            .unwrap_or(0)
+    }
+
+    /// Get the primary class (highest level).
+    pub fn primary_class(&self) -> Option<&ClassLevel> {
+        self.classes.iter().max_by_key(|c| c.level)
+    }
+}
+
+/// A class level entry for multiclass characters.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct ClassLevel {
+    /// ID of the class
+    pub class_id: String,
+    /// ID of the subclass (if chosen)
+    pub subclass: Option<String>,
+    /// Number of levels in this class
+    pub level: u8,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn character_spells_basic() {
+        let mut spells = CharacterSpells::new();
+        spells.add_cantrip("fire_bolt");
+        spells.learn_spell("magic_missile", "class");
+        spells.prepare_spell("magic_missile");
+
+        assert_eq!(spells.cantrips.len(), 1);
+        assert_eq!(spells.known.len(), 1);
+        assert_eq!(spells.prepared.len(), 1);
+    }
+
+    #[test]
+    fn spell_slot_usage() {
+        let mut spells = CharacterSpells::new();
+        spells.slots.insert(1, SpellSlotPool::new(4));
+        spells.slots.insert(2, SpellSlotPool::new(3));
+
+        assert!(spells.use_slot(1));
+        assert_eq!(spells.slots[&1].current, 3);
+
+        spells.restore_all_slots();
+        assert_eq!(spells.slots[&1].current, 4);
+    }
+
+    #[test]
+    fn character_feats_basic() {
+        let mut feats = CharacterFeats::new();
+        feats.acquire("great_weapon_master", Some(4));
+
+        assert!(feats.has_feat("great_weapon_master"));
+        assert!(!feats.has_feat("sentinel"));
+    }
+
+    #[test]
+    fn character_features_with_uses() {
+        let mut features = CharacterFeatures::new();
+        features.add_with_uses("second_wind", 1);
+
+        assert!(features.use_feature("second_wind"));
+        assert!(!features.use_feature("second_wind")); // No uses left
+
+        features.restore_all_uses();
+        assert!(features.use_feature("second_wind"));
+    }
+
+    #[test]
+    fn character_identity_multiclass() {
+        let mut identity = CharacterIdentity::new().with_race("human");
+        identity.add_class("fighter", 5);
+        identity.add_class("wizard", 2);
+
+        assert_eq!(identity.total_level, 7);
+        assert_eq!(identity.class_level("fighter"), 5);
+        assert_eq!(identity.class_level("wizard"), 2);
+        assert_eq!(identity.class_level("rogue"), 0);
+        assert_eq!(identity.primary_class().unwrap().class_id, "fighter");
+    }
+
+    #[test]
+    fn serialization_round_trip() {
+        let mut spells = CharacterSpells::new();
+        spells.add_cantrip("prestidigitation");
+        spells.learn_spell("shield", "class");
+        spells.slots.insert(1, SpellSlotPool::new(2));
+
+        let json = serde_json::to_string(&spells).unwrap();
+        let deserialized: CharacterSpells = serde_json::from_str(&json).unwrap();
+        assert_eq!(spells, deserialized);
+    }
+}

--- a/crates/domain/src/entities/class_feature.rs
+++ b/crates/domain/src/entities/class_feature.rs
@@ -1,0 +1,200 @@
+//! Class feature entity for TTRPG character abilities.
+//!
+//! Represents abilities and features that characters gain from their class
+//! or subclass as they level up.
+
+use serde::{Deserialize, Serialize};
+
+use super::feat::{RechargeType, UsesFormula};
+
+/// A class feature that a character gains from their class or subclass.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct ClassFeature {
+    /// Unique identifier for this feature
+    pub id: String,
+    /// Which game system this feature belongs to (e.g., "dnd5e", "pf2e")
+    pub system_id: String,
+    /// ID of the class that grants this feature
+    pub class_id: String,
+    /// ID of the subclass (if this is a subclass feature)
+    pub subclass_id: Option<String>,
+    /// Display name of the feature
+    pub name: String,
+    /// Level at which this feature is gained
+    pub level: u8,
+    /// Full description of what the feature does
+    pub description: String,
+    /// Uses tracking (if the feature has limited uses)
+    pub uses: Option<FeatureUses>,
+    /// Source book reference
+    pub source: String,
+    /// Whether this feature grants choices
+    #[serde(default)]
+    pub has_choices: bool,
+    /// Tags for categorization
+    #[serde(default)]
+    pub tags: Vec<String>,
+}
+
+/// Limited uses tracking for a class feature.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct FeatureUses {
+    /// How many uses the feature has
+    pub max: UsesFormula,
+    /// When uses are restored
+    pub recharge: RechargeType,
+}
+
+impl FeatureUses {
+    /// Create uses that recharge on a short rest.
+    pub fn short_rest(max: UsesFormula) -> Self {
+        Self {
+            max,
+            recharge: RechargeType::ShortRest,
+        }
+    }
+
+    /// Create uses that recharge on a long rest.
+    pub fn long_rest(max: UsesFormula) -> Self {
+        Self {
+            max,
+            recharge: RechargeType::LongRest,
+        }
+    }
+
+    /// Create fixed uses that recharge on a long rest.
+    pub fn fixed_long_rest(value: u8) -> Self {
+        Self {
+            max: UsesFormula::Fixed { value },
+            recharge: RechargeType::LongRest,
+        }
+    }
+
+    /// Create uses equal to proficiency bonus, recharging on a long rest.
+    pub fn proficiency_long_rest() -> Self {
+        Self {
+            max: UsesFormula::ProficiencyBonus,
+            recharge: RechargeType::LongRest,
+        }
+    }
+}
+
+/// A racial trait or ancestry feature.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct RacialTrait {
+    /// Unique identifier for this trait
+    pub id: String,
+    /// Which game system this trait belongs to
+    pub system_id: String,
+    /// ID of the race/ancestry that grants this trait
+    pub race_id: String,
+    /// ID of the subrace (if this is a subrace trait)
+    pub subrace_id: Option<String>,
+    /// Display name of the trait
+    pub name: String,
+    /// Full description of what the trait does
+    pub description: String,
+    /// Uses tracking (if the trait has limited uses)
+    pub uses: Option<FeatureUses>,
+    /// Source book reference
+    pub source: String,
+    /// Tags for categorization
+    #[serde(default)]
+    pub tags: Vec<String>,
+}
+
+/// A background feature.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct BackgroundFeature {
+    /// Unique identifier for this feature
+    pub id: String,
+    /// Which game system this feature belongs to
+    pub system_id: String,
+    /// ID of the background that grants this feature
+    pub background_id: String,
+    /// Display name of the feature
+    pub name: String,
+    /// Full description of what the feature does
+    pub description: String,
+    /// Source book reference
+    pub source: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn class_feature_serialization() {
+        let feature = ClassFeature {
+            id: "dnd5e_fighter_second_wind".into(),
+            system_id: "dnd5e".into(),
+            class_id: "fighter".into(),
+            subclass_id: None,
+            name: "Second Wind".into(),
+            level: 1,
+            description: "You have a limited well of stamina...".into(),
+            uses: Some(FeatureUses::short_rest(UsesFormula::Fixed { value: 1 })),
+            source: "PHB p.72".into(),
+            has_choices: false,
+            tags: vec!["healing".into()],
+        };
+
+        let json = serde_json::to_string(&feature).unwrap();
+        let deserialized: ClassFeature = serde_json::from_str(&json).unwrap();
+        assert_eq!(feature, deserialized);
+    }
+
+    #[test]
+    fn subclass_feature() {
+        let feature = ClassFeature {
+            id: "dnd5e_champion_improved_critical".into(),
+            system_id: "dnd5e".into(),
+            class_id: "fighter".into(),
+            subclass_id: Some("champion".into()),
+            name: "Improved Critical".into(),
+            level: 3,
+            description: "Your weapon attacks score a critical hit on a roll of 19 or 20.".into(),
+            uses: None,
+            source: "PHB p.72".into(),
+            has_choices: false,
+            tags: vec!["combat".into()],
+        };
+
+        assert!(feature.subclass_id.is_some());
+        assert!(feature.uses.is_none());
+    }
+
+    #[test]
+    fn feature_uses_constructors() {
+        let uses = FeatureUses::fixed_long_rest(2);
+        assert!(matches!(uses.max, UsesFormula::Fixed { value: 2 }));
+        assert_eq!(uses.recharge, RechargeType::LongRest);
+
+        let uses = FeatureUses::proficiency_long_rest();
+        assert!(matches!(uses.max, UsesFormula::ProficiencyBonus));
+    }
+
+    #[test]
+    fn racial_trait_serialization() {
+        let trait_ = RacialTrait {
+            id: "dnd5e_dwarf_darkvision".into(),
+            system_id: "dnd5e".into(),
+            race_id: "dwarf".into(),
+            subrace_id: None,
+            name: "Darkvision".into(),
+            description: "You can see in dim light within 60 feet...".into(),
+            uses: None,
+            source: "PHB p.20".into(),
+            tags: vec!["vision".into()],
+        };
+
+        let json = serde_json::to_string(&trait_).unwrap();
+        let deserialized: RacialTrait = serde_json::from_str(&json).unwrap();
+        assert_eq!(trait_, deserialized);
+    }
+}

--- a/crates/domain/src/entities/feat.rs
+++ b/crates/domain/src/entities/feat.rs
@@ -1,0 +1,386 @@
+//! Feat and feature entity for TTRPG character abilities.
+//!
+//! Provides a universal representation for feats, talents, and special
+//! abilities that characters can acquire in various game systems.
+
+use serde::{Deserialize, Serialize};
+
+/// A feat, talent, or special ability that a character can acquire.
+///
+/// This struct supports various TTRPG systems' concepts of character
+/// customization options (D&D feats, Pathfinder feats, etc.).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct Feat {
+    /// Unique identifier for this feat
+    pub id: String,
+    /// Which game system this feat belongs to (e.g., "dnd5e", "pf2e")
+    pub system_id: String,
+    /// Display name of the feat
+    pub name: String,
+    /// Full description of what the feat does
+    pub description: String,
+    /// Requirements to take this feat
+    #[serde(default)]
+    pub prerequisites: Vec<Prerequisite>,
+    /// Mechanical benefits granted by the feat
+    #[serde(default)]
+    pub benefits: Vec<FeatBenefit>,
+    /// Source book reference (e.g., "PHB p.165")
+    pub source: String,
+    /// Category of feat (system-specific, e.g., "general", "combat", "skill")
+    pub category: Option<String>,
+    /// Whether this feat can be taken multiple times
+    #[serde(default)]
+    pub repeatable: bool,
+    /// Tags for filtering and categorization
+    #[serde(default)]
+    pub tags: Vec<String>,
+}
+
+/// A prerequisite for acquiring a feat.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum Prerequisite {
+    /// Minimum ability score requirement
+    MinStat {
+        /// The stat name (e.g., "STR", "Dexterity")
+        stat: String,
+        /// Minimum value required
+        value: i32,
+    },
+    /// Minimum character level
+    MinLevel {
+        /// Minimum level required
+        level: u8,
+    },
+    /// Must have another feat
+    HasFeat {
+        /// ID of the required feat
+        feat_id: String,
+        /// Display name (for UI)
+        #[serde(default)]
+        feat_name: Option<String>,
+    },
+    /// Must have levels in a specific class
+    HasClass {
+        /// ID of the required class
+        class_id: String,
+        /// Display name (for UI)
+        #[serde(default)]
+        class_name: Option<String>,
+        /// Minimum levels in that class (if any)
+        min_level: Option<u8>,
+    },
+    /// Must have a specific proficiency
+    HasProficiency {
+        /// Type of proficiency (e.g., "armor", "weapon", "skill")
+        proficiency_type: String,
+        /// The specific proficiency (e.g., "heavy armor", "Athletics")
+        proficiency: String,
+    },
+    /// Must be a specific race or ancestry
+    Race {
+        /// Race ID or name
+        race: String,
+    },
+    /// Spellcasting ability requirement
+    Spellcaster {
+        /// Minimum spell level they must be able to cast
+        min_spell_level: Option<u8>,
+    },
+    /// Custom prerequisite with free-form text
+    Custom {
+        /// Description of the requirement
+        description: String,
+    },
+    /// Any one of the listed prerequisites
+    AnyOf {
+        /// List of alternative prerequisites
+        options: Vec<Prerequisite>,
+    },
+    /// All of the listed prerequisites
+    AllOf {
+        /// List of required prerequisites
+        requirements: Vec<Prerequisite>,
+    },
+}
+
+impl Prerequisite {
+    /// Create a minimum stat prerequisite.
+    pub fn min_stat(stat: impl Into<String>, value: i32) -> Self {
+        Prerequisite::MinStat {
+            stat: stat.into(),
+            value,
+        }
+    }
+
+    /// Create a minimum level prerequisite.
+    pub fn min_level(level: u8) -> Self {
+        Prerequisite::MinLevel { level }
+    }
+
+    /// Create a has-feat prerequisite.
+    pub fn has_feat(feat_id: impl Into<String>) -> Self {
+        Prerequisite::HasFeat {
+            feat_id: feat_id.into(),
+            feat_name: None,
+        }
+    }
+
+    /// Create a has-class prerequisite.
+    pub fn has_class(class_id: impl Into<String>) -> Self {
+        Prerequisite::HasClass {
+            class_id: class_id.into(),
+            class_name: None,
+            min_level: None,
+        }
+    }
+
+    /// Create a custom prerequisite.
+    pub fn custom(description: impl Into<String>) -> Self {
+        Prerequisite::Custom {
+            description: description.into(),
+        }
+    }
+}
+
+/// A mechanical benefit granted by a feat.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum FeatBenefit {
+    /// Increase an ability score
+    StatIncrease {
+        /// The stat to increase
+        stat: String,
+        /// Amount to increase by
+        value: i32,
+    },
+    /// Choose from multiple stats to increase
+    StatChoice {
+        /// Options to choose from
+        options: Vec<String>,
+        /// Amount to increase by
+        value: i32,
+        /// Number of choices to make
+        #[serde(default = "default_one")]
+        count: u8,
+    },
+    /// Grant proficiency in something
+    GrantProficiency {
+        /// Type of proficiency (e.g., "skill", "weapon", "armor", "tool")
+        proficiency_type: String,
+        /// The specific proficiency (e.g., "Athletics", "longsword")
+        proficiency: String,
+    },
+    /// Choose proficiency from a list
+    ChooseProficiency {
+        /// Type of proficiency
+        proficiency_type: String,
+        /// Options to choose from
+        options: Vec<String>,
+        /// Number of choices to make
+        #[serde(default = "default_one")]
+        count: u8,
+    },
+    /// Grant a special ability
+    GrantAbility {
+        /// Name of the ability
+        ability: String,
+        /// Description of what the ability does
+        description: String,
+        /// Uses per rest (if limited)
+        uses: Option<AbilityUses>,
+    },
+    /// Grant additional hit points
+    BonusHitPoints {
+        /// Fixed amount to add
+        fixed: Option<i32>,
+        /// Amount per level
+        per_level: Option<i32>,
+    },
+    /// Increase speed
+    SpeedIncrease {
+        /// Movement type (e.g., "walk", "fly", "swim")
+        movement_type: String,
+        /// Amount to increase by (in feet)
+        value: u32,
+    },
+    /// Grant resistance to a damage type
+    DamageResistance {
+        /// Damage type (e.g., "fire", "cold", "psychic")
+        damage_type: String,
+    },
+    /// Grant advantage on certain rolls
+    Advantage {
+        /// What the advantage applies to
+        on: String,
+    },
+    /// Custom benefit with free-form description
+    Custom {
+        /// Description of the benefit
+        description: String,
+    },
+}
+
+fn default_one() -> u8 {
+    1
+}
+
+/// Limited uses for an ability granted by a feat.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct AbilityUses {
+    /// Maximum uses
+    pub max: UsesFormula,
+    /// When uses are restored
+    pub recharge: RechargeType,
+}
+
+/// Formula for calculating ability uses.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum UsesFormula {
+    /// Fixed number of uses
+    Fixed { value: u8 },
+    /// Uses equal to proficiency bonus
+    ProficiencyBonus,
+    /// Uses equal to a stat modifier (minimum 1)
+    StatModifier {
+        /// Which stat modifier to use
+        stat: String,
+        /// Minimum value (usually 1)
+        #[serde(default = "default_one_i32")]
+        min: i32,
+    },
+    /// Custom formula
+    Formula {
+        /// Expression (e.g., "level / 2")
+        expression: String,
+    },
+}
+
+fn default_one_i32() -> i32 {
+    1
+}
+
+impl UsesFormula {
+    /// Create a fixed uses formula.
+    pub fn fixed(value: u8) -> Self {
+        UsesFormula::Fixed { value }
+    }
+
+    /// Create a proficiency bonus formula.
+    pub fn proficiency_bonus() -> Self {
+        UsesFormula::ProficiencyBonus
+    }
+
+    /// Create a stat modifier formula.
+    pub fn stat_modifier(stat: impl Into<String>) -> Self {
+        UsesFormula::StatModifier {
+            stat: stat.into(),
+            min: 1,
+        }
+    }
+}
+
+/// When ability uses are restored.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum RechargeType {
+    /// Restored on a short rest
+    ShortRest,
+    /// Restored on a long rest
+    LongRest,
+    /// Restored at dawn
+    Dawn,
+    /// Never restored automatically (manual tracking)
+    Manual,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn feat_serialization() {
+        let feat = Feat {
+            id: "dnd5e_great_weapon_master".into(),
+            system_id: "dnd5e".into(),
+            name: "Great Weapon Master".into(),
+            description: "You've learned to put the weight of a weapon...".into(),
+            prerequisites: vec![],
+            benefits: vec![
+                FeatBenefit::Custom {
+                    description: "On a critical hit or kill, bonus action attack".into(),
+                },
+                FeatBenefit::Custom {
+                    description: "-5 to hit for +10 damage".into(),
+                },
+            ],
+            source: "PHB p.167".into(),
+            category: Some("combat".into()),
+            repeatable: false,
+            tags: vec!["combat".into(), "melee".into()],
+        };
+
+        let json = serde_json::to_string(&feat).unwrap();
+        let deserialized: Feat = serde_json::from_str(&json).unwrap();
+        assert_eq!(feat, deserialized);
+    }
+
+    #[test]
+    fn prerequisite_constructors() {
+        let prereq = Prerequisite::min_stat("STR", 13);
+        assert!(matches!(prereq, Prerequisite::MinStat { stat, value } if stat == "STR" && value == 13));
+
+        let prereq = Prerequisite::min_level(4);
+        assert!(matches!(prereq, Prerequisite::MinLevel { level: 4 }));
+    }
+
+    #[test]
+    fn feat_with_prerequisites() {
+        let feat = Feat {
+            id: "dnd5e_sentinel".into(),
+            system_id: "dnd5e".into(),
+            name: "Sentinel".into(),
+            description: "You have mastered techniques...".into(),
+            prerequisites: vec![],
+            benefits: vec![],
+            source: "PHB p.169".into(),
+            category: None,
+            repeatable: false,
+            tags: vec![],
+        };
+
+        assert!(feat.prerequisites.is_empty());
+    }
+
+    #[test]
+    fn complex_prerequisites() {
+        let prereq = Prerequisite::AnyOf {
+            options: vec![
+                Prerequisite::min_stat("STR", 13),
+                Prerequisite::min_stat("DEX", 13),
+            ],
+        };
+
+        if let Prerequisite::AnyOf { options } = prereq {
+            assert_eq!(options.len(), 2);
+        } else {
+            panic!("Expected AnyOf prerequisite");
+        }
+    }
+
+    #[test]
+    fn uses_formula_constructors() {
+        let uses = UsesFormula::fixed(3);
+        assert!(matches!(uses, UsesFormula::Fixed { value: 3 }));
+
+        let uses = UsesFormula::proficiency_bonus();
+        assert!(matches!(uses, UsesFormula::ProficiencyBonus));
+
+        let uses = UsesFormula::stat_modifier("WIS");
+        assert!(matches!(uses, UsesFormula::StatModifier { stat, min: 1 } if stat == "WIS"));
+    }
+}

--- a/crates/domain/src/entities/mod.rs
+++ b/crates/domain/src/entities/mod.rs
@@ -2,7 +2,10 @@
 
 mod challenge;
 mod character;
+mod character_content;
+mod class_feature;
 mod event_chain;
+mod feat;
 mod gallery_asset;
 mod game_flag;
 mod generation_batch;
@@ -21,6 +24,7 @@ mod region_state;
 mod scene;
 mod sheet_template;
 mod skill;
+mod spell;
 mod staging;
 mod story_event;
 mod want;
@@ -33,7 +37,13 @@ pub use challenge::{
     Outcome, OutcomeTrigger, OutcomeType, TriggerCondition, TriggerType,
 };
 pub use character::{Character, StatBlock, StatModifier, StatValue};
+pub use character_content::{
+    AcquiredFeat, ActiveFeature, CharacterFeats, CharacterFeatures, CharacterIdentity,
+    CharacterSpells, ClassLevel, KnownSpell, SpellSlotPool,
+};
+pub use class_feature::{BackgroundFeature, ClassFeature, FeatureUses, RacialTrait};
 pub use event_chain::{ChainStatus, EventChain};
+pub use feat::{AbilityUses, Feat, FeatBenefit, Prerequisite, RechargeType, UsesFormula};
 pub use gallery_asset::{AssetType, EntityType, GalleryAsset, GenerationMetadata};
 pub use game_flag::{FlagScope, GameFlag};
 pub use generation_batch::{BatchStatus, GenerationBatch, GenerationRequest};
@@ -62,6 +72,10 @@ pub use sheet_template::{
     SelectOption, SheetField, SheetSection, SheetTemplateId,
 };
 pub use skill::{default_skills_for_variant, Skill, SkillCategory};
+pub use spell::{
+    CastingTime, CastingTimeUnit, DurationUnit, MaterialComponent, Spell, SpellComponents,
+    SpellDuration, SpellLevel, SpellRange,
+};
 pub use staging::{
     ResolvedStateInfo, ResolvedVisualState, StagedNpc, Staging, StagingSource, VisualStateSource,
 };

--- a/crates/domain/src/entities/sheet_template.rs
+++ b/crates/domain/src/entities/sheet_template.rs
@@ -402,6 +402,57 @@ impl CharacterSheetData {
         }
         None
     }
+
+    /// Get dice pool value (number of dice) for Blades in the Dark action ratings.
+    pub fn get_dice_pool(&self, field_id: &str) -> Option<u8> {
+        match self.values.get(field_id)? {
+            FieldValue::DicePool { dice, .. } => Some(*dice),
+            FieldValue::Number(n) => Some(*n as u8),
+            _ => None,
+        }
+    }
+
+    /// Get percentile value for CoC 7e skills.
+    pub fn get_percentile(&self, field_id: &str) -> Option<u8> {
+        match self.values.get(field_id)? {
+            FieldValue::Percentile(p) => Some(*p),
+            FieldValue::Number(n) => Some(*n as u8),
+            _ => None,
+        }
+    }
+
+    /// Get ladder rating for FATE Core skills.
+    pub fn get_ladder_rating(&self, field_id: &str) -> Option<i8> {
+        match self.values.get(field_id)? {
+            FieldValue::LadderRating(r) => Some(*r),
+            FieldValue::Number(n) => Some(*n as i8),
+            _ => None,
+        }
+    }
+
+    /// Get resource current value.
+    pub fn get_resource_current(&self, field_id: &str) -> Option<i32> {
+        match self.values.get(field_id)? {
+            FieldValue::Resource { current, .. } => Some(*current),
+            FieldValue::Number(n) => Some(*n),
+            _ => None,
+        }
+    }
+
+    /// Get any numeric value from a field, regardless of specific type.
+    /// This is useful for challenge modifiers that need to extract a number
+    /// from any field type that can represent a numeric value.
+    pub fn get_numeric_value(&self, field_id: &str) -> Option<i32> {
+        match self.values.get(field_id)? {
+            FieldValue::Number(n) => Some(*n),
+            FieldValue::SkillEntry { bonus, .. } => Some(*bonus),
+            FieldValue::DicePool { dice, .. } => Some(*dice as i32),
+            FieldValue::Percentile(p) => Some(*p as i32),
+            FieldValue::LadderRating(r) => Some(*r as i32),
+            FieldValue::Resource { current, .. } => Some(*current),
+            _ => None,
+        }
+    }
 }
 
 /// A value stored for a field
@@ -423,6 +474,15 @@ pub enum FieldValue {
         proficient: bool,
         bonus: i32,
     },
+    /// Dice pool (for Blades in the Dark action ratings, etc.)
+    DicePool {
+        dice: u8,
+        die_type: u8,
+    },
+    /// Percentile skill value (for CoC 7e, etc.)
+    Percentile(u8),
+    /// Ladder rating (for FATE Core, etc.)
+    LadderRating(i8),
 }
 
 // ============================================================================

--- a/crates/domain/src/entities/spell.rs
+++ b/crates/domain/src/entities/spell.rs
@@ -1,0 +1,409 @@
+//! Spell entity for TTRPG spellcasting systems.
+//!
+//! Provides a universal spell representation that works across different
+//! game systems (D&D 5e, Pathfinder, etc.) while supporting system-specific
+//! details through flexible fields.
+
+use serde::{Deserialize, Serialize};
+
+/// A spell or magical ability.
+///
+/// This struct is designed to be system-agnostic while supporting the
+/// common elements found in most TTRPG spell systems.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct Spell {
+    /// Unique identifier for this spell
+    pub id: String,
+    /// Which game system this spell belongs to (e.g., "dnd5e", "pf2e")
+    pub system_id: String,
+    /// Display name of the spell
+    pub name: String,
+    /// Spell level (cantrip = 0 for D&D-like systems)
+    pub level: SpellLevel,
+    /// School of magic (e.g., "Evocation", "Necromancy")
+    pub school: Option<String>,
+    /// How long it takes to cast
+    pub casting_time: CastingTime,
+    /// Range of the spell
+    pub range: SpellRange,
+    /// Required components (verbal, somatic, material)
+    pub components: SpellComponents,
+    /// How long the spell lasts
+    pub duration: SpellDuration,
+    /// Full description of the spell's effects
+    pub description: String,
+    /// Description of effects when cast at higher levels
+    pub higher_levels: Option<String>,
+    /// Classes that can learn this spell
+    pub classes: Vec<String>,
+    /// Source book reference (e.g., "PHB p.211")
+    pub source: String,
+    /// Tags for filtering and categorization
+    #[serde(default)]
+    pub tags: Vec<String>,
+    /// Whether this spell can be cast as a ritual
+    #[serde(default)]
+    pub ritual: bool,
+    /// Whether this spell requires concentration
+    #[serde(default)]
+    pub concentration: bool,
+}
+
+/// Spell level representation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum SpellLevel {
+    /// Cantrip (level 0 spell, can be cast at will)
+    Cantrip,
+    /// Leveled spell (1-9 for D&D-like systems)
+    Level(u8),
+}
+
+impl SpellLevel {
+    /// Convert to numeric level (cantrip = 0).
+    pub fn as_number(&self) -> u8 {
+        match self {
+            SpellLevel::Cantrip => 0,
+            SpellLevel::Level(n) => *n,
+        }
+    }
+
+    /// Check if this is a cantrip.
+    pub fn is_cantrip(&self) -> bool {
+        matches!(self, SpellLevel::Cantrip)
+    }
+}
+
+impl From<u8> for SpellLevel {
+    fn from(level: u8) -> Self {
+        if level == 0 {
+            SpellLevel::Cantrip
+        } else {
+            SpellLevel::Level(level)
+        }
+    }
+}
+
+/// How long it takes to cast a spell.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CastingTime {
+    /// The amount of time
+    pub amount: u32,
+    /// The unit of time
+    pub unit: CastingTimeUnit,
+    /// Additional condition (e.g., "which you take when..." for reactions)
+    pub condition: Option<String>,
+}
+
+/// Unit of time for casting.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum CastingTimeUnit {
+    Action,
+    BonusAction,
+    Reaction,
+    Minute,
+    Hour,
+    /// Special timing (e.g., "special", "see text")
+    Special,
+}
+
+impl CastingTime {
+    /// Create a standard action casting time.
+    pub fn action() -> Self {
+        Self {
+            amount: 1,
+            unit: CastingTimeUnit::Action,
+            condition: None,
+        }
+    }
+
+    /// Create a bonus action casting time.
+    pub fn bonus_action() -> Self {
+        Self {
+            amount: 1,
+            unit: CastingTimeUnit::BonusAction,
+            condition: None,
+        }
+    }
+
+    /// Create a reaction casting time with optional condition.
+    pub fn reaction(condition: Option<String>) -> Self {
+        Self {
+            amount: 1,
+            unit: CastingTimeUnit::Reaction,
+            condition,
+        }
+    }
+
+    /// Create a casting time in minutes.
+    pub fn minutes(amount: u32) -> Self {
+        Self {
+            amount,
+            unit: CastingTimeUnit::Minute,
+            condition: None,
+        }
+    }
+
+    /// Create a casting time in hours.
+    pub fn hours(amount: u32) -> Self {
+        Self {
+            amount,
+            unit: CastingTimeUnit::Hour,
+            condition: None,
+        }
+    }
+}
+
+/// Range of a spell.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "camelCase")]
+pub enum SpellRange {
+    /// Spell affects only the caster
+    #[serde(rename = "self")]
+    SelfOnly {
+        /// Optional area of effect (e.g., "15-foot cone")
+        area: Option<String>,
+    },
+    /// Touch range
+    Touch,
+    /// Specific distance in feet
+    Feet { distance: u32 },
+    /// Specific distance in miles
+    Miles { distance: u32 },
+    /// Unlimited range (same plane)
+    Unlimited,
+    /// Sight range
+    Sight,
+    /// Special range (see spell description)
+    Special { description: String },
+}
+
+impl SpellRange {
+    /// Create a self-only range.
+    pub fn self_only() -> Self {
+        SpellRange::SelfOnly { area: None }
+    }
+
+    /// Create a self range with an area of effect.
+    pub fn self_with_area(area: impl Into<String>) -> Self {
+        SpellRange::SelfOnly {
+            area: Some(area.into()),
+        }
+    }
+
+    /// Create a touch range.
+    pub fn touch() -> Self {
+        SpellRange::Touch
+    }
+
+    /// Create a range in feet.
+    pub fn feet(distance: u32) -> Self {
+        SpellRange::Feet { distance }
+    }
+}
+
+/// Spell components (what's required to cast).
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SpellComponents {
+    /// Requires verbal component
+    #[serde(default)]
+    pub verbal: bool,
+    /// Requires somatic component
+    #[serde(default)]
+    pub somatic: bool,
+    /// Material component details
+    pub material: Option<MaterialComponent>,
+}
+
+impl SpellComponents {
+    /// Create components with just verbal.
+    pub fn verbal() -> Self {
+        Self {
+            verbal: true,
+            somatic: false,
+            material: None,
+        }
+    }
+
+    /// Create components with verbal and somatic.
+    pub fn verbal_somatic() -> Self {
+        Self {
+            verbal: true,
+            somatic: true,
+            material: None,
+        }
+    }
+
+    /// Create components with all three.
+    pub fn all(material: impl Into<String>) -> Self {
+        Self {
+            verbal: true,
+            somatic: true,
+            material: Some(MaterialComponent {
+                description: material.into(),
+                consumed: false,
+                cost: None,
+            }),
+        }
+    }
+}
+
+/// Material component for a spell.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MaterialComponent {
+    /// Description of the material
+    pub description: String,
+    /// Whether the material is consumed by the spell
+    #[serde(default)]
+    pub consumed: bool,
+    /// Cost in gold pieces (if any)
+    pub cost: Option<u32>,
+}
+
+/// How long a spell's effects last.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "camelCase")]
+pub enum SpellDuration {
+    /// Effect happens instantly
+    Instantaneous,
+    /// Lasts for a specific amount of time
+    Timed {
+        amount: u32,
+        unit: DurationUnit,
+        /// Whether concentration is required
+        #[serde(default)]
+        concentration: bool,
+    },
+    /// Until dispelled or specific condition
+    UntilDispelled {
+        /// Optional triggering condition
+        trigger: Option<String>,
+    },
+    /// Special duration (see spell description)
+    Special { description: String },
+}
+
+/// Unit of time for duration.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum DurationUnit {
+    Round,
+    Minute,
+    Hour,
+    Day,
+}
+
+impl SpellDuration {
+    /// Create an instantaneous duration.
+    pub fn instantaneous() -> Self {
+        SpellDuration::Instantaneous
+    }
+
+    /// Create a duration in rounds.
+    pub fn rounds(amount: u32) -> Self {
+        SpellDuration::Timed {
+            amount,
+            unit: DurationUnit::Round,
+            concentration: false,
+        }
+    }
+
+    /// Create a duration in minutes.
+    pub fn minutes(amount: u32) -> Self {
+        SpellDuration::Timed {
+            amount,
+            unit: DurationUnit::Minute,
+            concentration: false,
+        }
+    }
+
+    /// Create a duration in hours.
+    pub fn hours(amount: u32) -> Self {
+        SpellDuration::Timed {
+            amount,
+            unit: DurationUnit::Hour,
+            concentration: false,
+        }
+    }
+
+    /// Create a concentration duration in minutes.
+    pub fn concentration_minutes(amount: u32) -> Self {
+        SpellDuration::Timed {
+            amount,
+            unit: DurationUnit::Minute,
+            concentration: true,
+        }
+    }
+
+    /// Create a concentration duration in hours.
+    pub fn concentration_hours(amount: u32) -> Self {
+        SpellDuration::Timed {
+            amount,
+            unit: DurationUnit::Hour,
+            concentration: true,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn spell_level_conversion() {
+        assert_eq!(SpellLevel::from(0), SpellLevel::Cantrip);
+        assert_eq!(SpellLevel::from(1), SpellLevel::Level(1));
+        assert_eq!(SpellLevel::from(9), SpellLevel::Level(9));
+    }
+
+    #[test]
+    fn spell_level_as_number() {
+        assert_eq!(SpellLevel::Cantrip.as_number(), 0);
+        assert_eq!(SpellLevel::Level(3).as_number(), 3);
+    }
+
+    #[test]
+    fn spell_serialization() {
+        let spell = Spell {
+            id: "dnd5e_fireball".into(),
+            system_id: "dnd5e".into(),
+            name: "Fireball".into(),
+            level: SpellLevel::Level(3),
+            school: Some("Evocation".into()),
+            casting_time: CastingTime::action(),
+            range: SpellRange::feet(150),
+            components: SpellComponents::all("a tiny ball of bat guano and sulfur"),
+            duration: SpellDuration::instantaneous(),
+            description: "A bright streak flashes...".into(),
+            higher_levels: Some("When cast at 4th level or higher...".into()),
+            classes: vec!["sorcerer".into(), "wizard".into()],
+            source: "PHB p.241".into(),
+            tags: vec!["damage".into(), "fire".into()],
+            ritual: false,
+            concentration: false,
+        };
+
+        let json = serde_json::to_string(&spell).unwrap();
+        let deserialized: Spell = serde_json::from_str(&json).unwrap();
+        assert_eq!(spell, deserialized);
+    }
+
+    #[test]
+    fn casting_time_constructors() {
+        assert_eq!(CastingTime::action().unit, CastingTimeUnit::Action);
+        assert_eq!(CastingTime::bonus_action().unit, CastingTimeUnit::BonusAction);
+        assert_eq!(CastingTime::minutes(10).amount, 10);
+    }
+
+    #[test]
+    fn spell_range_constructors() {
+        assert!(matches!(SpellRange::self_only(), SpellRange::SelfOnly { area: None }));
+        assert!(matches!(SpellRange::touch(), SpellRange::Touch));
+        assert!(matches!(SpellRange::feet(60), SpellRange::Feet { distance: 60 }));
+    }
+}

--- a/crates/domain/src/game_systems/blades.rs
+++ b/crates/domain/src/game_systems/blades.rs
@@ -1,0 +1,1990 @@
+//! Blades in the Dark game system implementation.
+//!
+//! Blades uses a d6 dice pool system with position/effect mechanics.
+//! Key features:
+//! - Roll dice pool, take highest
+//! - Position (Controlled/Risky/Desperate) determines consequence severity
+//! - Effect (Zero/Limited/Standard/Great) determines success magnitude
+//! - Stress as a spendable resource
+//! - Clocks for progress tracking
+
+use super::traits::{
+    CalculationEngine, CharacterSheetProvider, CharacterSheetSchema, ConditionLevel,
+    CreationStep, DerivedField, DerivationType, FieldDefinition, FieldLayout, FieldValidation,
+    GameSystem, ProficiencyLevel, ResourceColor, SchemaFieldType, SchemaSection,
+    SchemaSelectOption, SectionType,
+};
+use crate::entities::{StatBlock, StatModifier};
+use std::collections::HashMap;
+
+/// Blades action roll outcome.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BladesOutcome {
+    /// Multiple 6s - success with increased effect
+    Critical,
+    /// Highest die is 6 - clean success
+    Success,
+    /// Highest die is 4-5 - success with complication
+    PartialSuccess,
+    /// Highest die is 1-3 - failure with consequence
+    Failure,
+}
+
+impl BladesOutcome {
+    /// Determine outcome from dice results.
+    pub fn from_dice(dice: &[u8]) -> Self {
+        if dice.is_empty() {
+            return BladesOutcome::Failure;
+        }
+
+        let highest = *dice.iter().max().unwrap();
+        let sixes = dice.iter().filter(|&&d| d == 6).count();
+
+        if sixes >= 2 {
+            BladesOutcome::Critical
+        } else if highest == 6 {
+            BladesOutcome::Success
+        } else if highest >= 4 {
+            BladesOutcome::PartialSuccess
+        } else {
+            BladesOutcome::Failure
+        }
+    }
+
+    pub fn is_success(&self) -> bool {
+        matches!(
+            self,
+            BladesOutcome::Critical | BladesOutcome::Success | BladesOutcome::PartialSuccess
+        )
+    }
+}
+
+/// Position determines consequence severity.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Position {
+    /// Safe, dominant advantage - minor consequences
+    Controlled,
+    /// Standard risk - moderate consequences
+    Risky,
+    /// Serious trouble - severe consequences
+    Desperate,
+}
+
+impl Position {
+    /// XP is gained for desperate actions.
+    pub fn grants_xp(&self) -> bool {
+        matches!(self, Position::Desperate)
+    }
+}
+
+/// Effect level determines success magnitude.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum EffectLevel {
+    /// No meaningful progress
+    Zero,
+    /// Partial/weak effect (1 clock tick)
+    Limited,
+    /// Normal effect (2 clock ticks)
+    Standard,
+    /// Better than usual (3 clock ticks)
+    Great,
+    /// Extraordinary (4 clock ticks, from critical)
+    Extreme,
+}
+
+impl EffectLevel {
+    /// Clock segments filled by this effect level.
+    pub fn clock_ticks(&self) -> u8 {
+        match self {
+            EffectLevel::Zero => 0,
+            EffectLevel::Limited => 1,
+            EffectLevel::Standard => 2,
+            EffectLevel::Great => 3,
+            EffectLevel::Extreme => 4,
+        }
+    }
+
+    /// Increase effect by one level (e.g., from critical).
+    pub fn increase(self) -> Self {
+        match self {
+            EffectLevel::Zero => EffectLevel::Limited,
+            EffectLevel::Limited => EffectLevel::Standard,
+            EffectLevel::Standard => EffectLevel::Great,
+            EffectLevel::Great => EffectLevel::Extreme,
+            EffectLevel::Extreme => EffectLevel::Extreme,
+        }
+    }
+
+    /// Decrease effect by one level.
+    pub fn decrease(self) -> Self {
+        match self {
+            EffectLevel::Zero => EffectLevel::Zero,
+            EffectLevel::Limited => EffectLevel::Zero,
+            EffectLevel::Standard => EffectLevel::Limited,
+            EffectLevel::Great => EffectLevel::Standard,
+            EffectLevel::Extreme => EffectLevel::Great,
+        }
+    }
+}
+
+/// Harm levels in Blades.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HarmLevel {
+    /// Lesser harm - narrative only
+    Level1,
+    /// Moderate harm - -1d to related actions
+    Level2,
+    /// Severe harm - -1d (stacks)
+    Level3,
+    /// Fatal - dying/dead
+    Level4,
+}
+
+impl HarmLevel {
+    /// Dice penalty from this harm level.
+    pub fn dice_penalty(&self) -> u8 {
+        match self {
+            HarmLevel::Level1 => 0,
+            HarmLevel::Level2 => 1,
+            HarmLevel::Level3 => 1,
+            HarmLevel::Level4 => 0, // You're dying, penalties don't matter
+        }
+    }
+}
+
+/// Trauma conditions in Blades.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TraumaCondition {
+    Cold,
+    Haunted,
+    Obsessed,
+    Paranoid,
+    Reckless,
+    Soft,
+    Unstable,
+    Vicious,
+}
+
+/// Load levels for equipment.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LoadLevel {
+    /// 3 items, no penalty
+    Light,
+    /// 5 items, no penalty
+    Normal,
+    /// 6 items, -1d to Prowess actions
+    Heavy,
+}
+
+impl LoadLevel {
+    pub fn max_items(&self) -> u8 {
+        match self {
+            LoadLevel::Light => 3,
+            LoadLevel::Normal => 5,
+            LoadLevel::Heavy => 6,
+        }
+    }
+
+    pub fn prowess_penalty(&self) -> u8 {
+        match self {
+            LoadLevel::Light | LoadLevel::Normal => 0,
+            LoadLevel::Heavy => 1,
+        }
+    }
+}
+
+/// Blades in the Dark game system.
+pub struct BladesSystem {
+    action_names: Vec<&'static str>,
+}
+
+impl BladesSystem {
+    pub fn new() -> Self {
+        Self {
+            action_names: vec![
+                // Insight
+                "Hunt",
+                "Study",
+                "Survey",
+                "Tinker",
+                // Prowess
+                "Finesse",
+                "Prowl",
+                "Skirmish",
+                "Wreck",
+                // Resolve
+                "Attune",
+                "Command",
+                "Consort",
+                "Sway",
+            ],
+        }
+    }
+
+    /// Calculate attribute rating from action dots.
+    pub fn insight_rating(hunt: u8, study: u8, survey: u8, tinker: u8) -> u8 {
+        hunt + study + survey + tinker
+    }
+
+    pub fn prowess_rating(finesse: u8, prowl: u8, skirmish: u8, wreck: u8) -> u8 {
+        finesse + prowl + skirmish + wreck
+    }
+
+    pub fn resolve_rating(attune: u8, command: u8, consort: u8, sway: u8) -> u8 {
+        attune + command + consort + sway
+    }
+
+    /// Calculate resistance roll stress cost.
+    pub fn resistance_roll_cost(sixes_rolled: u8) -> u8 {
+        6_u8.saturating_sub(sixes_rolled)
+    }
+}
+
+impl Default for BladesSystem {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl GameSystem for BladesSystem {
+    fn system_id(&self) -> &str {
+        "blades"
+    }
+
+    fn display_name(&self) -> &str {
+        "Blades in the Dark"
+    }
+
+    fn calculation_engine(&self) -> &dyn CalculationEngine {
+        self
+    }
+
+    fn stat_names(&self) -> &[&str] {
+        // Blades uses attributes (Insight, Prowess, Resolve)
+        // but these are derived from actions
+        &["Insight", "Prowess", "Resolve"]
+    }
+
+    fn skill_names(&self) -> &[&str] {
+        // Actions are like skills
+        &self.action_names
+    }
+}
+
+impl CalculationEngine for BladesSystem {
+    fn ability_modifier(&self, score: i32) -> i32 {
+        // In Blades, action ratings (0-4) ARE the dice pool
+        score
+    }
+
+    fn proficiency_bonus(&self, _level: u8) -> i32 {
+        // Blades has no proficiency system
+        0
+    }
+
+    fn spell_save_dc(&self, _stats: &StatBlock, _casting_stat: &str) -> i32 {
+        // Blades doesn't use spell DCs
+        0
+    }
+
+    fn spell_attack_bonus(&self, _stats: &StatBlock, _casting_stat: &str) -> i32 {
+        // Attune is used for supernatural
+        0
+    }
+
+    fn attack_bonus(&self, stats: &StatBlock, attack_action: &str, _proficient: bool) -> i32 {
+        // Return action rating as dice pool
+        stats.get_stat(attack_action).unwrap_or(0)
+    }
+
+    fn stack_modifiers(&self, modifiers: &[StatModifier]) -> i32 {
+        // In Blades, modifiers add/remove dice from pool
+        modifiers
+            .iter()
+            .filter(|m| m.active)
+            .map(|m| m.value)
+            .sum()
+    }
+
+    fn calculate_ac(
+        &self,
+        _stats: &StatBlock,
+        _armor_ac: Option<i32>,
+        _shield_bonus: Option<i32>,
+        _allows_dex: bool,
+        _max_dex_bonus: Option<i32>,
+    ) -> i32 {
+        // Blades doesn't have AC
+        0
+    }
+
+    fn skill_modifier(
+        &self,
+        stats: &StatBlock,
+        action: &str,
+        _proficiency_level: ProficiencyLevel,
+    ) -> i32 {
+        // Return action rating
+        stats.get_stat(action).unwrap_or(0)
+    }
+
+    fn saving_throw_modifier(
+        &self,
+        stats: &StatBlock,
+        attribute: &str,
+        _proficient: bool,
+    ) -> i32 {
+        // Resistance rolls use attribute ratings
+        stats.get_stat(attribute).unwrap_or(0)
+    }
+
+    fn passive_perception(&self, stats: &StatBlock, _proficiency_level: ProficiencyLevel) -> i32 {
+        // Survey is closest to perception
+        stats.get_stat("Survey").unwrap_or(0)
+    }
+
+    fn hit_die(&self, _class_name: &str) -> u8 {
+        // Blades uses stress, not HP
+        0
+    }
+
+    fn calculate_max_hp(
+        &self,
+        _level: u8,
+        _class_name: &str,
+        _constitution_modifier: i32,
+        _additional_hp: i32,
+    ) -> i32 {
+        // Max stress is 9
+        9
+    }
+}
+
+impl CharacterSheetProvider for BladesSystem {
+    fn character_sheet_schema(&self) -> CharacterSheetSchema {
+        CharacterSheetSchema {
+            system_id: "blades".to_string(),
+            system_name: "Blades in the Dark".to_string(),
+            sections: vec![
+                self.identity_section(),
+                self.attributes_actions_section(),
+                self.harm_section(),
+                self.stress_trauma_section(),
+                self.load_armor_section(),
+                self.special_abilities_section(),
+            ],
+            creation_steps: vec![
+                CreationStep {
+                    id: "identity".to_string(),
+                    label: "Identity".to_string(),
+                    description: "Choose your character's name, alias, playbook, heritage, background, and vice.".to_string(),
+                    section_ids: vec!["identity".to_string()],
+                    order: 1,
+                    required: true,
+                },
+                CreationStep {
+                    id: "actions".to_string(),
+                    label: "Action Ratings".to_string(),
+                    description: "Assign action dots based on your playbook. You get 4 action dots to assign, plus your playbook's starting action at rating 2.".to_string(),
+                    section_ids: vec!["attributes_actions".to_string()],
+                    order: 2,
+                    required: true,
+                },
+                CreationStep {
+                    id: "abilities".to_string(),
+                    label: "Special Abilities".to_string(),
+                    description: "Choose your starting special ability from your playbook.".to_string(),
+                    section_ids: vec!["special_abilities".to_string()],
+                    order: 3,
+                    required: true,
+                },
+                CreationStep {
+                    id: "load".to_string(),
+                    label: "Load & Equipment".to_string(),
+                    description: "Choose your load level and equipment for the score.".to_string(),
+                    section_ids: vec!["load_armor".to_string()],
+                    order: 4,
+                    required: false,
+                },
+            ],
+        }
+    }
+
+    fn calculate_derived_values(
+        &self,
+        values: &HashMap<String, serde_json::Value>,
+    ) -> HashMap<String, serde_json::Value> {
+        let mut derived = HashMap::new();
+
+        // Helper to get action rating
+        let get_action = |name: &str| -> u8 {
+            values
+                .get(name)
+                .and_then(|v| v.as_u64())
+                .unwrap_or(0) as u8
+        };
+
+        // Calculate Insight attribute (number of actions with 1+ dots)
+        let insight_actions = ["HUNT", "STUDY", "SURVEY", "TINKER"];
+        let insight_rating: u8 = insight_actions
+            .iter()
+            .filter(|a| get_action(a) > 0)
+            .count() as u8;
+        derived.insert("INSIGHT".to_string(), serde_json::json!(insight_rating));
+
+        // Calculate Prowess attribute
+        let prowess_actions = ["FINESSE", "PROWL", "SKIRMISH", "WRECK"];
+        let prowess_rating: u8 = prowess_actions
+            .iter()
+            .filter(|a| get_action(a) > 0)
+            .count() as u8;
+        derived.insert("PROWESS".to_string(), serde_json::json!(prowess_rating));
+
+        // Calculate Resolve attribute
+        let resolve_actions = ["ATTUNE", "COMMAND", "CONSORT", "SWAY"];
+        let resolve_rating: u8 = resolve_actions
+            .iter()
+            .filter(|a| get_action(a) > 0)
+            .count() as u8;
+        derived.insert("RESOLVE".to_string(), serde_json::json!(resolve_rating));
+
+        // Calculate trauma count
+        let trauma_conditions = [
+            "TRAUMA_COLD",
+            "TRAUMA_HAUNTED",
+            "TRAUMA_OBSESSED",
+            "TRAUMA_PARANOID",
+            "TRAUMA_RECKLESS",
+            "TRAUMA_SOFT",
+            "TRAUMA_UNSTABLE",
+            "TRAUMA_VICIOUS",
+        ];
+        let trauma_count: u8 = trauma_conditions
+            .iter()
+            .filter(|t| values.get(&t.to_string()).and_then(|v| v.as_bool()).unwrap_or(false))
+            .count() as u8;
+        derived.insert("TRAUMA_COUNT".to_string(), serde_json::json!(trauma_count));
+
+        // Calculate load used
+        // This would sum up equipped items' load values
+        // For now, just track the load level's max
+        if let Some(load_level) = values.get("LOAD_LEVEL").and_then(|v| v.as_str()) {
+            let max_load = match load_level {
+                "light" => 3,
+                "normal" => 5,
+                "heavy" => 6,
+                _ => 5,
+            };
+            derived.insert("MAX_LOAD".to_string(), serde_json::json!(max_load));
+        }
+
+        // Calculate XP trigger based on playbook
+        if let Some(playbook) = values.get("PLAYBOOK").and_then(|v| v.as_str()) {
+            let xp_trigger = match playbook {
+                "cutter" => "Address challenges with violence or coercion",
+                "hound" => "Address challenges with tracking or violence",
+                "leech" => "Address challenges with technical skill or mayhem",
+                "lurk" => "Address challenges with stealth or evasion",
+                "slide" => "Address challenges with deception or influence",
+                "spider" => "Address challenges with calculation or conspiracy",
+                "whisper" => "Address challenges with knowledge or arcane power",
+                _ => "",
+            };
+            derived.insert("XP_TRIGGER".to_string(), serde_json::json!(xp_trigger));
+        }
+
+        derived
+    }
+
+    fn validate_field(
+        &self,
+        field_id: &str,
+        value: &serde_json::Value,
+        all_values: &HashMap<String, serde_json::Value>,
+    ) -> Option<String> {
+        match field_id {
+            // Validate action ratings (0-4)
+            "HUNT" | "STUDY" | "SURVEY" | "TINKER" | "FINESSE" | "PROWL" | "SKIRMISH"
+            | "WRECK" | "ATTUNE" | "COMMAND" | "CONSORT" | "SWAY" => {
+                if let Some(rating) = value.as_u64() {
+                    if rating > 4 {
+                        return Some("Action ratings must be between 0 and 4".to_string());
+                    }
+                } else {
+                    return Some("Action rating must be a number".to_string());
+                }
+            }
+
+            // Validate stress (0-9)
+            "STRESS" => {
+                if let Some(stress) = value.as_u64() {
+                    if stress > 9 {
+                        return Some("Stress must be between 0 and 9".to_string());
+                    }
+                } else {
+                    return Some("Stress must be a number".to_string());
+                }
+            }
+
+            // Validate trauma count
+            "TRAUMA_COLD" | "TRAUMA_HAUNTED" | "TRAUMA_OBSESSED" | "TRAUMA_PARANOID"
+            | "TRAUMA_RECKLESS" | "TRAUMA_SOFT" | "TRAUMA_UNSTABLE" | "TRAUMA_VICIOUS" => {
+                // Count current traumas
+                let trauma_conditions = [
+                    "TRAUMA_COLD",
+                    "TRAUMA_HAUNTED",
+                    "TRAUMA_OBSESSED",
+                    "TRAUMA_PARANOID",
+                    "TRAUMA_RECKLESS",
+                    "TRAUMA_SOFT",
+                    "TRAUMA_UNSTABLE",
+                    "TRAUMA_VICIOUS",
+                ];
+
+                let current_count: usize = trauma_conditions
+                    .iter()
+                    .filter(|t| {
+                        if **t == field_id {
+                            value.as_bool().unwrap_or(false)
+                        } else {
+                            all_values
+                                .get(&t.to_string())
+                                .and_then(|v| v.as_bool())
+                                .unwrap_or(false)
+                        }
+                    })
+                    .count();
+
+                if current_count > 4 {
+                    return Some("Maximum 4 traumas allowed".to_string());
+                }
+            }
+
+            // Validate name
+            "NAME" => {
+                if let Some(name) = value.as_str() {
+                    if name.is_empty() {
+                        return Some("Name is required".to_string());
+                    }
+                } else {
+                    return Some("Name must be a string".to_string());
+                }
+            }
+
+            _ => {}
+        }
+        None
+    }
+
+    fn default_values(&self) -> HashMap<String, serde_json::Value> {
+        let mut defaults = HashMap::new();
+
+        // Actions default to 0
+        for action in &[
+            "HUNT", "STUDY", "SURVEY", "TINKER", "FINESSE", "PROWL", "SKIRMISH", "WRECK",
+            "ATTUNE", "COMMAND", "CONSORT", "SWAY",
+        ] {
+            defaults.insert(action.to_string(), serde_json::json!(0));
+        }
+
+        // Stress defaults to 0
+        defaults.insert("STRESS".to_string(), serde_json::json!(0));
+
+        // Traumas default to false
+        for trauma in &[
+            "TRAUMA_COLD",
+            "TRAUMA_HAUNTED",
+            "TRAUMA_OBSESSED",
+            "TRAUMA_PARANOID",
+            "TRAUMA_RECKLESS",
+            "TRAUMA_SOFT",
+            "TRAUMA_UNSTABLE",
+            "TRAUMA_VICIOUS",
+        ] {
+            defaults.insert(trauma.to_string(), serde_json::json!(false));
+        }
+
+        // Harm defaults to empty
+        defaults.insert("HARM_LEVEL1_1".to_string(), serde_json::json!(""));
+        defaults.insert("HARM_LEVEL1_2".to_string(), serde_json::json!(""));
+        defaults.insert("HARM_LEVEL2_1".to_string(), serde_json::json!(""));
+        defaults.insert("HARM_LEVEL2_2".to_string(), serde_json::json!(""));
+        defaults.insert("HARM_LEVEL3".to_string(), serde_json::json!(""));
+
+        // Armor defaults to false
+        defaults.insert("ARMOR_STANDARD".to_string(), serde_json::json!(false));
+        defaults.insert("ARMOR_HEAVY".to_string(), serde_json::json!(false));
+        defaults.insert("ARMOR_SPECIAL".to_string(), serde_json::json!(false));
+
+        // Load defaults to normal
+        defaults.insert("LOAD_LEVEL".to_string(), serde_json::json!("normal"));
+
+        // Healing clock defaults to 0
+        defaults.insert("HEALING_CLOCK".to_string(), serde_json::json!(0));
+
+        defaults
+    }
+}
+
+// Helper methods for building the schema
+impl BladesSystem {
+    fn identity_section(&self) -> SchemaSection {
+        SchemaSection {
+            id: "identity".to_string(),
+            label: "Identity".to_string(),
+            section_type: SectionType::Identity,
+            fields: vec![
+                FieldDefinition {
+                    id: "NAME".to_string(),
+                    label: "Name".to_string(),
+                    field_type: SchemaFieldType::Text {
+                        multiline: false,
+                        max_length: Some(100),
+                    },
+                    editable: true,
+                    required: true,
+                    derived_from: None,
+                    validation: None,
+                    layout: FieldLayout {
+                        width: Some(4),
+                        ..Default::default()
+                    },
+                    description: None,
+                    placeholder: Some("Character name".to_string()),
+                },
+                FieldDefinition {
+                    id: "ALIAS".to_string(),
+                    label: "Alias".to_string(),
+                    field_type: SchemaFieldType::Text {
+                        multiline: false,
+                        max_length: Some(100),
+                    },
+                    editable: true,
+                    required: false,
+                    derived_from: None,
+                    validation: None,
+                    layout: FieldLayout {
+                        width: Some(4),
+                        ..Default::default()
+                    },
+                    description: Some("Your street name or nickname".to_string()),
+                    placeholder: Some("Alias".to_string()),
+                },
+                FieldDefinition {
+                    id: "PLAYBOOK".to_string(),
+                    label: "Playbook".to_string(),
+                    field_type: SchemaFieldType::Select {
+                        options: vec![
+                            SchemaSelectOption {
+                                value: "cutter".to_string(),
+                                label: "Cutter".to_string(),
+                                description: Some("A dangerous and intimidating fighter".to_string()),
+                            },
+                            SchemaSelectOption {
+                                value: "hound".to_string(),
+                                label: "Hound".to_string(),
+                                description: Some("A deadly sharpshooter and tracker".to_string()),
+                            },
+                            SchemaSelectOption {
+                                value: "leech".to_string(),
+                                label: "Leech".to_string(),
+                                description: Some("A saboteur and technician".to_string()),
+                            },
+                            SchemaSelectOption {
+                                value: "lurk".to_string(),
+                                label: "Lurk".to_string(),
+                                description: Some("A stealthy infiltrator and burglar".to_string()),
+                            },
+                            SchemaSelectOption {
+                                value: "slide".to_string(),
+                                label: "Slide".to_string(),
+                                description: Some("A subtle manipulator and spy".to_string()),
+                            },
+                            SchemaSelectOption {
+                                value: "spider".to_string(),
+                                label: "Spider".to_string(),
+                                description: Some("A devious mastermind".to_string()),
+                            },
+                            SchemaSelectOption {
+                                value: "whisper".to_string(),
+                                label: "Whisper".to_string(),
+                                description: Some("An arcane adept and channeler".to_string()),
+                            },
+                        ],
+                        allow_custom: false,
+                    },
+                    editable: true,
+                    required: true,
+                    derived_from: None,
+                    validation: None,
+                    layout: FieldLayout {
+                        width: Some(4),
+                        ..Default::default()
+                    },
+                    description: None,
+                    placeholder: None,
+                },
+                FieldDefinition {
+                    id: "HERITAGE".to_string(),
+                    label: "Heritage".to_string(),
+                    field_type: SchemaFieldType::Select {
+                        options: vec![
+                            SchemaSelectOption {
+                                value: "akoros".to_string(),
+                                label: "Akoros".to_string(),
+                                description: Some("Educated and industrialized".to_string()),
+                            },
+                            SchemaSelectOption {
+                                value: "dagger_isles".to_string(),
+                                label: "Dagger Isles".to_string(),
+                                description: Some("Fierce and independent".to_string()),
+                            },
+                            SchemaSelectOption {
+                                value: "iruvia".to_string(),
+                                label: "Iruvia".to_string(),
+                                description: Some("Rich, proud, and tradition-bound".to_string()),
+                            },
+                            SchemaSelectOption {
+                                value: "severos".to_string(),
+                                label: "Severos".to_string(),
+                                description: Some("Hardened and rugged".to_string()),
+                            },
+                            SchemaSelectOption {
+                                value: "skovlan".to_string(),
+                                label: "Skovlan".to_string(),
+                                description: Some("Tenacious and hardworking".to_string()),
+                            },
+                            SchemaSelectOption {
+                                value: "tycheros".to_string(),
+                                label: "Tycheros".to_string(),
+                                description: Some("Alien and unfamiliar".to_string()),
+                            },
+                        ],
+                        allow_custom: true,
+                    },
+                    editable: true,
+                    required: false,
+                    derived_from: None,
+                    validation: None,
+                    layout: FieldLayout {
+                        width: Some(4),
+                        new_row: true,
+                        ..Default::default()
+                    },
+                    description: Some("Where your family line is from".to_string()),
+                    placeholder: None,
+                },
+                FieldDefinition {
+                    id: "BACKGROUND".to_string(),
+                    label: "Background".to_string(),
+                    field_type: SchemaFieldType::Select {
+                        options: vec![
+                            SchemaSelectOption {
+                                value: "academic".to_string(),
+                                label: "Academic".to_string(),
+                                description: Some("A scholar, scientist, or professor".to_string()),
+                            },
+                            SchemaSelectOption {
+                                value: "labor".to_string(),
+                                label: "Labor".to_string(),
+                                description: Some("A worker, tradesperson, or servant".to_string()),
+                            },
+                            SchemaSelectOption {
+                                value: "law".to_string(),
+                                label: "Law".to_string(),
+                                description: Some("A lawyer, judge, or inspector".to_string()),
+                            },
+                            SchemaSelectOption {
+                                value: "trade".to_string(),
+                                label: "Trade".to_string(),
+                                description: Some("A merchant, shopkeeper, or broker".to_string()),
+                            },
+                            SchemaSelectOption {
+                                value: "military".to_string(),
+                                label: "Military".to_string(),
+                                description: Some("A soldier, mercenary, or officer".to_string()),
+                            },
+                            SchemaSelectOption {
+                                value: "noble".to_string(),
+                                label: "Noble".to_string(),
+                                description: Some("An aristocrat, courtier, or heir".to_string()),
+                            },
+                            SchemaSelectOption {
+                                value: "underworld".to_string(),
+                                label: "Underworld".to_string(),
+                                description: Some("A criminal, gang member, or fence".to_string()),
+                            },
+                        ],
+                        allow_custom: true,
+                    },
+                    editable: true,
+                    required: false,
+                    derived_from: None,
+                    validation: None,
+                    layout: FieldLayout {
+                        width: Some(4),
+                        ..Default::default()
+                    },
+                    description: Some("Your previous life before becoming a scoundrel".to_string()),
+                    placeholder: None,
+                },
+                FieldDefinition {
+                    id: "VICE".to_string(),
+                    label: "Vice".to_string(),
+                    field_type: SchemaFieldType::Select {
+                        options: vec![
+                            SchemaSelectOption {
+                                value: "faith".to_string(),
+                                label: "Faith".to_string(),
+                                description: Some("Worship of a deity or forgotten god".to_string()),
+                            },
+                            SchemaSelectOption {
+                                value: "gambling".to_string(),
+                                label: "Gambling".to_string(),
+                                description: Some("Games of chance and risk".to_string()),
+                            },
+                            SchemaSelectOption {
+                                value: "luxury".to_string(),
+                                label: "Luxury".to_string(),
+                                description: Some("Expensive or extravagant pleasures".to_string()),
+                            },
+                            SchemaSelectOption {
+                                value: "obligation".to_string(),
+                                label: "Obligation".to_string(),
+                                description: Some("Family, friends, or causes you support".to_string()),
+                            },
+                            SchemaSelectOption {
+                                value: "pleasure".to_string(),
+                                label: "Pleasure".to_string(),
+                                description: Some("Hedonistic gratification".to_string()),
+                            },
+                            SchemaSelectOption {
+                                value: "stupor".to_string(),
+                                label: "Stupor".to_string(),
+                                description: Some("Drugs, alcohol, or other intoxicants".to_string()),
+                            },
+                            SchemaSelectOption {
+                                value: "weird".to_string(),
+                                label: "Weird".to_string(),
+                                description: Some("Occult or strange practices".to_string()),
+                            },
+                        ],
+                        allow_custom: true,
+                    },
+                    editable: true,
+                    required: false,
+                    derived_from: None,
+                    validation: None,
+                    layout: FieldLayout {
+                        width: Some(4),
+                        ..Default::default()
+                    },
+                    description: Some("How you relieve stress".to_string()),
+                    placeholder: None,
+                },
+                FieldDefinition {
+                    id: "XP_TRIGGER".to_string(),
+                    label: "XP Trigger".to_string(),
+                    field_type: SchemaFieldType::Text {
+                        multiline: false,
+                        max_length: Some(200),
+                    },
+                    editable: false,
+                    required: false,
+                    derived_from: Some(DerivedField {
+                        derivation_type: DerivationType::Custom,
+                        dependencies: vec!["PLAYBOOK".to_string()],
+                        display_format: None,
+                    }),
+                    validation: None,
+                    layout: FieldLayout {
+                        width: Some(12),
+                        new_row: true,
+                        ..Default::default()
+                    },
+                    description: Some("Earn XP when you...".to_string()),
+                    placeholder: None,
+                },
+            ],
+            collapsible: false,
+            collapsed_default: false,
+            description: None,
+        }
+    }
+
+    fn attributes_actions_section(&self) -> SchemaSection {
+        let action_field = |id: &str, label: &str, description: &str| FieldDefinition {
+            id: id.to_string(),
+            label: label.to_string(),
+            field_type: SchemaFieldType::DicePool {
+                max_dice: 4,
+                die_type: 6,
+            },
+            editable: true,
+            required: false,
+            derived_from: None,
+            validation: Some(FieldValidation {
+                min: Some(0),
+                max: Some(4),
+                pattern: None,
+                error_message: Some("Action ratings must be 0-4".to_string()),
+            }),
+            layout: FieldLayout {
+                width: Some(3),
+                ..Default::default()
+            },
+            description: Some(description.to_string()),
+            placeholder: None,
+        };
+
+        let attribute_field = |id: &str, label: &str, deps: Vec<&str>| FieldDefinition {
+            id: id.to_string(),
+            label: label.to_string(),
+            field_type: SchemaFieldType::Integer {
+                min: Some(0),
+                max: Some(4),
+                show_modifier: false,
+            },
+            editable: false,
+            required: false,
+            derived_from: Some(DerivedField {
+                derivation_type: DerivationType::Custom,
+                dependencies: deps.into_iter().map(String::from).collect(),
+                display_format: None,
+            }),
+            validation: None,
+            layout: FieldLayout {
+                width: Some(12),
+                new_row: true,
+                ..Default::default()
+            },
+            description: Some("Number of actions with 1+ dots in this attribute".to_string()),
+            placeholder: None,
+        };
+
+        SchemaSection {
+            id: "attributes_actions".to_string(),
+            label: "Attributes & Actions".to_string(),
+            section_type: SectionType::Skills,
+            fields: vec![
+                // Insight attribute header
+                attribute_field("INSIGHT", "Insight", vec!["HUNT", "STUDY", "SURVEY", "TINKER"]),
+                // Insight actions
+                action_field("HUNT", "Hunt", "Track, ambush, attack from a distance"),
+                action_field("STUDY", "Study", "Scrutinize, research, analyze"),
+                action_field("SURVEY", "Survey", "Observe, search, gather information"),
+                action_field("TINKER", "Tinker", "Build, repair, disable mechanisms"),
+                // Prowess attribute header
+                attribute_field("PROWESS", "Prowess", vec!["FINESSE", "PROWL", "SKIRMISH", "WRECK"]),
+                // Prowess actions
+                action_field("FINESSE", "Finesse", "Precise movement, sleight of hand"),
+                action_field("PROWL", "Prowl", "Move quietly, hide, sneak"),
+                action_field("SKIRMISH", "Skirmish", "Fight in close combat"),
+                action_field("WRECK", "Wreck", "Destroy, smash, break things"),
+                // Resolve attribute header
+                attribute_field("RESOLVE", "Resolve", vec!["ATTUNE", "COMMAND", "CONSORT", "SWAY"]),
+                // Resolve actions
+                action_field("ATTUNE", "Attune", "Open mind to the ghost field, use arcane powers"),
+                action_field("COMMAND", "Command", "Compel with authority, intimidate"),
+                action_field("CONSORT", "Consort", "Socialize, make connections"),
+                action_field("SWAY", "Sway", "Influence with guile, charm, argue"),
+            ],
+            collapsible: false,
+            collapsed_default: false,
+            description: Some("Your action ratings determine your dice pool. Attribute ratings are the count of actions with at least 1 dot.".to_string()),
+        }
+    }
+
+    fn harm_section(&self) -> SchemaSection {
+        SchemaSection {
+            id: "harm".to_string(),
+            label: "Harm".to_string(),
+            section_type: SectionType::Combat,
+            fields: vec![
+                FieldDefinition {
+                    id: "HARM_TRACK".to_string(),
+                    label: "Harm".to_string(),
+                    field_type: SchemaFieldType::ConditionTrack {
+                        levels: vec![
+                            ConditionLevel {
+                                level: 1,
+                                label: "Less Serious (2 slots)".to_string(),
+                                effect: None,
+                            },
+                            ConditionLevel {
+                                level: 2,
+                                label: "Serious (2 slots)".to_string(),
+                                effect: Some("-1d to related actions".to_string()),
+                            },
+                            ConditionLevel {
+                                level: 3,
+                                label: "Severe/Fatal (1 slot)".to_string(),
+                                effect: Some("Need help to act, -1d stacks with level 2".to_string()),
+                            },
+                        ],
+                    },
+                    editable: false,
+                    required: false,
+                    derived_from: None,
+                    validation: None,
+                    layout: FieldLayout {
+                        width: Some(12),
+                        ..Default::default()
+                    },
+                    description: Some("Injuries reduce your effectiveness".to_string()),
+                    placeholder: None,
+                },
+                // Level 3 harm (1 slot)
+                FieldDefinition {
+                    id: "HARM_LEVEL3".to_string(),
+                    label: "Severe/Fatal".to_string(),
+                    field_type: SchemaFieldType::Text {
+                        multiline: false,
+                        max_length: Some(50),
+                    },
+                    editable: true,
+                    required: false,
+                    derived_from: None,
+                    validation: None,
+                    layout: FieldLayout {
+                        width: Some(12),
+                        new_row: true,
+                        ..Default::default()
+                    },
+                    description: Some("Level 3 harm - Need help to act".to_string()),
+                    placeholder: Some("Broken leg, impaled, shot in the chest...".to_string()),
+                },
+                // Level 2 harm (2 slots)
+                FieldDefinition {
+                    id: "HARM_LEVEL2_1".to_string(),
+                    label: "Serious".to_string(),
+                    field_type: SchemaFieldType::Text {
+                        multiline: false,
+                        max_length: Some(50),
+                    },
+                    editable: true,
+                    required: false,
+                    derived_from: None,
+                    validation: None,
+                    layout: FieldLayout {
+                        width: Some(6),
+                        new_row: true,
+                        ..Default::default()
+                    },
+                    description: Some("Level 2 harm - Reduces effect by 1".to_string()),
+                    placeholder: Some("Slashed arm, burned hand...".to_string()),
+                },
+                FieldDefinition {
+                    id: "HARM_LEVEL2_2".to_string(),
+                    label: "Serious".to_string(),
+                    field_type: SchemaFieldType::Text {
+                        multiline: false,
+                        max_length: Some(50),
+                    },
+                    editable: true,
+                    required: false,
+                    derived_from: None,
+                    validation: None,
+                    layout: FieldLayout {
+                        width: Some(6),
+                        ..Default::default()
+                    },
+                    description: Some("Level 2 harm - Reduces effect by 1".to_string()),
+                    placeholder: Some("Exhausted, concussed...".to_string()),
+                },
+                // Level 1 harm (2 slots)
+                FieldDefinition {
+                    id: "HARM_LEVEL1_1".to_string(),
+                    label: "Less Serious".to_string(),
+                    field_type: SchemaFieldType::Text {
+                        multiline: false,
+                        max_length: Some(50),
+                    },
+                    editable: true,
+                    required: false,
+                    derived_from: None,
+                    validation: None,
+                    layout: FieldLayout {
+                        width: Some(6),
+                        new_row: true,
+                        ..Default::default()
+                    },
+                    description: Some("Level 1 harm - No mechanical effect".to_string()),
+                    placeholder: Some("Bruised, tired...".to_string()),
+                },
+                FieldDefinition {
+                    id: "HARM_LEVEL1_2".to_string(),
+                    label: "Less Serious".to_string(),
+                    field_type: SchemaFieldType::Text {
+                        multiline: false,
+                        max_length: Some(50),
+                    },
+                    editable: true,
+                    required: false,
+                    derived_from: None,
+                    validation: None,
+                    layout: FieldLayout {
+                        width: Some(6),
+                        ..Default::default()
+                    },
+                    description: Some("Level 1 harm - No mechanical effect".to_string()),
+                    placeholder: Some("Shaken, winded...".to_string()),
+                },
+                // Healing clock
+                FieldDefinition {
+                    id: "HEALING_CLOCK".to_string(),
+                    label: "Healing Clock".to_string(),
+                    field_type: SchemaFieldType::Clock {
+                        segments: 4,
+                    },
+                    editable: true,
+                    required: false,
+                    derived_from: None,
+                    validation: None,
+                    layout: FieldLayout {
+                        width: Some(6),
+                        new_row: true,
+                        ..Default::default()
+                    },
+                    description: Some("When filled, reduce harm by one level".to_string()),
+                    placeholder: None,
+                },
+            ],
+            collapsible: false,
+            collapsed_default: false,
+            description: None,
+        }
+    }
+
+    fn stress_trauma_section(&self) -> SchemaSection {
+        SchemaSection {
+            id: "stress_trauma".to_string(),
+            label: "Stress & Trauma".to_string(),
+            section_type: SectionType::Resources,
+            fields: vec![
+                FieldDefinition {
+                    id: "STRESS".to_string(),
+                    label: "Stress".to_string(),
+                    field_type: SchemaFieldType::ResourceBar {
+                        max_field: "MAX_STRESS".to_string(),
+                        color: ResourceColor::Purple,
+                    },
+                    editable: true,
+                    required: false,
+                    derived_from: None,
+                    validation: Some(FieldValidation {
+                        min: Some(0),
+                        max: Some(9),
+                        pattern: None,
+                        error_message: Some("Stress must be 0-9".to_string()),
+                    }),
+                    layout: FieldLayout {
+                        width: Some(6),
+                        ..Default::default()
+                    },
+                    description: Some("Spend stress to push yourself, assist, or resist consequences. At 9 stress, you trauma out.".to_string()),
+                    placeholder: None,
+                },
+                FieldDefinition {
+                    id: "MAX_STRESS".to_string(),
+                    label: "Max Stress".to_string(),
+                    field_type: SchemaFieldType::Integer {
+                        min: Some(9),
+                        max: Some(9),
+                        show_modifier: false,
+                    },
+                    editable: false,
+                    required: false,
+                    derived_from: None,
+                    validation: None,
+                    layout: FieldLayout {
+                        width: Some(2),
+                        ..Default::default()
+                    },
+                    description: None,
+                    placeholder: None,
+                },
+                FieldDefinition {
+                    id: "TRAUMA_COUNT".to_string(),
+                    label: "Trauma".to_string(),
+                    field_type: SchemaFieldType::Integer {
+                        min: Some(0),
+                        max: Some(4),
+                        show_modifier: false,
+                    },
+                    editable: false,
+                    required: false,
+                    derived_from: Some(DerivedField {
+                        derivation_type: DerivationType::Custom,
+                        dependencies: vec![
+                            "TRAUMA_COLD".to_string(),
+                            "TRAUMA_HAUNTED".to_string(),
+                            "TRAUMA_OBSESSED".to_string(),
+                            "TRAUMA_PARANOID".to_string(),
+                            "TRAUMA_RECKLESS".to_string(),
+                            "TRAUMA_SOFT".to_string(),
+                            "TRAUMA_UNSTABLE".to_string(),
+                            "TRAUMA_VICIOUS".to_string(),
+                        ],
+                        display_format: Some("{}/4".to_string()),
+                    }),
+                    validation: None,
+                    layout: FieldLayout {
+                        width: Some(4),
+                        ..Default::default()
+                    },
+                    description: Some("At 4 trauma, your character retires".to_string()),
+                    placeholder: None,
+                },
+                // Trauma conditions as checkboxes
+                FieldDefinition {
+                    id: "TRAUMA_COLD".to_string(),
+                    label: "Cold".to_string(),
+                    field_type: SchemaFieldType::Boolean {
+                        checked_label: Some("Cold".to_string()),
+                        unchecked_label: None,
+                    },
+                    editable: true,
+                    required: false,
+                    derived_from: None,
+                    validation: None,
+                    layout: FieldLayout {
+                        width: Some(3),
+                        new_row: true,
+                        ..Default::default()
+                    },
+                    description: Some("You're not moved by emotional appeals or danger".to_string()),
+                    placeholder: None,
+                },
+                FieldDefinition {
+                    id: "TRAUMA_HAUNTED".to_string(),
+                    label: "Haunted".to_string(),
+                    field_type: SchemaFieldType::Boolean {
+                        checked_label: Some("Haunted".to_string()),
+                        unchecked_label: None,
+                    },
+                    editable: true,
+                    required: false,
+                    derived_from: None,
+                    validation: None,
+                    layout: FieldLayout {
+                        width: Some(3),
+                        ..Default::default()
+                    },
+                    description: Some("You're often lost in reverie, reliving past horrors".to_string()),
+                    placeholder: None,
+                },
+                FieldDefinition {
+                    id: "TRAUMA_OBSESSED".to_string(),
+                    label: "Obsessed".to_string(),
+                    field_type: SchemaFieldType::Boolean {
+                        checked_label: Some("Obsessed".to_string()),
+                        unchecked_label: None,
+                    },
+                    editable: true,
+                    required: false,
+                    derived_from: None,
+                    validation: None,
+                    layout: FieldLayout {
+                        width: Some(3),
+                        ..Default::default()
+                    },
+                    description: Some("You're fixated on a particular goal or idea".to_string()),
+                    placeholder: None,
+                },
+                FieldDefinition {
+                    id: "TRAUMA_PARANOID".to_string(),
+                    label: "Paranoid".to_string(),
+                    field_type: SchemaFieldType::Boolean {
+                        checked_label: Some("Paranoid".to_string()),
+                        unchecked_label: None,
+                    },
+                    editable: true,
+                    required: false,
+                    derived_from: None,
+                    validation: None,
+                    layout: FieldLayout {
+                        width: Some(3),
+                        ..Default::default()
+                    },
+                    description: Some("You imagine threats everywhere and can't trust anyone".to_string()),
+                    placeholder: None,
+                },
+                FieldDefinition {
+                    id: "TRAUMA_RECKLESS".to_string(),
+                    label: "Reckless".to_string(),
+                    field_type: SchemaFieldType::Boolean {
+                        checked_label: Some("Reckless".to_string()),
+                        unchecked_label: None,
+                    },
+                    editable: true,
+                    required: false,
+                    derived_from: None,
+                    validation: None,
+                    layout: FieldLayout {
+                        width: Some(3),
+                        new_row: true,
+                        ..Default::default()
+                    },
+                    description: Some("You have little regard for your own safety or best interests".to_string()),
+                    placeholder: None,
+                },
+                FieldDefinition {
+                    id: "TRAUMA_SOFT".to_string(),
+                    label: "Soft".to_string(),
+                    field_type: SchemaFieldType::Boolean {
+                        checked_label: Some("Soft".to_string()),
+                        unchecked_label: None,
+                    },
+                    editable: true,
+                    required: false,
+                    derived_from: None,
+                    validation: None,
+                    layout: FieldLayout {
+                        width: Some(3),
+                        ..Default::default()
+                    },
+                    description: Some("You lose your edge, become sentimental and easily manipulated".to_string()),
+                    placeholder: None,
+                },
+                FieldDefinition {
+                    id: "TRAUMA_UNSTABLE".to_string(),
+                    label: "Unstable".to_string(),
+                    field_type: SchemaFieldType::Boolean {
+                        checked_label: Some("Unstable".to_string()),
+                        unchecked_label: None,
+                    },
+                    editable: true,
+                    required: false,
+                    derived_from: None,
+                    validation: None,
+                    layout: FieldLayout {
+                        width: Some(3),
+                        ..Default::default()
+                    },
+                    description: Some("Your moods and actions are erratic and unpredictable".to_string()),
+                    placeholder: None,
+                },
+                FieldDefinition {
+                    id: "TRAUMA_VICIOUS".to_string(),
+                    label: "Vicious".to_string(),
+                    field_type: SchemaFieldType::Boolean {
+                        checked_label: Some("Vicious".to_string()),
+                        unchecked_label: None,
+                    },
+                    editable: true,
+                    required: false,
+                    derived_from: None,
+                    validation: None,
+                    layout: FieldLayout {
+                        width: Some(3),
+                        ..Default::default()
+                    },
+                    description: Some("You seek revenge and enjoy inflicting pain and misery".to_string()),
+                    placeholder: None,
+                },
+            ],
+            collapsible: false,
+            collapsed_default: false,
+            description: None,
+        }
+    }
+
+    fn load_armor_section(&self) -> SchemaSection {
+        SchemaSection {
+            id: "load_armor".to_string(),
+            label: "Load & Armor".to_string(),
+            section_type: SectionType::Inventory,
+            fields: vec![
+                FieldDefinition {
+                    id: "LOAD_LEVEL".to_string(),
+                    label: "Load".to_string(),
+                    field_type: SchemaFieldType::Select {
+                        options: vec![
+                            SchemaSelectOption {
+                                value: "light".to_string(),
+                                label: "Light (3)".to_string(),
+                                description: Some("Quick and quiet, 3 load".to_string()),
+                            },
+                            SchemaSelectOption {
+                                value: "normal".to_string(),
+                                label: "Normal (5)".to_string(),
+                                description: Some("Standard load, 5 load".to_string()),
+                            },
+                            SchemaSelectOption {
+                                value: "heavy".to_string(),
+                                label: "Heavy (6)".to_string(),
+                                description: Some("Slow and noisy, 6 load, -1d to Prowess".to_string()),
+                            },
+                        ],
+                        allow_custom: false,
+                    },
+                    editable: true,
+                    required: false,
+                    derived_from: None,
+                    validation: None,
+                    layout: FieldLayout {
+                        width: Some(4),
+                        ..Default::default()
+                    },
+                    description: Some("Determines how much gear you can carry".to_string()),
+                    placeholder: None,
+                },
+                FieldDefinition {
+                    id: "MAX_LOAD".to_string(),
+                    label: "Max Load".to_string(),
+                    field_type: SchemaFieldType::Integer {
+                        min: Some(3),
+                        max: Some(6),
+                        show_modifier: false,
+                    },
+                    editable: false,
+                    required: false,
+                    derived_from: Some(DerivedField {
+                        derivation_type: DerivationType::Custom,
+                        dependencies: vec!["LOAD_LEVEL".to_string()],
+                        display_format: None,
+                    }),
+                    validation: None,
+                    layout: FieldLayout {
+                        width: Some(2),
+                        ..Default::default()
+                    },
+                    description: None,
+                    placeholder: None,
+                },
+                FieldDefinition {
+                    id: "ARMOR_STANDARD".to_string(),
+                    label: "Armor".to_string(),
+                    field_type: SchemaFieldType::Boolean {
+                        checked_label: Some("Armor (worn)".to_string()),
+                        unchecked_label: Some("Armor (available)".to_string()),
+                    },
+                    editable: true,
+                    required: false,
+                    derived_from: None,
+                    validation: None,
+                    layout: FieldLayout {
+                        width: Some(2),
+                        ..Default::default()
+                    },
+                    description: Some("Negate harm from an attack (1 load)".to_string()),
+                    placeholder: None,
+                },
+                FieldDefinition {
+                    id: "ARMOR_HEAVY".to_string(),
+                    label: "Heavy".to_string(),
+                    field_type: SchemaFieldType::Boolean {
+                        checked_label: Some("Heavy (used)".to_string()),
+                        unchecked_label: Some("Heavy (available)".to_string()),
+                    },
+                    editable: true,
+                    required: false,
+                    derived_from: None,
+                    validation: None,
+                    layout: FieldLayout {
+                        width: Some(2),
+                        ..Default::default()
+                    },
+                    description: Some("Additional armor use (+1 load)".to_string()),
+                    placeholder: None,
+                },
+                FieldDefinition {
+                    id: "ARMOR_SPECIAL".to_string(),
+                    label: "Special".to_string(),
+                    field_type: SchemaFieldType::Boolean {
+                        checked_label: Some("Special (used)".to_string()),
+                        unchecked_label: Some("Special (available)".to_string()),
+                    },
+                    editable: true,
+                    required: false,
+                    derived_from: None,
+                    validation: None,
+                    layout: FieldLayout {
+                        width: Some(2),
+                        ..Default::default()
+                    },
+                    description: Some("From playbook abilities".to_string()),
+                    placeholder: None,
+                },
+            ],
+            collapsible: true,
+            collapsed_default: false,
+            description: Some("Choose your load before each score. Mark armor when used.".to_string()),
+        }
+    }
+
+    fn special_abilities_section(&self) -> SchemaSection {
+        SchemaSection {
+            id: "special_abilities".to_string(),
+            label: "Special Abilities".to_string(),
+            section_type: SectionType::Features,
+            fields: vec![
+                FieldDefinition {
+                    id: "SPECIAL_ABILITIES".to_string(),
+                    label: "Special Abilities".to_string(),
+                    field_type: SchemaFieldType::Text {
+                        multiline: true,
+                        max_length: None,
+                    },
+                    editable: true,
+                    required: false,
+                    derived_from: None,
+                    validation: None,
+                    layout: FieldLayout {
+                        width: Some(12),
+                        ..Default::default()
+                    },
+                    description: Some("Your playbook special abilities".to_string()),
+                    placeholder: Some("Enter your special abilities...".to_string()),
+                },
+                FieldDefinition {
+                    id: "ITEMS".to_string(),
+                    label: "Items".to_string(),
+                    field_type: SchemaFieldType::Text {
+                        multiline: true,
+                        max_length: None,
+                    },
+                    editable: true,
+                    required: false,
+                    derived_from: None,
+                    validation: None,
+                    layout: FieldLayout {
+                        width: Some(12),
+                        new_row: true,
+                        ..Default::default()
+                    },
+                    description: Some("Your carried items and their load cost".to_string()),
+                    placeholder: Some("Fine pistol (1), blade (1), throwing knives (1)...".to_string()),
+                },
+            ],
+            collapsible: true,
+            collapsed_default: true,
+            description: None,
+        }
+    }
+}
+
+/// Progress clock structure.
+#[derive(Debug, Clone)]
+pub struct ProgressClock {
+    pub name: String,
+    pub segments: u8,
+    pub filled: u8,
+}
+
+impl ProgressClock {
+    pub fn new(name: impl Into<String>, segments: u8) -> Self {
+        Self {
+            name: name.into(),
+            segments,
+            filled: 0,
+        }
+    }
+
+    pub fn tick(&mut self, amount: u8) {
+        self.filled = (self.filled + amount).min(self.segments);
+    }
+
+    pub fn is_complete(&self) -> bool {
+        self.filled >= self.segments
+    }
+
+    pub fn remaining(&self) -> u8 {
+        self.segments.saturating_sub(self.filled)
+    }
+}
+
+/// Playbook types in Blades.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Playbook {
+    Cutter,    // Fighter
+    Hound,     // Sharpshooter
+    Leech,     // Technician
+    Lurk,      // Infiltrator
+    Slide,     // Manipulator
+    Spider,    // Mastermind
+    Whisper,   // Channeler
+}
+
+impl Playbook {
+    pub fn starting_action(&self) -> (&'static str, u8) {
+        match self {
+            Playbook::Cutter => ("Skirmish", 2),
+            Playbook::Hound => ("Hunt", 2),
+            Playbook::Leech => ("Wreck", 2),
+            Playbook::Lurk => ("Prowl", 2),
+            Playbook::Slide => ("Sway", 2),
+            Playbook::Spider => ("Study", 2),
+            Playbook::Whisper => ("Attune", 2),
+        }
+    }
+
+    pub fn xp_trigger(&self) -> &'static str {
+        match self {
+            Playbook::Cutter => "Address challenges with violence or coercion",
+            Playbook::Hound => "Address challenges with tracking or violence",
+            Playbook::Leech => "Address challenges with technical skill or mayhem",
+            Playbook::Lurk => "Address challenges with stealth or evasion",
+            Playbook::Slide => "Address challenges with deception or influence",
+            Playbook::Spider => "Address challenges with calculation or conspiracy",
+            Playbook::Whisper => "Address challenges with knowledge or arcane power",
+        }
+    }
+}
+
+/// Crew types in Blades.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CrewType {
+    Assassins,
+    Bravos,
+    Cult,
+    Hawkers,
+    Shadows,
+    Smugglers,
+}
+
+impl CrewType {
+    pub fn hunting_grounds(&self) -> &'static str {
+        match self {
+            CrewType::Assassins => "Killings",
+            CrewType::Bravos => "Extortion, sabotage",
+            CrewType::Cult => "Occult operations",
+            CrewType::Hawkers => "Product sales",
+            CrewType::Shadows => "Burglary, espionage",
+            CrewType::Smugglers => "Smuggling routes",
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn outcome_from_dice() {
+        // Critical (multiple 6s)
+        assert_eq!(BladesOutcome::from_dice(&[6, 6, 3]), BladesOutcome::Critical);
+
+        // Success (single 6)
+        assert_eq!(BladesOutcome::from_dice(&[6, 3, 2]), BladesOutcome::Success);
+
+        // Partial (4-5)
+        assert_eq!(BladesOutcome::from_dice(&[5, 3, 2]), BladesOutcome::PartialSuccess);
+        assert_eq!(BladesOutcome::from_dice(&[4, 2, 1]), BladesOutcome::PartialSuccess);
+
+        // Failure (1-3)
+        assert_eq!(BladesOutcome::from_dice(&[3, 2, 1]), BladesOutcome::Failure);
+    }
+
+    #[test]
+    fn effect_level_clock_ticks() {
+        assert_eq!(EffectLevel::Zero.clock_ticks(), 0);
+        assert_eq!(EffectLevel::Limited.clock_ticks(), 1);
+        assert_eq!(EffectLevel::Standard.clock_ticks(), 2);
+        assert_eq!(EffectLevel::Great.clock_ticks(), 3);
+        assert_eq!(EffectLevel::Extreme.clock_ticks(), 4);
+    }
+
+    #[test]
+    fn effect_level_changes() {
+        assert_eq!(EffectLevel::Standard.increase(), EffectLevel::Great);
+        assert_eq!(EffectLevel::Standard.decrease(), EffectLevel::Limited);
+        assert_eq!(EffectLevel::Extreme.increase(), EffectLevel::Extreme);
+        assert_eq!(EffectLevel::Zero.decrease(), EffectLevel::Zero);
+    }
+
+    #[test]
+    fn attribute_ratings() {
+        assert_eq!(BladesSystem::insight_rating(1, 2, 1, 0), 4);
+        assert_eq!(BladesSystem::prowess_rating(2, 3, 1, 0), 6);
+        assert_eq!(BladesSystem::resolve_rating(1, 0, 1, 2), 4);
+    }
+
+    #[test]
+    fn resistance_roll_cost() {
+        assert_eq!(BladesSystem::resistance_roll_cost(0), 6);
+        assert_eq!(BladesSystem::resistance_roll_cost(1), 5);
+        assert_eq!(BladesSystem::resistance_roll_cost(3), 3);
+        assert_eq!(BladesSystem::resistance_roll_cost(6), 0);
+    }
+
+    #[test]
+    fn load_levels() {
+        assert_eq!(LoadLevel::Light.max_items(), 3);
+        assert_eq!(LoadLevel::Normal.max_items(), 5);
+        assert_eq!(LoadLevel::Heavy.max_items(), 6);
+        assert_eq!(LoadLevel::Heavy.prowess_penalty(), 1);
+    }
+
+    #[test]
+    fn progress_clock() {
+        let mut clock = ProgressClock::new("Pick Lock", 6);
+        assert_eq!(clock.remaining(), 6);
+
+        clock.tick(2);
+        assert_eq!(clock.filled, 2);
+        assert!(!clock.is_complete());
+
+        clock.tick(10); // Should cap at segments
+        assert_eq!(clock.filled, 6);
+        assert!(clock.is_complete());
+    }
+
+    #[test]
+    fn playbook_info() {
+        assert_eq!(Playbook::Lurk.starting_action(), ("Prowl", 2));
+        assert!(Playbook::Cutter
+            .xp_trigger()
+            .contains("violence or coercion"));
+    }
+
+    #[test]
+    fn system_identification() {
+        let system = BladesSystem::new();
+        assert_eq!(system.system_id(), "blades");
+        assert_eq!(system.display_name(), "Blades in the Dark");
+    }
+
+    #[test]
+    fn character_sheet_schema_structure() {
+        let system = BladesSystem::new();
+        let schema = system.character_sheet_schema();
+
+        assert_eq!(schema.system_id, "blades");
+        assert_eq!(schema.system_name, "Blades in the Dark");
+        assert_eq!(schema.sections.len(), 6);
+
+        // Verify section IDs
+        let section_ids: Vec<&str> = schema.sections.iter().map(|s| s.id.as_str()).collect();
+        assert!(section_ids.contains(&"identity"));
+        assert!(section_ids.contains(&"attributes_actions"));
+        assert!(section_ids.contains(&"harm"));
+        assert!(section_ids.contains(&"stress_trauma"));
+        assert!(section_ids.contains(&"load_armor"));
+        assert!(section_ids.contains(&"special_abilities"));
+
+        // Verify creation steps
+        assert_eq!(schema.creation_steps.len(), 4);
+    }
+
+    #[test]
+    fn character_sheet_playbook_options() {
+        let system = BladesSystem::new();
+        let schema = system.character_sheet_schema();
+
+        let identity = schema.sections.iter().find(|s| s.id == "identity").unwrap();
+        let playbook_field = identity.fields.iter().find(|f| f.id == "PLAYBOOK").unwrap();
+
+        if let SchemaFieldType::Select { options, .. } = &playbook_field.field_type {
+            assert_eq!(options.len(), 7);
+            let values: Vec<&str> = options.iter().map(|o| o.value.as_str()).collect();
+            assert!(values.contains(&"cutter"));
+            assert!(values.contains(&"hound"));
+            assert!(values.contains(&"leech"));
+            assert!(values.contains(&"lurk"));
+            assert!(values.contains(&"slide"));
+            assert!(values.contains(&"spider"));
+            assert!(values.contains(&"whisper"));
+        } else {
+            panic!("PLAYBOOK should be a Select field");
+        }
+    }
+
+    #[test]
+    fn character_sheet_action_fields() {
+        let system = BladesSystem::new();
+        let schema = system.character_sheet_schema();
+
+        let actions = schema
+            .sections
+            .iter()
+            .find(|s| s.id == "attributes_actions")
+            .unwrap();
+
+        // Check that all 12 actions are present
+        let action_ids = ["HUNT", "STUDY", "SURVEY", "TINKER", "FINESSE", "PROWL",
+            "SKIRMISH", "WRECK", "ATTUNE", "COMMAND", "CONSORT", "SWAY"];
+
+        for action in &action_ids {
+            let field = actions.fields.iter().find(|f| f.id == *action);
+            assert!(field.is_some(), "Action {} should exist", action);
+
+            if let Some(f) = field {
+                if let SchemaFieldType::DicePool { max_dice, die_type } = f.field_type {
+                    assert_eq!(max_dice, 4);
+                    assert_eq!(die_type, 6);
+                } else {
+                    panic!("{} should be a DicePool field", action);
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn character_sheet_trauma_conditions() {
+        let system = BladesSystem::new();
+        let schema = system.character_sheet_schema();
+
+        let stress_trauma = schema
+            .sections
+            .iter()
+            .find(|s| s.id == "stress_trauma")
+            .unwrap();
+
+        let trauma_ids = ["TRAUMA_COLD", "TRAUMA_HAUNTED", "TRAUMA_OBSESSED",
+            "TRAUMA_PARANOID", "TRAUMA_RECKLESS", "TRAUMA_SOFT",
+            "TRAUMA_UNSTABLE", "TRAUMA_VICIOUS"];
+
+        for trauma in &trauma_ids {
+            let field = stress_trauma.fields.iter().find(|f| f.id == *trauma);
+            assert!(field.is_some(), "Trauma {} should exist", trauma);
+
+            if let Some(f) = field {
+                assert!(matches!(f.field_type, SchemaFieldType::Boolean { .. }));
+            }
+        }
+    }
+
+    #[test]
+    fn calculate_derived_attribute_ratings() {
+        let system = BladesSystem::new();
+
+        let mut values = HashMap::new();
+        // Set some Insight actions
+        values.insert("HUNT".to_string(), serde_json::json!(2));
+        values.insert("STUDY".to_string(), serde_json::json!(1));
+        values.insert("SURVEY".to_string(), serde_json::json!(0));
+        values.insert("TINKER".to_string(), serde_json::json!(0));
+        // Set some Prowess actions
+        values.insert("FINESSE".to_string(), serde_json::json!(1));
+        values.insert("PROWL".to_string(), serde_json::json!(2));
+        values.insert("SKIRMISH".to_string(), serde_json::json!(1));
+        values.insert("WRECK".to_string(), serde_json::json!(0));
+        // Set some Resolve actions
+        values.insert("ATTUNE".to_string(), serde_json::json!(0));
+        values.insert("COMMAND".to_string(), serde_json::json!(1));
+        values.insert("CONSORT".to_string(), serde_json::json!(0));
+        values.insert("SWAY".to_string(), serde_json::json!(0));
+
+        let derived = system.calculate_derived_values(&values);
+
+        // Insight: 2 actions with dots (HUNT, STUDY)
+        assert_eq!(derived.get("INSIGHT").unwrap(), &serde_json::json!(2));
+        // Prowess: 3 actions with dots (FINESSE, PROWL, SKIRMISH)
+        assert_eq!(derived.get("PROWESS").unwrap(), &serde_json::json!(3));
+        // Resolve: 1 action with dots (COMMAND)
+        assert_eq!(derived.get("RESOLVE").unwrap(), &serde_json::json!(1));
+    }
+
+    #[test]
+    fn calculate_derived_trauma_count() {
+        let system = BladesSystem::new();
+
+        let mut values = HashMap::new();
+        values.insert("TRAUMA_COLD".to_string(), serde_json::json!(true));
+        values.insert("TRAUMA_HAUNTED".to_string(), serde_json::json!(false));
+        values.insert("TRAUMA_OBSESSED".to_string(), serde_json::json!(true));
+        values.insert("TRAUMA_PARANOID".to_string(), serde_json::json!(false));
+        values.insert("TRAUMA_RECKLESS".to_string(), serde_json::json!(false));
+        values.insert("TRAUMA_SOFT".to_string(), serde_json::json!(false));
+        values.insert("TRAUMA_UNSTABLE".to_string(), serde_json::json!(true));
+        values.insert("TRAUMA_VICIOUS".to_string(), serde_json::json!(false));
+
+        let derived = system.calculate_derived_values(&values);
+
+        assert_eq!(derived.get("TRAUMA_COUNT").unwrap(), &serde_json::json!(3));
+    }
+
+    #[test]
+    fn calculate_derived_xp_trigger() {
+        let system = BladesSystem::new();
+
+        let mut values = HashMap::new();
+        values.insert("PLAYBOOK".to_string(), serde_json::json!("lurk"));
+
+        let derived = system.calculate_derived_values(&values);
+
+        assert_eq!(
+            derived.get("XP_TRIGGER").unwrap(),
+            &serde_json::json!("Address challenges with stealth or evasion")
+        );
+    }
+
+    #[test]
+    fn calculate_derived_max_load() {
+        let system = BladesSystem::new();
+
+        let mut values = HashMap::new();
+        values.insert("LOAD_LEVEL".to_string(), serde_json::json!("heavy"));
+
+        let derived = system.calculate_derived_values(&values);
+
+        assert_eq!(derived.get("MAX_LOAD").unwrap(), &serde_json::json!(6));
+    }
+
+    #[test]
+    fn validate_action_rating() {
+        let system = BladesSystem::new();
+        let values = HashMap::new();
+
+        // Valid rating
+        assert!(system.validate_field("HUNT", &serde_json::json!(3), &values).is_none());
+
+        // Invalid rating (too high)
+        assert!(system.validate_field("HUNT", &serde_json::json!(5), &values).is_some());
+
+        // Invalid type
+        assert!(system.validate_field("HUNT", &serde_json::json!("two"), &values).is_some());
+    }
+
+    #[test]
+    fn validate_stress() {
+        let system = BladesSystem::new();
+        let values = HashMap::new();
+
+        // Valid stress
+        assert!(system.validate_field("STRESS", &serde_json::json!(5), &values).is_none());
+
+        // Invalid stress (too high)
+        assert!(system.validate_field("STRESS", &serde_json::json!(10), &values).is_some());
+    }
+
+    #[test]
+    fn validate_trauma_limit() {
+        let system = BladesSystem::new();
+
+        let mut values = HashMap::new();
+        values.insert("TRAUMA_COLD".to_string(), serde_json::json!(true));
+        values.insert("TRAUMA_HAUNTED".to_string(), serde_json::json!(true));
+        values.insert("TRAUMA_OBSESSED".to_string(), serde_json::json!(true));
+        values.insert("TRAUMA_PARANOID".to_string(), serde_json::json!(true));
+
+        // Adding a 5th trauma should fail
+        let result = system.validate_field("TRAUMA_RECKLESS", &serde_json::json!(true), &values);
+        assert!(result.is_some());
+        assert!(result.unwrap().contains("Maximum 4 traumas"));
+    }
+
+    #[test]
+    fn default_values() {
+        let system = BladesSystem::new();
+        let defaults = system.default_values();
+
+        // Actions default to 0
+        assert_eq!(defaults.get("HUNT").unwrap(), &serde_json::json!(0));
+        assert_eq!(defaults.get("SWAY").unwrap(), &serde_json::json!(0));
+
+        // Stress defaults to 0
+        assert_eq!(defaults.get("STRESS").unwrap(), &serde_json::json!(0));
+
+        // Traumas default to false
+        assert_eq!(defaults.get("TRAUMA_COLD").unwrap(), &serde_json::json!(false));
+
+        // Load defaults to normal
+        assert_eq!(defaults.get("LOAD_LEVEL").unwrap(), &serde_json::json!("normal"));
+
+        // Armor defaults to false
+        assert_eq!(defaults.get("ARMOR_STANDARD").unwrap(), &serde_json::json!(false));
+    }
+}

--- a/crates/domain/src/game_systems/blades.rs
+++ b/crates/domain/src/game_systems/blades.rs
@@ -372,6 +372,7 @@ impl CharacterSheetProvider for BladesSystem {
                 self.stress_trauma_section(),
                 self.load_armor_section(),
                 self.special_abilities_section(),
+                self.modifiers_section(),
             ],
             creation_steps: vec![
                 CreationStep {
@@ -1561,6 +1562,36 @@ impl BladesSystem {
             collapsible: true,
             collapsed_default: true,
             description: None,
+        }
+    }
+
+    fn modifiers_section(&self) -> SchemaSection {
+        SchemaSection {
+            id: "modifiers".to_string(),
+            label: "Active Effects".to_string(),
+            section_type: SectionType::Modifiers,
+            fields: vec![
+                FieldDefinition {
+                    id: "ACTIVE_MODIFIERS".to_string(),
+                    label: "Conditions & Effects".to_string(),
+                    field_type: SchemaFieldType::ModifierList { filter_stat: None },
+                    editable: false,
+                    required: false,
+                    derived_from: None,
+                    validation: None,
+                    layout: FieldLayout {
+                        width: Some(12),
+                        ..Default::default()
+                    },
+                    description: Some(
+                        "Active effects modifying your rolls (Harm penalties, Devil's Bargains, etc.)".to_string(),
+                    ),
+                    placeholder: None,
+                },
+            ],
+            collapsible: true,
+            collapsed_default: false,
+            description: Some("Harm penalties: Level 1 = narrative only, Level 2 = -1d to related actions, Level 3 = -1d stacking and need help to act.".to_string()),
         }
     }
 }

--- a/crates/domain/src/game_systems/coc7e.rs
+++ b/crates/domain/src/game_systems/coc7e.rs
@@ -1,0 +1,1805 @@
+//! Call of Cthulhu 7th Edition game system implementation.
+//!
+//! CoC 7e uses a percentile (d100) roll-under system.
+//! Key features:
+//! - Eight characteristics (STR, CON, SIZ, DEX, APP, INT, POW, EDU)
+//! - Skills as percentile values
+//! - Three success tiers: Regular, Hard (half), Extreme (fifth)
+//! - Sanity system
+//! - Luck as a spendable resource
+
+use super::traits::{
+    CalculationEngine, CharacterSheetProvider, CharacterSheetSchema, CreationStep, DerivationType,
+    DerivedField, FieldDefinition, FieldLayout, FieldValidation, GameSystem, ProficiencyLevel,
+    ResourceColor, SchemaFieldType, SchemaSection, SchemaSelectOption, SectionType,
+};
+use crate::entities::{StatBlock, StatModifier};
+use std::collections::HashMap;
+
+/// Success levels for CoC 7e skill checks.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum SuccessLevel {
+    /// Roll of 01 - always succeeds, exceptional outcome
+    Critical,
+    /// Roll <= skill / 5
+    Extreme,
+    /// Roll <= skill / 2
+    Hard,
+    /// Roll <= skill
+    Regular,
+    /// Roll > skill but not a fumble
+    Failure,
+    /// 96-100 if skill < 50, or 100 if skill >= 50
+    Fumble,
+}
+
+impl SuccessLevel {
+    /// Check if this is any form of success.
+    pub fn is_success(&self) -> bool {
+        matches!(
+            self,
+            SuccessLevel::Critical
+                | SuccessLevel::Extreme
+                | SuccessLevel::Hard
+                | SuccessLevel::Regular
+        )
+    }
+}
+
+/// Determine success level for a CoC 7e roll.
+pub fn check_success(roll: u8, skill: u8) -> SuccessLevel {
+    // Critical: roll of 01
+    if roll == 1 {
+        return SuccessLevel::Critical;
+    }
+
+    // Fumble check
+    if is_fumble(roll, skill) {
+        return SuccessLevel::Fumble;
+    }
+
+    // Calculate thresholds
+    let hard = skill / 2;
+    let extreme = skill / 5;
+
+    if roll <= extreme {
+        SuccessLevel::Extreme
+    } else if roll <= hard {
+        SuccessLevel::Hard
+    } else if roll <= skill {
+        SuccessLevel::Regular
+    } else {
+        SuccessLevel::Failure
+    }
+}
+
+/// Check if a roll is a fumble.
+pub fn is_fumble(roll: u8, skill: u8) -> bool {
+    if skill < 50 {
+        roll >= 96
+    } else {
+        roll == 100
+    }
+}
+
+/// Check if a roll is a critical (01).
+pub fn is_critical(roll: u8) -> bool {
+    roll == 1
+}
+
+/// Sanity check result.
+#[derive(Debug, Clone)]
+pub struct SanityCheckResult {
+    pub passed: bool,
+    pub loss: u8,
+    pub bout_of_madness: bool,
+}
+
+/// Perform a sanity check.
+///
+/// # Arguments
+/// * `roll` - The d100 roll
+/// * `current_sanity` - Current sanity value
+/// * `pass_loss` - Sanity lost on success (e.g., "0" or "1d3")
+/// * `fail_loss` - Sanity lost on failure (e.g., "1d6")
+/// * `actual_loss` - The actual loss after rolling (pre-computed)
+pub fn sanity_check(roll: u8, current_sanity: u8, actual_loss: u8) -> SanityCheckResult {
+    let passed = roll <= current_sanity;
+    let bout_of_madness = actual_loss >= 5;
+
+    SanityCheckResult {
+        passed,
+        loss: actual_loss,
+        bout_of_madness,
+    }
+}
+
+/// Call of Cthulhu 7th Edition game system.
+pub struct Coc7eSystem {
+    stat_names: Vec<&'static str>,
+    skill_names: Vec<&'static str>,
+}
+
+impl Coc7eSystem {
+    pub fn new() -> Self {
+        Self {
+            stat_names: vec!["STR", "CON", "SIZ", "DEX", "APP", "INT", "POW", "EDU"],
+            skill_names: vec![
+                // Combat
+                "Dodge",
+                "Fighting (Brawl)",
+                "Firearms (Handgun)",
+                "Firearms (Rifle/Shotgun)",
+                "Throw",
+                // Investigation
+                "Appraise",
+                "Library Use",
+                "Listen",
+                "Spot Hidden",
+                "Track",
+                // Social
+                "Charm",
+                "Fast Talk",
+                "Intimidate",
+                "Persuade",
+                "Psychology",
+                // Knowledge
+                "Accounting",
+                "Anthropology",
+                "Archaeology",
+                "Art/Craft",
+                "Cthulhu Mythos",
+                "History",
+                "Language (Other)",
+                "Language (Own)",
+                "Law",
+                "Medicine",
+                "Natural World",
+                "Navigate",
+                "Occult",
+                "Science",
+                // Practical
+                "Climb",
+                "Drive Auto",
+                "Electrical Repair",
+                "First Aid",
+                "Jump",
+                "Locksmith",
+                "Mechanical Repair",
+                "Operate Heavy Machinery",
+                "Pilot",
+                "Ride",
+                "Sleight of Hand",
+                "Stealth",
+                "Survival",
+                "Swim",
+            ],
+        }
+    }
+
+    /// Calculate derived HP from CON and SIZ.
+    pub fn calculate_hp(con: u8, siz: u8) -> u8 {
+        (con as u16 + siz as u16) as u8 / 10
+    }
+
+    /// Calculate starting sanity from POW.
+    pub fn calculate_starting_sanity(pow: u8) -> u8 {
+        pow
+    }
+
+    /// Calculate magic points from POW.
+    pub fn calculate_magic_points(pow: u8) -> u8 {
+        pow / 5
+    }
+
+    /// Calculate move rate from STR, DEX, SIZ.
+    pub fn calculate_move_rate(str_val: u8, dex: u8, siz: u8) -> u8 {
+        if dex < siz && str_val < siz {
+            7
+        } else if str_val > siz && dex > siz {
+            9
+        } else {
+            8
+        }
+    }
+
+    /// Calculate damage bonus from STR + SIZ.
+    pub fn calculate_damage_bonus(str_val: u8, siz: u8) -> &'static str {
+        let total = str_val as u16 + siz as u16;
+        match total {
+            2..=64 => "-2",
+            65..=84 => "-1",
+            85..=124 => "None",
+            125..=164 => "+1d4",
+            165..=204 => "+1d6",
+            205..=284 => "+2d6",
+            285..=364 => "+3d6",
+            _ => "+4d6",
+        }
+    }
+
+    /// Calculate build from STR + SIZ.
+    pub fn calculate_build(str_val: u8, siz: u8) -> i8 {
+        let total = str_val as u16 + siz as u16;
+        match total {
+            2..=64 => -2,
+            65..=84 => -1,
+            85..=124 => 0,
+            125..=164 => 1,
+            165..=204 => 2,
+            205..=284 => 3,
+            285..=364 => 4,
+            _ => 5,
+        }
+    }
+}
+
+impl Default for Coc7eSystem {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl GameSystem for Coc7eSystem {
+    fn system_id(&self) -> &str {
+        "coc7e"
+    }
+
+    fn display_name(&self) -> &str {
+        "Call of Cthulhu 7th Edition"
+    }
+
+    fn calculation_engine(&self) -> &dyn CalculationEngine {
+        self
+    }
+
+    fn stat_names(&self) -> &[&str] {
+        &self.stat_names
+    }
+
+    fn skill_names(&self) -> &[&str] {
+        &self.skill_names
+    }
+}
+
+impl CalculationEngine for Coc7eSystem {
+    fn ability_modifier(&self, score: i32) -> i32 {
+        // CoC doesn't use modifiers like D&D - skills are percentile
+        // Return the score itself as the "modifier" (the percentage chance)
+        score
+    }
+
+    fn proficiency_bonus(&self, _level: u8) -> i32 {
+        // CoC has no proficiency bonus system
+        0
+    }
+
+    fn spell_save_dc(&self, stats: &StatBlock, _casting_stat: &str) -> i32 {
+        // CoC uses POW for magic resistance
+        // Spells are resisted on resistance table
+        stats.get_stat("POW").unwrap_or(50)
+    }
+
+    fn spell_attack_bonus(&self, stats: &StatBlock, _casting_stat: &str) -> i32 {
+        // CoC magic uses POW vs target's POW on resistance table
+        stats.get_stat("POW").unwrap_or(50)
+    }
+
+    fn attack_bonus(&self, stats: &StatBlock, _attack_stat: &str, _proficient: bool) -> i32 {
+        // CoC uses skill percentages directly
+        // Return the Fighting skill or Firearms skill
+        stats.get_stat("Fighting (Brawl)").unwrap_or(25)
+    }
+
+    fn stack_modifiers(&self, modifiers: &[StatModifier]) -> i32 {
+        // CoC modifiers typically stack (they're flat bonuses/penalties)
+        modifiers.iter().filter(|m| m.active).map(|m| m.value).sum()
+    }
+
+    fn calculate_ac(
+        &self,
+        _stats: &StatBlock,
+        _armor_ac: Option<i32>,
+        _shield_bonus: Option<i32>,
+        _allows_dex: bool,
+        _max_dex_bonus: Option<i32>,
+    ) -> i32 {
+        // CoC doesn't have AC - combat uses opposed rolls
+        // Return 0 as a placeholder
+        0
+    }
+
+    fn skill_modifier(
+        &self,
+        stats: &StatBlock,
+        skill: &str,
+        _proficiency_level: ProficiencyLevel,
+    ) -> i32 {
+        // In CoC, skill values ARE the percentile chance
+        // Return the skill value directly
+        stats.get_stat(skill).unwrap_or_else(|| {
+            // Return default base values for skills
+            get_skill_base(skill)
+        })
+    }
+
+    fn saving_throw_modifier(&self, stats: &StatBlock, ability: &str, _proficient: bool) -> i32 {
+        // CoC uses characteristic rolls directly
+        stats.get_stat(ability).unwrap_or(50)
+    }
+
+    fn passive_perception(&self, stats: &StatBlock, _proficiency_level: ProficiencyLevel) -> i32 {
+        // CoC uses Spot Hidden skill
+        stats.get_stat("Spot Hidden").unwrap_or(25)
+    }
+
+    fn hit_die(&self, _class_name: &str) -> u8 {
+        // CoC doesn't use hit dice - HP is derived from CON + SIZ
+        0
+    }
+
+    fn calculate_max_hp(
+        &self,
+        _level: u8,
+        _class_name: &str,
+        _constitution_modifier: i32,
+        _additional_hp: i32,
+    ) -> i32 {
+        // HP should be calculated using calculate_hp(con, siz)
+        // This method signature doesn't fit CoC well
+        // Return a placeholder
+        12
+    }
+}
+
+impl CharacterSheetProvider for Coc7eSystem {
+    fn character_sheet_schema(&self) -> CharacterSheetSchema {
+        CharacterSheetSchema {
+            system_id: "coc7e".to_string(),
+            system_name: "Call of Cthulhu 7th Edition".to_string(),
+            sections: vec![
+                self.identity_section(),
+                self.characteristics_section(),
+                self.derived_attributes_section(),
+                self.skills_section(),
+                self.combat_section(),
+                self.resources_section(),
+            ],
+            creation_steps: vec![
+                CreationStep {
+                    id: "identity".to_string(),
+                    label: "Investigator Info".to_string(),
+                    description: "Define your investigator's basic information.".to_string(),
+                    section_ids: vec!["identity".to_string()],
+                    order: 1,
+                    required: true,
+                },
+                CreationStep {
+                    id: "characteristics".to_string(),
+                    label: "Characteristics".to_string(),
+                    description: "Roll or assign your eight characteristics (3d6*5 or 2d6+6*5)."
+                        .to_string(),
+                    section_ids: vec!["characteristics".to_string()],
+                    order: 2,
+                    required: true,
+                },
+                CreationStep {
+                    id: "derived".to_string(),
+                    label: "Derived Attributes".to_string(),
+                    description: "Calculate derived values from characteristics.".to_string(),
+                    section_ids: vec!["derived_attributes".to_string()],
+                    order: 3,
+                    required: true,
+                },
+                CreationStep {
+                    id: "skills".to_string(),
+                    label: "Skills".to_string(),
+                    description: "Allocate occupation and personal interest skill points."
+                        .to_string(),
+                    section_ids: vec!["skills".to_string(), "combat".to_string()],
+                    order: 4,
+                    required: true,
+                },
+            ],
+        }
+    }
+
+    fn calculate_derived_values(
+        &self,
+        values: &HashMap<String, serde_json::Value>,
+    ) -> HashMap<String, serde_json::Value> {
+        let mut derived = HashMap::new();
+
+        // Get characteristics
+        let str_val = values.get("STR").and_then(|v| v.as_i64()).unwrap_or(50) as u8;
+        let con = values.get("CON").and_then(|v| v.as_i64()).unwrap_or(50) as u8;
+        let siz = values.get("SIZ").and_then(|v| v.as_i64()).unwrap_or(50) as u8;
+        let dex = values.get("DEX").and_then(|v| v.as_i64()).unwrap_or(50) as u8;
+        let pow = values.get("POW").and_then(|v| v.as_i64()).unwrap_or(50) as u8;
+        let edu = values.get("EDU").and_then(|v| v.as_i64()).unwrap_or(50) as u8;
+
+        // Calculate HP = (CON + SIZ) / 10
+        let max_hp = Self::calculate_hp(con, siz);
+        derived.insert("MAX_HP".to_string(), serde_json::json!(max_hp));
+
+        // Calculate Sanity = POW (starting value)
+        let max_sanity = Self::calculate_starting_sanity(pow);
+        derived.insert("MAX_SANITY".to_string(), serde_json::json!(max_sanity));
+
+        // Calculate Magic Points = POW / 5
+        let max_mp = Self::calculate_magic_points(pow);
+        derived.insert("MAX_MP".to_string(), serde_json::json!(max_mp));
+
+        // Calculate Move Rate
+        let move_rate = Self::calculate_move_rate(str_val, dex, siz);
+        derived.insert("MOVE".to_string(), serde_json::json!(move_rate));
+
+        // Calculate Build
+        let build = Self::calculate_build(str_val, siz);
+        derived.insert("BUILD".to_string(), serde_json::json!(build));
+
+        // Calculate Damage Bonus
+        let damage_bonus = Self::calculate_damage_bonus(str_val, siz);
+        derived.insert("DAMAGE_BONUS".to_string(), serde_json::json!(damage_bonus));
+
+        // Calculate half and fifth values for characteristics
+        for (id, val) in [
+            ("STR", str_val),
+            ("CON", con),
+            ("SIZ", siz),
+            ("DEX", dex),
+            ("POW", pow),
+            ("EDU", edu),
+        ] {
+            derived.insert(format!("{}_HALF", id), serde_json::json!(val / 2));
+            derived.insert(format!("{}_FIFTH", id), serde_json::json!(val / 5));
+        }
+
+        // Also calculate APP and INT halves/fifths
+        let app = values.get("APP").and_then(|v| v.as_i64()).unwrap_or(50) as u8;
+        let int = values.get("INT").and_then(|v| v.as_i64()).unwrap_or(50) as u8;
+
+        derived.insert("APP_HALF".to_string(), serde_json::json!(app / 2));
+        derived.insert("APP_FIFTH".to_string(), serde_json::json!(app / 5));
+        derived.insert("INT_HALF".to_string(), serde_json::json!(int / 2));
+        derived.insert("INT_FIFTH".to_string(), serde_json::json!(int / 5));
+
+        // Calculate Dodge base value (DEX / 2)
+        let dodge_base = dex / 2;
+        derived.insert("DODGE_BASE".to_string(), serde_json::json!(dodge_base));
+
+        // Calculate Language (Own) base value (EDU)
+        derived.insert("LANGUAGE_OWN_BASE".to_string(), serde_json::json!(edu));
+
+        // Calculate half/fifth values for skills that have values set
+        let skill_ids = self.get_all_skill_ids();
+        for skill_id in skill_ids {
+            if let Some(val) = values.get(&skill_id).and_then(|v| v.as_i64()) {
+                let val = val as u8;
+                derived.insert(format!("{}_HALF", skill_id), serde_json::json!(val / 2));
+                derived.insert(format!("{}_FIFTH", skill_id), serde_json::json!(val / 5));
+            }
+        }
+
+        derived
+    }
+
+    fn validate_field(
+        &self,
+        field_id: &str,
+        value: &serde_json::Value,
+        _all_values: &HashMap<String, serde_json::Value>,
+    ) -> Option<String> {
+        match field_id {
+            // Characteristics: 0-99 percentile
+            "STR" | "CON" | "SIZ" | "DEX" | "APP" | "INT" | "POW" | "EDU" => {
+                if let Some(score) = value.as_i64() {
+                    if score < 0 || score > 99 {
+                        return Some("Characteristics must be between 0 and 99".to_string());
+                    }
+                } else {
+                    return Some("Characteristic must be a number".to_string());
+                }
+            }
+            // Skills: 0-99 percentile (except Cthulhu Mythos which is special)
+            _ if field_id.ends_with("_SKILL") || self.is_skill_field(field_id) => {
+                if let Some(score) = value.as_i64() {
+                    if score < 0 || score > 99 {
+                        return Some("Skills must be between 0 and 99".to_string());
+                    }
+                } else {
+                    return Some("Skill value must be a number".to_string());
+                }
+            }
+            // Luck: 0-99
+            "LUCK" | "CURRENT_LUCK" => {
+                if let Some(luck) = value.as_i64() {
+                    if luck < 0 || luck > 99 {
+                        return Some("Luck must be between 0 and 99".to_string());
+                    }
+                } else {
+                    return Some("Luck must be a number".to_string());
+                }
+            }
+            // Sanity: 0-99
+            "CURRENT_SANITY" => {
+                if let Some(san) = value.as_i64() {
+                    if san < 0 || san > 99 {
+                        return Some("Sanity must be between 0 and 99".to_string());
+                    }
+                } else {
+                    return Some("Sanity must be a number".to_string());
+                }
+            }
+            // Age: reasonable range
+            "AGE" => {
+                if let Some(age) = value.as_i64() {
+                    if age < 15 || age > 90 {
+                        return Some("Age must be between 15 and 90".to_string());
+                    }
+                } else {
+                    return Some("Age must be a number".to_string());
+                }
+            }
+            "NAME" => {
+                if let Some(name) = value.as_str() {
+                    if name.is_empty() {
+                        return Some("Name is required".to_string());
+                    }
+                } else {
+                    return Some("Name must be a string".to_string());
+                }
+            }
+            _ => {}
+        }
+        None
+    }
+
+    fn default_values(&self) -> HashMap<String, serde_json::Value> {
+        let mut defaults = HashMap::new();
+
+        // Default characteristics (average human)
+        defaults.insert("STR".to_string(), serde_json::json!(50));
+        defaults.insert("CON".to_string(), serde_json::json!(50));
+        defaults.insert("SIZ".to_string(), serde_json::json!(50));
+        defaults.insert("DEX".to_string(), serde_json::json!(50));
+        defaults.insert("APP".to_string(), serde_json::json!(50));
+        defaults.insert("INT".to_string(), serde_json::json!(50));
+        defaults.insert("POW".to_string(), serde_json::json!(50));
+        defaults.insert("EDU".to_string(), serde_json::json!(50));
+
+        // Luck starts at 3d6*5 average (52-53)
+        defaults.insert("LUCK".to_string(), serde_json::json!(50));
+        defaults.insert("CURRENT_LUCK".to_string(), serde_json::json!(50));
+
+        // Current resources start at max
+        defaults.insert("CURRENT_HP".to_string(), serde_json::json!(10));
+        defaults.insert("CURRENT_SANITY".to_string(), serde_json::json!(50));
+        defaults.insert("CURRENT_MP".to_string(), serde_json::json!(10));
+
+        // Default skill values (base values)
+        defaults.insert("DODGE".to_string(), serde_json::json!(25)); // DEX/2 base
+        defaults.insert("FIGHTING_BRAWL".to_string(), serde_json::json!(25));
+        defaults.insert("FIREARMS_HANDGUN".to_string(), serde_json::json!(20));
+        defaults.insert("FIREARMS_RIFLE".to_string(), serde_json::json!(25));
+        defaults.insert("FIRST_AID".to_string(), serde_json::json!(30));
+        defaults.insert("LIBRARY_USE".to_string(), serde_json::json!(20));
+        defaults.insert("LISTEN".to_string(), serde_json::json!(20));
+        defaults.insert("SPOT_HIDDEN".to_string(), serde_json::json!(25));
+        defaults.insert("STEALTH".to_string(), serde_json::json!(20));
+        defaults.insert("PSYCHOLOGY".to_string(), serde_json::json!(10));
+        defaults.insert("PERSUADE".to_string(), serde_json::json!(10));
+        defaults.insert("FAST_TALK".to_string(), serde_json::json!(5));
+        defaults.insert("CHARM".to_string(), serde_json::json!(15));
+        defaults.insert("INTIMIDATE".to_string(), serde_json::json!(15));
+        defaults.insert("CREDIT_RATING".to_string(), serde_json::json!(0));
+        defaults.insert("CTHULHU_MYTHOS".to_string(), serde_json::json!(0));
+        defaults.insert("OCCULT".to_string(), serde_json::json!(5));
+
+        defaults
+    }
+}
+
+// Helper methods for building the schema
+impl Coc7eSystem {
+    fn identity_section(&self) -> SchemaSection {
+        SchemaSection {
+            id: "identity".to_string(),
+            label: "Investigator Identity".to_string(),
+            section_type: SectionType::Identity,
+            fields: vec![
+                FieldDefinition {
+                    id: "NAME".to_string(),
+                    label: "Name".to_string(),
+                    field_type: SchemaFieldType::Text {
+                        multiline: false,
+                        max_length: Some(100),
+                    },
+                    editable: true,
+                    required: true,
+                    derived_from: None,
+                    validation: None,
+                    layout: FieldLayout {
+                        width: Some(6),
+                        ..Default::default()
+                    },
+                    description: None,
+                    placeholder: Some("Enter investigator name".to_string()),
+                },
+                FieldDefinition {
+                    id: "OCCUPATION".to_string(),
+                    label: "Occupation".to_string(),
+                    field_type: SchemaFieldType::Select {
+                        options: vec![
+                            SchemaSelectOption {
+                                value: "antiquarian".to_string(),
+                                label: "Antiquarian".to_string(),
+                                description: Some("Collector and dealer of antiques".to_string()),
+                            },
+                            SchemaSelectOption {
+                                value: "author".to_string(),
+                                label: "Author".to_string(),
+                                description: Some("Writer of fiction or non-fiction".to_string()),
+                            },
+                            SchemaSelectOption {
+                                value: "detective".to_string(),
+                                label: "Private Detective".to_string(),
+                                description: Some("Private investigator for hire".to_string()),
+                            },
+                            SchemaSelectOption {
+                                value: "dilettante".to_string(),
+                                label: "Dilettante".to_string(),
+                                description: Some(
+                                    "Wealthy amateur with varied interests".to_string(),
+                                ),
+                            },
+                            SchemaSelectOption {
+                                value: "doctor".to_string(),
+                                label: "Doctor of Medicine".to_string(),
+                                description: Some("Licensed physician".to_string()),
+                            },
+                            SchemaSelectOption {
+                                value: "journalist".to_string(),
+                                label: "Journalist".to_string(),
+                                description: Some("Reporter or editor for news media".to_string()),
+                            },
+                            SchemaSelectOption {
+                                value: "lawyer".to_string(),
+                                label: "Lawyer".to_string(),
+                                description: Some("Attorney or legal counsel".to_string()),
+                            },
+                            SchemaSelectOption {
+                                value: "librarian".to_string(),
+                                label: "Librarian".to_string(),
+                                description: Some("Keeper of books and knowledge".to_string()),
+                            },
+                            SchemaSelectOption {
+                                value: "parapsychologist".to_string(),
+                                label: "Parapsychologist".to_string(),
+                                description: Some("Researcher of paranormal phenomena".to_string()),
+                            },
+                            SchemaSelectOption {
+                                value: "police_detective".to_string(),
+                                label: "Police Detective".to_string(),
+                                description: Some(
+                                    "Official law enforcement investigator".to_string(),
+                                ),
+                            },
+                            SchemaSelectOption {
+                                value: "professor".to_string(),
+                                label: "Professor".to_string(),
+                                description: Some("Academic expert and teacher".to_string()),
+                            },
+                            SchemaSelectOption {
+                                value: "soldier".to_string(),
+                                label: "Soldier".to_string(),
+                                description: Some("Military personnel".to_string()),
+                            },
+                        ],
+                        allow_custom: true,
+                    },
+                    editable: true,
+                    required: true,
+                    derived_from: None,
+                    validation: None,
+                    layout: FieldLayout {
+                        width: Some(6),
+                        ..Default::default()
+                    },
+                    description: Some(
+                        "Determines skill points and Credit Rating range".to_string(),
+                    ),
+                    placeholder: None,
+                },
+                FieldDefinition {
+                    id: "AGE".to_string(),
+                    label: "Age".to_string(),
+                    field_type: SchemaFieldType::Integer {
+                        min: Some(15),
+                        max: Some(90),
+                        show_modifier: false,
+                    },
+                    editable: true,
+                    required: true,
+                    derived_from: None,
+                    validation: Some(FieldValidation {
+                        min: Some(15),
+                        max: Some(90),
+                        pattern: None,
+                        error_message: Some("Age must be between 15 and 90".to_string()),
+                    }),
+                    layout: FieldLayout {
+                        width: Some(2),
+                        new_row: true,
+                        ..Default::default()
+                    },
+                    description: Some("Age affects EDU and physical characteristics".to_string()),
+                    placeholder: None,
+                },
+                FieldDefinition {
+                    id: "RESIDENCE".to_string(),
+                    label: "Residence".to_string(),
+                    field_type: SchemaFieldType::Text {
+                        multiline: false,
+                        max_length: Some(100),
+                    },
+                    editable: true,
+                    required: false,
+                    derived_from: None,
+                    validation: None,
+                    layout: FieldLayout {
+                        width: Some(5),
+                        ..Default::default()
+                    },
+                    description: None,
+                    placeholder: Some("Where the investigator lives".to_string()),
+                },
+                FieldDefinition {
+                    id: "BIRTHPLACE".to_string(),
+                    label: "Birthplace".to_string(),
+                    field_type: SchemaFieldType::Text {
+                        multiline: false,
+                        max_length: Some(100),
+                    },
+                    editable: true,
+                    required: false,
+                    derived_from: None,
+                    validation: None,
+                    layout: FieldLayout {
+                        width: Some(5),
+                        ..Default::default()
+                    },
+                    description: None,
+                    placeholder: Some("Where the investigator was born".to_string()),
+                },
+            ],
+            collapsible: false,
+            collapsed_default: false,
+            description: None,
+        }
+    }
+
+    fn characteristics_section(&self) -> SchemaSection {
+        let characteristics = [
+            ("STR", "Strength", "Physical power (3d6*5)"),
+            ("CON", "Constitution", "Health and resilience (3d6*5)"),
+            ("SIZ", "Size", "Physical mass (2d6+6*5)"),
+            ("DEX", "Dexterity", "Agility and coordination (3d6*5)"),
+            ("APP", "Appearance", "Physical attractiveness (3d6*5)"),
+            ("INT", "Intelligence", "Learning and reasoning (2d6+6*5)"),
+            ("POW", "Power", "Willpower and magical potential (3d6*5)"),
+            ("EDU", "Education", "Formal and life knowledge (2d6+6*5)"),
+        ];
+
+        let fields: Vec<FieldDefinition> = characteristics
+            .iter()
+            .map(|(id, label, description)| FieldDefinition {
+                id: id.to_string(),
+                label: label.to_string(),
+                field_type: SchemaFieldType::PercentileSkill { show_derived: true },
+                editable: true,
+                required: true,
+                derived_from: None,
+                validation: Some(FieldValidation {
+                    min: Some(0),
+                    max: Some(99),
+                    pattern: None,
+                    error_message: Some("Characteristics must be 0-99".to_string()),
+                }),
+                layout: FieldLayout {
+                    width: Some(3),
+                    ..Default::default()
+                },
+                description: Some(description.to_string()),
+                placeholder: None,
+            })
+            .collect();
+
+        SchemaSection {
+            id: "characteristics".to_string(),
+            label: "Characteristics".to_string(),
+            section_type: SectionType::AbilityScores,
+            fields,
+            collapsible: false,
+            collapsed_default: false,
+            description: Some(
+                "Eight core characteristics as percentile values. Shows Regular/Half/Fifth."
+                    .to_string(),
+            ),
+        }
+    }
+
+    fn derived_attributes_section(&self) -> SchemaSection {
+        SchemaSection {
+            id: "derived_attributes".to_string(),
+            label: "Derived Attributes".to_string(),
+            section_type: SectionType::Combat,
+            fields: vec![
+                FieldDefinition {
+                    id: "MAX_HP".to_string(),
+                    label: "Hit Points".to_string(),
+                    field_type: SchemaFieldType::Integer {
+                        min: Some(1),
+                        max: None,
+                        show_modifier: false,
+                    },
+                    editable: false,
+                    required: false,
+                    derived_from: Some(DerivedField {
+                        derivation_type: DerivationType::Custom,
+                        dependencies: vec!["CON".to_string(), "SIZ".to_string()],
+                        display_format: None,
+                    }),
+                    validation: None,
+                    layout: FieldLayout {
+                        width: Some(2),
+                        ..Default::default()
+                    },
+                    description: Some("(CON + SIZ) / 10".to_string()),
+                    placeholder: None,
+                },
+                FieldDefinition {
+                    id: "MAX_SANITY".to_string(),
+                    label: "Sanity".to_string(),
+                    field_type: SchemaFieldType::Integer {
+                        min: Some(0),
+                        max: Some(99),
+                        show_modifier: false,
+                    },
+                    editable: false,
+                    required: false,
+                    derived_from: Some(DerivedField {
+                        derivation_type: DerivationType::Custom,
+                        dependencies: vec!["POW".to_string()],
+                        display_format: None,
+                    }),
+                    validation: None,
+                    layout: FieldLayout {
+                        width: Some(2),
+                        ..Default::default()
+                    },
+                    description: Some("Starting value equals POW".to_string()),
+                    placeholder: None,
+                },
+                FieldDefinition {
+                    id: "MAX_MP".to_string(),
+                    label: "Magic Points".to_string(),
+                    field_type: SchemaFieldType::Integer {
+                        min: Some(0),
+                        max: None,
+                        show_modifier: false,
+                    },
+                    editable: false,
+                    required: false,
+                    derived_from: Some(DerivedField {
+                        derivation_type: DerivationType::Fifth,
+                        dependencies: vec!["POW".to_string()],
+                        display_format: None,
+                    }),
+                    validation: None,
+                    layout: FieldLayout {
+                        width: Some(2),
+                        ..Default::default()
+                    },
+                    description: Some("POW / 5".to_string()),
+                    placeholder: None,
+                },
+                FieldDefinition {
+                    id: "LUCK".to_string(),
+                    label: "Luck".to_string(),
+                    field_type: SchemaFieldType::Integer {
+                        min: Some(0),
+                        max: Some(99),
+                        show_modifier: false,
+                    },
+                    editable: true,
+                    required: true,
+                    derived_from: None,
+                    validation: Some(FieldValidation {
+                        min: Some(0),
+                        max: Some(99),
+                        pattern: None,
+                        error_message: Some("Luck must be 0-99".to_string()),
+                    }),
+                    layout: FieldLayout {
+                        width: Some(2),
+                        ..Default::default()
+                    },
+                    description: Some("Roll 3d6*5. Expendable resource.".to_string()),
+                    placeholder: None,
+                },
+                FieldDefinition {
+                    id: "MOVE".to_string(),
+                    label: "Move Rate".to_string(),
+                    field_type: SchemaFieldType::Integer {
+                        min: Some(0),
+                        max: None,
+                        show_modifier: false,
+                    },
+                    editable: false,
+                    required: false,
+                    derived_from: Some(DerivedField {
+                        derivation_type: DerivationType::Custom,
+                        dependencies: vec!["STR".to_string(), "DEX".to_string(), "SIZ".to_string()],
+                        display_format: None,
+                    }),
+                    validation: None,
+                    layout: FieldLayout {
+                        width: Some(2),
+                        new_row: true,
+                        ..Default::default()
+                    },
+                    description: Some("Based on STR, DEX, SIZ comparison".to_string()),
+                    placeholder: None,
+                },
+                FieldDefinition {
+                    id: "BUILD".to_string(),
+                    label: "Build".to_string(),
+                    field_type: SchemaFieldType::Integer {
+                        min: None,
+                        max: None,
+                        show_modifier: true,
+                    },
+                    editable: false,
+                    required: false,
+                    derived_from: Some(DerivedField {
+                        derivation_type: DerivationType::Custom,
+                        dependencies: vec!["STR".to_string(), "SIZ".to_string()],
+                        display_format: None,
+                    }),
+                    validation: None,
+                    layout: FieldLayout {
+                        width: Some(2),
+                        ..Default::default()
+                    },
+                    description: Some("Based on STR + SIZ".to_string()),
+                    placeholder: None,
+                },
+                FieldDefinition {
+                    id: "DAMAGE_BONUS".to_string(),
+                    label: "Damage Bonus".to_string(),
+                    field_type: SchemaFieldType::Text {
+                        multiline: false,
+                        max_length: Some(10),
+                    },
+                    editable: false,
+                    required: false,
+                    derived_from: Some(DerivedField {
+                        derivation_type: DerivationType::Custom,
+                        dependencies: vec!["STR".to_string(), "SIZ".to_string()],
+                        display_format: None,
+                    }),
+                    validation: None,
+                    layout: FieldLayout {
+                        width: Some(2),
+                        ..Default::default()
+                    },
+                    description: Some("Based on STR + SIZ".to_string()),
+                    placeholder: None,
+                },
+            ],
+            collapsible: false,
+            collapsed_default: false,
+            description: Some("Values calculated from characteristics".to_string()),
+        }
+    }
+
+    fn skills_section(&self) -> SchemaSection {
+        // Define skills with their base values
+        let skills = [
+            ("ACCOUNTING", "Accounting", 5),
+            ("ANTHROPOLOGY", "Anthropology", 1),
+            ("ARCHAEOLOGY", "Archaeology", 1),
+            ("ART_CRAFT", "Art/Craft", 5),
+            ("CHARM", "Charm", 15),
+            ("CLIMB", "Climb", 20),
+            ("CREDIT_RATING", "Credit Rating", 0),
+            ("CTHULHU_MYTHOS", "Cthulhu Mythos", 0),
+            ("DISGUISE", "Disguise", 5),
+            ("DRIVE_AUTO", "Drive Auto", 20),
+            ("ELECTRICAL_REPAIR", "Electrical Repair", 10),
+            ("FAST_TALK", "Fast Talk", 5),
+            ("FIRST_AID", "First Aid", 30),
+            ("HISTORY", "History", 5),
+            ("INTIMIDATE", "Intimidate", 15),
+            ("JUMP", "Jump", 20),
+            ("LANGUAGE_OWN", "Language (Own)", 0), // EDU as base, handled specially
+            ("LANGUAGE_OTHER", "Language (Other)", 1),
+            ("LAW", "Law", 5),
+            ("LIBRARY_USE", "Library Use", 20),
+            ("LISTEN", "Listen", 20),
+            ("LOCKSMITH", "Locksmith", 1),
+            ("MECHANICAL_REPAIR", "Mechanical Repair", 10),
+            ("MEDICINE", "Medicine", 1),
+            ("NATURAL_WORLD", "Natural World", 10),
+            ("NAVIGATE", "Navigate", 10),
+            ("OCCULT", "Occult", 5),
+            ("OPERATE_HEAVY_MACHINERY", "Operate Heavy Machinery", 1),
+            ("PERSUADE", "Persuade", 10),
+            ("PILOT", "Pilot", 1),
+            ("PSYCHOLOGY", "Psychology", 10),
+            ("PSYCHOANALYSIS", "Psychoanalysis", 1),
+            ("RIDE", "Ride", 5),
+            ("SCIENCE", "Science", 1),
+            ("SLEIGHT_OF_HAND", "Sleight of Hand", 10),
+            ("SPOT_HIDDEN", "Spot Hidden", 25),
+            ("STEALTH", "Stealth", 20),
+            ("SURVIVAL", "Survival", 10),
+            ("SWIM", "Swim", 20),
+            ("THROW", "Throw", 20),
+            ("TRACK", "Track", 10),
+        ];
+
+        let fields: Vec<FieldDefinition> = skills
+            .iter()
+            .map(|(id, label, base)| {
+                let description = if *id == "CTHULHU_MYTHOS" {
+                    Some(
+                        "Cannot be raised normally. Gains from reading forbidden tomes."
+                            .to_string(),
+                    )
+                } else if *id == "LANGUAGE_OWN" {
+                    Some("Base equals EDU".to_string())
+                } else {
+                    Some(format!("Base: {}%", base))
+                };
+
+                FieldDefinition {
+                    id: id.to_string(),
+                    label: label.to_string(),
+                    field_type: SchemaFieldType::PercentileSkill { show_derived: true },
+                    editable: true,
+                    required: false,
+                    derived_from: None,
+                    validation: Some(FieldValidation {
+                        min: Some(0),
+                        max: Some(99),
+                        pattern: None,
+                        error_message: Some("Skills must be 0-99".to_string()),
+                    }),
+                    layout: FieldLayout {
+                        width: Some(4),
+                        ..Default::default()
+                    },
+                    description,
+                    placeholder: Some(format!("{}", base)),
+                }
+            })
+            .collect();
+
+        SchemaSection {
+            id: "skills".to_string(),
+            label: "Skills".to_string(),
+            section_type: SectionType::Skills,
+            fields,
+            collapsible: true,
+            collapsed_default: false,
+            description: Some(
+                "Percentile skills. Shows Regular/Half/Fifth values for difficulty levels."
+                    .to_string(),
+            ),
+        }
+    }
+
+    fn combat_section(&self) -> SchemaSection {
+        SchemaSection {
+            id: "combat".to_string(),
+            label: "Combat Skills".to_string(),
+            section_type: SectionType::Combat,
+            fields: vec![
+                FieldDefinition {
+                    id: "DODGE".to_string(),
+                    label: "Dodge".to_string(),
+                    field_type: SchemaFieldType::PercentileSkill { show_derived: true },
+                    editable: true,
+                    required: false,
+                    derived_from: None,
+                    validation: Some(FieldValidation {
+                        min: Some(0),
+                        max: Some(99),
+                        pattern: None,
+                        error_message: Some("Skills must be 0-99".to_string()),
+                    }),
+                    layout: FieldLayout {
+                        width: Some(4),
+                        ..Default::default()
+                    },
+                    description: Some("Base: DEX/2".to_string()),
+                    placeholder: None,
+                },
+                FieldDefinition {
+                    id: "FIGHTING_BRAWL".to_string(),
+                    label: "Fighting (Brawl)".to_string(),
+                    field_type: SchemaFieldType::PercentileSkill { show_derived: true },
+                    editable: true,
+                    required: false,
+                    derived_from: None,
+                    validation: Some(FieldValidation {
+                        min: Some(0),
+                        max: Some(99),
+                        pattern: None,
+                        error_message: Some("Skills must be 0-99".to_string()),
+                    }),
+                    layout: FieldLayout {
+                        width: Some(4),
+                        ..Default::default()
+                    },
+                    description: Some("Base: 25%".to_string()),
+                    placeholder: Some("25".to_string()),
+                },
+                FieldDefinition {
+                    id: "FIREARMS_HANDGUN".to_string(),
+                    label: "Firearms (Handgun)".to_string(),
+                    field_type: SchemaFieldType::PercentileSkill { show_derived: true },
+                    editable: true,
+                    required: false,
+                    derived_from: None,
+                    validation: Some(FieldValidation {
+                        min: Some(0),
+                        max: Some(99),
+                        pattern: None,
+                        error_message: Some("Skills must be 0-99".to_string()),
+                    }),
+                    layout: FieldLayout {
+                        width: Some(4),
+                        ..Default::default()
+                    },
+                    description: Some("Base: 20%".to_string()),
+                    placeholder: Some("20".to_string()),
+                },
+                FieldDefinition {
+                    id: "FIREARMS_RIFLE".to_string(),
+                    label: "Firearms (Rifle/Shotgun)".to_string(),
+                    field_type: SchemaFieldType::PercentileSkill { show_derived: true },
+                    editable: true,
+                    required: false,
+                    derived_from: None,
+                    validation: Some(FieldValidation {
+                        min: Some(0),
+                        max: Some(99),
+                        pattern: None,
+                        error_message: Some("Skills must be 0-99".to_string()),
+                    }),
+                    layout: FieldLayout {
+                        width: Some(4),
+                        ..Default::default()
+                    },
+                    description: Some("Base: 25%".to_string()),
+                    placeholder: Some("25".to_string()),
+                },
+            ],
+            collapsible: false,
+            collapsed_default: false,
+            description: Some("Combat-related skills".to_string()),
+        }
+    }
+
+    fn resources_section(&self) -> SchemaSection {
+        SchemaSection {
+            id: "resources".to_string(),
+            label: "Current Resources".to_string(),
+            section_type: SectionType::Resources,
+            fields: vec![
+                FieldDefinition {
+                    id: "CURRENT_HP".to_string(),
+                    label: "Current HP".to_string(),
+                    field_type: SchemaFieldType::ResourceBar {
+                        max_field: "MAX_HP".to_string(),
+                        color: ResourceColor::Red,
+                    },
+                    editable: true,
+                    required: false,
+                    derived_from: None,
+                    validation: None,
+                    layout: FieldLayout {
+                        width: Some(6),
+                        ..Default::default()
+                    },
+                    description: None,
+                    placeholder: None,
+                },
+                FieldDefinition {
+                    id: "CURRENT_SANITY".to_string(),
+                    label: "Current Sanity".to_string(),
+                    field_type: SchemaFieldType::ResourceBar {
+                        max_field: "MAX_SANITY".to_string(),
+                        color: ResourceColor::Blue,
+                    },
+                    editable: true,
+                    required: false,
+                    derived_from: None,
+                    validation: None,
+                    layout: FieldLayout {
+                        width: Some(6),
+                        ..Default::default()
+                    },
+                    description: Some(
+                        "Sanity loss leads to temporary and indefinite insanity".to_string(),
+                    ),
+                    placeholder: None,
+                },
+                FieldDefinition {
+                    id: "CURRENT_MP".to_string(),
+                    label: "Current Magic Points".to_string(),
+                    field_type: SchemaFieldType::ResourceBar {
+                        max_field: "MAX_MP".to_string(),
+                        color: ResourceColor::Purple,
+                    },
+                    editable: true,
+                    required: false,
+                    derived_from: None,
+                    validation: None,
+                    layout: FieldLayout {
+                        width: Some(6),
+                        new_row: true,
+                        ..Default::default()
+                    },
+                    description: Some("Regenerates at rate of 1 per day".to_string()),
+                    placeholder: None,
+                },
+                FieldDefinition {
+                    id: "CURRENT_LUCK".to_string(),
+                    label: "Current Luck".to_string(),
+                    field_type: SchemaFieldType::ResourceBar {
+                        max_field: "LUCK".to_string(),
+                        color: ResourceColor::Green,
+                    },
+                    editable: true,
+                    required: false,
+                    derived_from: None,
+                    validation: None,
+                    layout: FieldLayout {
+                        width: Some(6),
+                        ..Default::default()
+                    },
+                    description: Some(
+                        "Spend to adjust roll results. Does not regenerate.".to_string(),
+                    ),
+                    placeholder: None,
+                },
+            ],
+            collapsible: false,
+            collapsed_default: false,
+            description: Some("Track current values of expendable resources".to_string()),
+        }
+    }
+
+    /// Get all skill field IDs for derived value calculations.
+    fn get_all_skill_ids(&self) -> Vec<String> {
+        vec![
+            "ACCOUNTING".to_string(),
+            "ANTHROPOLOGY".to_string(),
+            "ARCHAEOLOGY".to_string(),
+            "ART_CRAFT".to_string(),
+            "CHARM".to_string(),
+            "CLIMB".to_string(),
+            "CREDIT_RATING".to_string(),
+            "CTHULHU_MYTHOS".to_string(),
+            "DISGUISE".to_string(),
+            "DODGE".to_string(),
+            "DRIVE_AUTO".to_string(),
+            "ELECTRICAL_REPAIR".to_string(),
+            "FAST_TALK".to_string(),
+            "FIGHTING_BRAWL".to_string(),
+            "FIREARMS_HANDGUN".to_string(),
+            "FIREARMS_RIFLE".to_string(),
+            "FIRST_AID".to_string(),
+            "HISTORY".to_string(),
+            "INTIMIDATE".to_string(),
+            "JUMP".to_string(),
+            "LANGUAGE_OWN".to_string(),
+            "LANGUAGE_OTHER".to_string(),
+            "LAW".to_string(),
+            "LIBRARY_USE".to_string(),
+            "LISTEN".to_string(),
+            "LOCKSMITH".to_string(),
+            "MECHANICAL_REPAIR".to_string(),
+            "MEDICINE".to_string(),
+            "NATURAL_WORLD".to_string(),
+            "NAVIGATE".to_string(),
+            "OCCULT".to_string(),
+            "OPERATE_HEAVY_MACHINERY".to_string(),
+            "PERSUADE".to_string(),
+            "PILOT".to_string(),
+            "PSYCHOLOGY".to_string(),
+            "PSYCHOANALYSIS".to_string(),
+            "RIDE".to_string(),
+            "SCIENCE".to_string(),
+            "SLEIGHT_OF_HAND".to_string(),
+            "SPOT_HIDDEN".to_string(),
+            "STEALTH".to_string(),
+            "SURVIVAL".to_string(),
+            "SWIM".to_string(),
+            "THROW".to_string(),
+            "TRACK".to_string(),
+        ]
+    }
+
+    /// Check if a field ID corresponds to a skill.
+    fn is_skill_field(&self, field_id: &str) -> bool {
+        self.get_all_skill_ids().contains(&field_id.to_string())
+    }
+}
+
+/// Get the base value for a skill in CoC 7e.
+pub fn get_skill_base(skill: &str) -> i32 {
+    match skill.to_lowercase().as_str() {
+        // Combat
+        "dodge" => 0, // DEX/2, calculated separately
+        "fighting (brawl)" => 25,
+        "firearms (handgun)" => 20,
+        "firearms (rifle/shotgun)" => 25,
+        "throw" => 20,
+        // Investigation
+        "appraise" => 5,
+        "library use" => 20,
+        "listen" => 20,
+        "spot hidden" => 25,
+        "track" => 10,
+        // Social
+        "charm" => 15,
+        "fast talk" => 5,
+        "intimidate" => 15,
+        "persuade" => 10,
+        "psychology" => 10,
+        // Knowledge
+        "accounting" => 5,
+        "anthropology" => 1,
+        "archaeology" => 1,
+        "cthulhu mythos" => 0, // Special: cannot be raised normally
+        "history" => 5,
+        "law" => 5,
+        "medicine" => 1,
+        "natural world" => 10,
+        "navigate" => 10,
+        "occult" => 5,
+        // Practical
+        "climb" => 20,
+        "drive auto" => 20,
+        "electrical repair" => 10,
+        "first aid" => 30,
+        "jump" => 20,
+        "locksmith" => 1,
+        "mechanical repair" => 10,
+        "operate heavy machinery" => 1,
+        "ride" => 5,
+        "sleight of hand" => 10,
+        "stealth" => 20,
+        "swim" => 20,
+        // Art/Craft and Language have variable bases
+        _ if skill.to_lowercase().starts_with("art/craft") => 5,
+        _ if skill.to_lowercase().starts_with("language (own)") => 0, // EDU
+        _ if skill.to_lowercase().starts_with("language") => 1,
+        _ if skill.to_lowercase().starts_with("pilot") => 1,
+        _ if skill.to_lowercase().starts_with("science") => 1,
+        _ if skill.to_lowercase().starts_with("survival") => 10,
+        _ => 1, // Default for specialized skills
+    }
+}
+
+/// Credit Rating to lifestyle mapping.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Lifestyle {
+    Penniless,
+    Poor,
+    Average,
+    Affluent,
+    Wealthy,
+    SuperRich,
+}
+
+impl Lifestyle {
+    pub fn from_credit_rating(rating: u8) -> Self {
+        match rating {
+            0 => Lifestyle::Penniless,
+            1..=9 => Lifestyle::Poor,
+            10..=49 => Lifestyle::Average,
+            50..=89 => Lifestyle::Affluent,
+            90..=98 => Lifestyle::Wealthy,
+            _ => Lifestyle::SuperRich,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn success_level_determination() {
+        // Critical on 01
+        assert_eq!(check_success(1, 50), SuccessLevel::Critical);
+
+        // Extreme success (roll <= skill/5)
+        assert_eq!(check_success(10, 50), SuccessLevel::Extreme); // 10 <= 10
+
+        // Hard success (roll <= skill/2)
+        assert_eq!(check_success(20, 50), SuccessLevel::Hard); // 20 <= 25
+
+        // Regular success (roll <= skill)
+        assert_eq!(check_success(45, 50), SuccessLevel::Regular);
+
+        // Failure
+        assert_eq!(check_success(60, 50), SuccessLevel::Failure);
+
+        // Fumble (skill < 50, roll >= 96)
+        assert_eq!(check_success(96, 40), SuccessLevel::Fumble);
+
+        // Fumble (skill >= 50, roll == 100)
+        assert_eq!(check_success(100, 60), SuccessLevel::Fumble);
+
+        // Not fumble (skill >= 50, roll 96-99)
+        assert_eq!(check_success(96, 60), SuccessLevel::Failure);
+    }
+
+    #[test]
+    fn hp_calculation() {
+        assert_eq!(Coc7eSystem::calculate_hp(60, 65), 12); // (60+65)/10 = 12
+        assert_eq!(Coc7eSystem::calculate_hp(50, 50), 10);
+    }
+
+    #[test]
+    fn magic_points_calculation() {
+        assert_eq!(Coc7eSystem::calculate_magic_points(50), 10);
+        assert_eq!(Coc7eSystem::calculate_magic_points(65), 13);
+    }
+
+    #[test]
+    fn move_rate_calculation() {
+        // Both DEX and STR < SIZ
+        assert_eq!(Coc7eSystem::calculate_move_rate(40, 40, 60), 7);
+
+        // Both DEX and STR > SIZ
+        assert_eq!(Coc7eSystem::calculate_move_rate(60, 60, 40), 9);
+
+        // Mixed
+        assert_eq!(Coc7eSystem::calculate_move_rate(50, 50, 50), 8);
+    }
+
+    #[test]
+    fn damage_bonus_calculation() {
+        assert_eq!(Coc7eSystem::calculate_damage_bonus(40, 40), "-1"); // 80
+        assert_eq!(Coc7eSystem::calculate_damage_bonus(50, 50), "None"); // 100
+        assert_eq!(Coc7eSystem::calculate_damage_bonus(70, 70), "+1d4"); // 140
+    }
+
+    #[test]
+    fn build_calculation() {
+        assert_eq!(Coc7eSystem::calculate_build(40, 40), -1); // 80
+        assert_eq!(Coc7eSystem::calculate_build(50, 50), 0); // 100
+        assert_eq!(Coc7eSystem::calculate_build(70, 70), 1); // 140
+    }
+
+    #[test]
+    fn skill_base_values() {
+        assert_eq!(get_skill_base("Spot Hidden"), 25);
+        assert_eq!(get_skill_base("First Aid"), 30);
+        assert_eq!(get_skill_base("Cthulhu Mythos"), 0);
+        assert_eq!(get_skill_base("Medicine"), 1);
+    }
+
+    #[test]
+    fn lifestyle_from_credit_rating() {
+        assert_eq!(Lifestyle::from_credit_rating(0), Lifestyle::Penniless);
+        assert_eq!(Lifestyle::from_credit_rating(5), Lifestyle::Poor);
+        assert_eq!(Lifestyle::from_credit_rating(30), Lifestyle::Average);
+        assert_eq!(Lifestyle::from_credit_rating(60), Lifestyle::Affluent);
+        assert_eq!(Lifestyle::from_credit_rating(95), Lifestyle::Wealthy);
+        assert_eq!(Lifestyle::from_credit_rating(99), Lifestyle::SuperRich);
+    }
+
+    #[test]
+    fn system_identification() {
+        let system = Coc7eSystem::new();
+        assert_eq!(system.system_id(), "coc7e");
+        assert_eq!(system.display_name(), "Call of Cthulhu 7th Edition");
+    }
+
+    // CharacterSheetProvider tests
+
+    #[test]
+    fn character_sheet_schema_structure() {
+        let system = Coc7eSystem::new();
+        let schema = system.character_sheet_schema();
+
+        assert_eq!(schema.system_id, "coc7e");
+        assert_eq!(schema.system_name, "Call of Cthulhu 7th Edition");
+        assert_eq!(schema.sections.len(), 6);
+
+        // Verify section IDs
+        let section_ids: Vec<&str> = schema.sections.iter().map(|s| s.id.as_str()).collect();
+        assert!(section_ids.contains(&"identity"));
+        assert!(section_ids.contains(&"characteristics"));
+        assert!(section_ids.contains(&"derived_attributes"));
+        assert!(section_ids.contains(&"skills"));
+        assert!(section_ids.contains(&"combat"));
+        assert!(section_ids.contains(&"resources"));
+    }
+
+    #[test]
+    fn character_sheet_creation_steps() {
+        let system = Coc7eSystem::new();
+        let schema = system.character_sheet_schema();
+
+        assert_eq!(schema.creation_steps.len(), 4);
+
+        let step_ids: Vec<&str> = schema
+            .creation_steps
+            .iter()
+            .map(|s| s.id.as_str())
+            .collect();
+        assert!(step_ids.contains(&"identity"));
+        assert!(step_ids.contains(&"characteristics"));
+        assert!(step_ids.contains(&"derived"));
+        assert!(step_ids.contains(&"skills"));
+    }
+
+    #[test]
+    fn characteristics_section_has_all_eight() {
+        let system = Coc7eSystem::new();
+        let schema = system.character_sheet_schema();
+
+        let char_section = schema
+            .sections
+            .iter()
+            .find(|s| s.id == "characteristics")
+            .unwrap();
+
+        assert_eq!(char_section.fields.len(), 8);
+
+        let char_ids: Vec<&str> = char_section.fields.iter().map(|f| f.id.as_str()).collect();
+        assert!(char_ids.contains(&"STR"));
+        assert!(char_ids.contains(&"CON"));
+        assert!(char_ids.contains(&"SIZ"));
+        assert!(char_ids.contains(&"DEX"));
+        assert!(char_ids.contains(&"APP"));
+        assert!(char_ids.contains(&"INT"));
+        assert!(char_ids.contains(&"POW"));
+        assert!(char_ids.contains(&"EDU"));
+    }
+
+    #[test]
+    fn derived_values_calculation() {
+        let system = Coc7eSystem::new();
+        let mut values = HashMap::new();
+
+        // Set characteristics
+        values.insert("STR".to_string(), serde_json::json!(60));
+        values.insert("CON".to_string(), serde_json::json!(65));
+        values.insert("SIZ".to_string(), serde_json::json!(55));
+        values.insert("DEX".to_string(), serde_json::json!(50));
+        values.insert("APP".to_string(), serde_json::json!(45));
+        values.insert("INT".to_string(), serde_json::json!(70));
+        values.insert("POW".to_string(), serde_json::json!(55));
+        values.insert("EDU".to_string(), serde_json::json!(60));
+
+        let derived = system.calculate_derived_values(&values);
+
+        // HP = (CON + SIZ) / 10 = (65 + 55) / 10 = 12
+        assert_eq!(derived.get("MAX_HP").unwrap().as_i64().unwrap(), 12);
+
+        // Sanity = POW = 55
+        assert_eq!(derived.get("MAX_SANITY").unwrap().as_i64().unwrap(), 55);
+
+        // MP = POW / 5 = 55 / 5 = 11
+        assert_eq!(derived.get("MAX_MP").unwrap().as_i64().unwrap(), 11);
+
+        // Move = 8 (STR > SIZ but DEX < SIZ, so mixed)
+        assert_eq!(derived.get("MOVE").unwrap().as_i64().unwrap(), 8);
+
+        // Build = 0 (STR + SIZ = 115, in 85-124 range)
+        assert_eq!(derived.get("BUILD").unwrap().as_i64().unwrap(), 0);
+
+        // Damage Bonus = "None" (STR + SIZ = 115)
+        assert_eq!(
+            derived.get("DAMAGE_BONUS").unwrap().as_str().unwrap(),
+            "None"
+        );
+
+        // Half/Fifth values for STR
+        assert_eq!(derived.get("STR_HALF").unwrap().as_i64().unwrap(), 30);
+        assert_eq!(derived.get("STR_FIFTH").unwrap().as_i64().unwrap(), 12);
+    }
+
+    #[test]
+    fn skill_half_fifth_values() {
+        let system = Coc7eSystem::new();
+        let mut values = HashMap::new();
+
+        values.insert("SPOT_HIDDEN".to_string(), serde_json::json!(60));
+        values.insert("LIBRARY_USE".to_string(), serde_json::json!(45));
+
+        let derived = system.calculate_derived_values(&values);
+
+        // Spot Hidden: 60 -> half=30, fifth=12
+        assert_eq!(
+            derived.get("SPOT_HIDDEN_HALF").unwrap().as_i64().unwrap(),
+            30
+        );
+        assert_eq!(
+            derived.get("SPOT_HIDDEN_FIFTH").unwrap().as_i64().unwrap(),
+            12
+        );
+
+        // Library Use: 45 -> half=22, fifth=9
+        assert_eq!(
+            derived.get("LIBRARY_USE_HALF").unwrap().as_i64().unwrap(),
+            22
+        );
+        assert_eq!(
+            derived.get("LIBRARY_USE_FIFTH").unwrap().as_i64().unwrap(),
+            9
+        );
+    }
+
+    #[test]
+    fn field_validation_characteristics() {
+        let system = Coc7eSystem::new();
+        let all_values = HashMap::new();
+
+        // Valid characteristic
+        assert!(system
+            .validate_field("STR", &serde_json::json!(50), &all_values)
+            .is_none());
+
+        // Invalid: too high
+        assert!(system
+            .validate_field("STR", &serde_json::json!(100), &all_values)
+            .is_some());
+
+        // Invalid: negative
+        assert!(system
+            .validate_field("CON", &serde_json::json!(-5), &all_values)
+            .is_some());
+
+        // Invalid: not a number
+        assert!(system
+            .validate_field("DEX", &serde_json::json!("fifty"), &all_values)
+            .is_some());
+    }
+
+    #[test]
+    fn field_validation_skills() {
+        let system = Coc7eSystem::new();
+        let all_values = HashMap::new();
+
+        // Valid skill
+        assert!(system
+            .validate_field("SPOT_HIDDEN", &serde_json::json!(50), &all_values)
+            .is_none());
+
+        // Invalid: too high
+        assert!(system
+            .validate_field("LIBRARY_USE", &serde_json::json!(100), &all_values)
+            .is_some());
+    }
+
+    #[test]
+    fn field_validation_sanity_and_luck() {
+        let system = Coc7eSystem::new();
+        let all_values = HashMap::new();
+
+        // Valid sanity
+        assert!(system
+            .validate_field("CURRENT_SANITY", &serde_json::json!(45), &all_values)
+            .is_none());
+
+        // Invalid sanity
+        assert!(system
+            .validate_field("CURRENT_SANITY", &serde_json::json!(100), &all_values)
+            .is_some());
+
+        // Valid luck
+        assert!(system
+            .validate_field("LUCK", &serde_json::json!(55), &all_values)
+            .is_none());
+
+        // Invalid luck
+        assert!(system
+            .validate_field("CURRENT_LUCK", &serde_json::json!(-1), &all_values)
+            .is_some());
+    }
+
+    #[test]
+    fn default_values_set() {
+        let system = Coc7eSystem::new();
+        let defaults = system.default_values();
+
+        // Characteristics default to 50
+        assert_eq!(defaults.get("STR").unwrap().as_i64().unwrap(), 50);
+        assert_eq!(defaults.get("CON").unwrap().as_i64().unwrap(), 50);
+        assert_eq!(defaults.get("POW").unwrap().as_i64().unwrap(), 50);
+
+        // Luck defaults
+        assert_eq!(defaults.get("LUCK").unwrap().as_i64().unwrap(), 50);
+
+        // Some skill defaults
+        assert_eq!(defaults.get("FIRST_AID").unwrap().as_i64().unwrap(), 30);
+        assert_eq!(defaults.get("SPOT_HIDDEN").unwrap().as_i64().unwrap(), 25);
+        assert_eq!(defaults.get("CTHULHU_MYTHOS").unwrap().as_i64().unwrap(), 0);
+    }
+
+    #[test]
+    fn skills_use_percentile_skill_type() {
+        let system = Coc7eSystem::new();
+        let schema = system.character_sheet_schema();
+
+        let skills_section = schema.sections.iter().find(|s| s.id == "skills").unwrap();
+
+        for field in &skills_section.fields {
+            match &field.field_type {
+                SchemaFieldType::PercentileSkill { show_derived } => {
+                    assert!(
+                        show_derived,
+                        "Skill {} should show derived values",
+                        field.id
+                    );
+                }
+                _ => panic!("Skill {} should use PercentileSkill type", field.id),
+            }
+        }
+    }
+
+    #[test]
+    fn resources_section_has_resource_bars() {
+        let system = Coc7eSystem::new();
+        let schema = system.character_sheet_schema();
+
+        let resources_section = schema
+            .sections
+            .iter()
+            .find(|s| s.id == "resources")
+            .unwrap();
+
+        assert_eq!(resources_section.fields.len(), 4);
+
+        // Check that all fields use ResourceBar type
+        for field in &resources_section.fields {
+            match &field.field_type {
+                SchemaFieldType::ResourceBar { max_field, .. } => {
+                    assert!(!max_field.is_empty(), "ResourceBar should have max_field");
+                }
+                _ => panic!("Resource {} should use ResourceBar type", field.id),
+            }
+        }
+    }
+
+    #[test]
+    fn identity_section_fields() {
+        let system = Coc7eSystem::new();
+        let schema = system.character_sheet_schema();
+
+        let identity_section = schema.sections.iter().find(|s| s.id == "identity").unwrap();
+
+        let field_ids: Vec<&str> = identity_section
+            .fields
+            .iter()
+            .map(|f| f.id.as_str())
+            .collect();
+        assert!(field_ids.contains(&"NAME"));
+        assert!(field_ids.contains(&"OCCUPATION"));
+        assert!(field_ids.contains(&"AGE"));
+        assert!(field_ids.contains(&"RESIDENCE"));
+        assert!(field_ids.contains(&"BIRTHPLACE"));
+    }
+}

--- a/crates/domain/src/game_systems/coc7e.rs
+++ b/crates/domain/src/game_systems/coc7e.rs
@@ -364,6 +364,7 @@ impl CharacterSheetProvider for Coc7eSystem {
                 self.skills_section(),
                 self.combat_section(),
                 self.resources_section(),
+                self.modifiers_section(),
             ],
             creation_steps: vec![
                 CreationStep {
@@ -1338,6 +1339,36 @@ impl Coc7eSystem {
     /// Check if a field ID corresponds to a skill.
     fn is_skill_field(&self, field_id: &str) -> bool {
         self.get_all_skill_ids().contains(&field_id.to_string())
+    }
+
+    fn modifiers_section(&self) -> SchemaSection {
+        SchemaSection {
+            id: "modifiers".to_string(),
+            label: "Status & Conditions".to_string(),
+            section_type: SectionType::Modifiers,
+            fields: vec![
+                FieldDefinition {
+                    id: "ACTIVE_MODIFIERS".to_string(),
+                    label: "Active Conditions".to_string(),
+                    field_type: SchemaFieldType::ModifierList { filter_stat: None },
+                    editable: false,
+                    required: false,
+                    derived_from: None,
+                    validation: None,
+                    layout: FieldLayout {
+                        width: Some(12),
+                        ..Default::default()
+                    },
+                    description: Some(
+                        "Active conditions affecting your investigator (injuries, temporary insanity, phobias, etc.)".to_string(),
+                    ),
+                    placeholder: None,
+                },
+            ],
+            collapsible: true,
+            collapsed_default: false,
+            description: Some("Track injuries, bouts of madness, phobias, manias, and other conditions affecting skill checks.".to_string()),
+        }
     }
 }
 

--- a/crates/domain/src/game_systems/dnd5e.rs
+++ b/crates/domain/src/game_systems/dnd5e.rs
@@ -1,0 +1,1679 @@
+//! D&D 5th Edition game system implementation.
+//!
+//! Implements all calculation rules and spellcasting mechanics for D&D 5e.
+
+use super::traits::{
+    CalculationEngine, CasterType, CharacterSheetProvider, CharacterSheetSchema,
+    CreationStep, DerivedField, DerivationType, FieldDefinition, FieldLayout,
+    FieldValidation, GameSystem, ProficiencyLevel, ProficiencyOption, ResourceColor,
+    SchemaFieldType, SchemaSection, SchemaSelectOption, SectionType, SpellcastingSystem,
+};
+use crate::entities::{StatBlock, StatModifier};
+use std::collections::HashMap;
+
+/// D&D 5th Edition game system.
+pub struct Dnd5eSystem;
+
+impl Default for Dnd5eSystem {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Dnd5eSystem {
+    /// Create a new D&D 5e system instance.
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl GameSystem for Dnd5eSystem {
+    fn system_id(&self) -> &str {
+        "dnd5e"
+    }
+
+    fn display_name(&self) -> &str {
+        "D&D 5th Edition"
+    }
+
+    fn calculation_engine(&self) -> &dyn CalculationEngine {
+        self
+    }
+
+    fn spellcasting_system(&self) -> Option<&dyn SpellcastingSystem> {
+        Some(self)
+    }
+
+    fn stat_names(&self) -> &[&str] {
+        &["STR", "DEX", "CON", "INT", "WIS", "CHA"]
+    }
+
+    fn skill_names(&self) -> &[&str] {
+        &[
+            "Acrobatics",
+            "Animal Handling",
+            "Arcana",
+            "Athletics",
+            "Deception",
+            "History",
+            "Insight",
+            "Intimidation",
+            "Investigation",
+            "Medicine",
+            "Nature",
+            "Perception",
+            "Performance",
+            "Persuasion",
+            "Religion",
+            "Sleight of Hand",
+            "Stealth",
+            "Survival",
+        ]
+    }
+}
+
+impl CalculationEngine for Dnd5eSystem {
+    fn ability_modifier(&self, score: i32) -> i32 {
+        // D&D uses floor division, Rust's / rounds toward zero
+        // Use proper floor division: floor((score - 10) / 2)
+        let diff = score - 10;
+        if diff >= 0 {
+            diff / 2
+        } else {
+            (diff - 1) / 2
+        }
+    }
+
+    fn proficiency_bonus(&self, level: u8) -> i32 {
+        ((level as i32 - 1) / 4) + 2
+    }
+
+    fn spell_save_dc(&self, stats: &StatBlock, casting_stat: &str) -> i32 {
+        let stat_value = stats.get_stat(casting_stat).unwrap_or(10);
+        let modifier = self.ability_modifier(stat_value);
+        let level = stats.get_stat("LEVEL").unwrap_or(1) as u8;
+        let prof = self.proficiency_bonus(level);
+        8 + modifier + prof
+    }
+
+    fn spell_attack_bonus(&self, stats: &StatBlock, casting_stat: &str) -> i32 {
+        let stat_value = stats.get_stat(casting_stat).unwrap_or(10);
+        let modifier = self.ability_modifier(stat_value);
+        let level = stats.get_stat("LEVEL").unwrap_or(1) as u8;
+        let prof = self.proficiency_bonus(level);
+        modifier + prof
+    }
+
+    fn attack_bonus(&self, stats: &StatBlock, attack_stat: &str, proficient: bool) -> i32 {
+        let stat_value = stats.get_stat(attack_stat).unwrap_or(10);
+        let modifier = self.ability_modifier(stat_value);
+        if proficient {
+            let level = stats.get_stat("LEVEL").unwrap_or(1) as u8;
+            modifier + self.proficiency_bonus(level)
+        } else {
+            modifier
+        }
+    }
+
+    fn stack_modifiers(&self, modifiers: &[StatModifier]) -> i32 {
+        // D&D 5e stacking rules:
+        // - Same-named bonuses don't stack (take highest)
+        // - Different-named bonuses do stack
+        // - Penalties always stack
+        // For simplicity, we take the highest active bonus
+        modifiers
+            .iter()
+            .filter(|m| m.active)
+            .map(|m| m.value)
+            .max()
+            .unwrap_or(0)
+    }
+
+    fn calculate_ac(
+        &self,
+        stats: &StatBlock,
+        armor_ac: Option<i32>,
+        shield_bonus: Option<i32>,
+        allows_dex: bool,
+        max_dex_bonus: Option<i32>,
+    ) -> i32 {
+        let dex = stats.get_stat("DEX").unwrap_or(10);
+        let dex_mod = self.ability_modifier(dex);
+
+        let base_ac = match armor_ac {
+            Some(ac) => {
+                // Armor provides a base AC
+                if allows_dex {
+                    let dex_bonus = match max_dex_bonus {
+                        Some(max) => dex_mod.min(max),
+                        None => dex_mod,
+                    };
+                    ac + dex_bonus
+                } else {
+                    ac
+                }
+            }
+            None => 10 + dex_mod, // Unarmored: 10 + DEX (always applies)
+        };
+
+        base_ac + shield_bonus.unwrap_or(0)
+    }
+
+    fn skill_modifier(
+        &self,
+        stats: &StatBlock,
+        ability: &str,
+        proficiency_level: ProficiencyLevel,
+    ) -> i32 {
+        let stat_value = stats.get_stat(ability).unwrap_or(10);
+        let modifier = self.ability_modifier(stat_value);
+        let level = stats.get_stat("LEVEL").unwrap_or(1) as u8;
+        let prof = self.proficiency_bonus(level);
+
+        let prof_bonus = match proficiency_level {
+            ProficiencyLevel::None => 0,
+            ProficiencyLevel::Half => prof / 2,
+            ProficiencyLevel::Proficient => prof,
+            ProficiencyLevel::Expert => prof * 2,
+        };
+
+        modifier + prof_bonus
+    }
+
+    fn saving_throw_modifier(&self, stats: &StatBlock, ability: &str, proficient: bool) -> i32 {
+        let stat_value = stats.get_stat(ability).unwrap_or(10);
+        let modifier = self.ability_modifier(stat_value);
+
+        if proficient {
+            let level = stats.get_stat("LEVEL").unwrap_or(1) as u8;
+            modifier + self.proficiency_bonus(level)
+        } else {
+            modifier
+        }
+    }
+
+    fn passive_perception(&self, stats: &StatBlock, proficiency_level: ProficiencyLevel) -> i32 {
+        10 + self.skill_modifier(stats, "WIS", proficiency_level)
+    }
+
+    fn hit_die(&self, class_name: &str) -> u8 {
+        match class_name.to_lowercase().as_str() {
+            "barbarian" => 12,
+            "fighter" | "paladin" | "ranger" => 10,
+            "bard" | "cleric" | "druid" | "monk" | "rogue" | "warlock" => 8,
+            "sorcerer" | "wizard" => 6,
+            _ => 8, // Default to d8
+        }
+    }
+
+    fn calculate_max_hp(
+        &self,
+        level: u8,
+        class_name: &str,
+        constitution_modifier: i32,
+        additional_hp: i32,
+    ) -> i32 {
+        let hit_die = self.hit_die(class_name) as i32;
+        // First level: max hit die + CON mod
+        // Subsequent levels: average (ceil) + CON mod per level
+        let first_level_hp = hit_die + constitution_modifier;
+        let avg_roll = (hit_die / 2) + 1; // Average rounded up
+        let subsequent_hp = (level as i32 - 1) * (avg_roll + constitution_modifier);
+
+        (first_level_hp + subsequent_hp + additional_hp).max(1)
+    }
+}
+
+impl SpellcastingSystem for Dnd5eSystem {
+    fn caster_type(&self, class: &str) -> Option<CasterType> {
+        match class.to_lowercase().as_str() {
+            "wizard" | "cleric" | "druid" | "sorcerer" | "bard" => Some(CasterType::Full),
+            "paladin" | "ranger" => Some(CasterType::Half),
+            "warlock" => Some(CasterType::Pact),
+            "eldritch knight" | "arcane trickster" => Some(CasterType::Third),
+            _ => None,
+        }
+    }
+
+    fn spellcasting_stat(&self, class: &str) -> Option<&str> {
+        match class.to_lowercase().as_str() {
+            "wizard" => Some("INT"),
+            "cleric" | "druid" | "ranger" | "monk" => Some("WIS"),
+            "sorcerer" | "bard" | "paladin" | "warlock" => Some("CHA"),
+            "eldritch knight" | "arcane trickster" => Some("INT"),
+            _ => None,
+        }
+    }
+
+    fn uses_spell_preparation(&self, class: &str) -> bool {
+        matches!(
+            class.to_lowercase().as_str(),
+            "wizard" | "cleric" | "druid" | "paladin"
+        )
+    }
+
+    fn max_prepared_spells(&self, class: &str, level: u8, stat_mod: i32) -> u8 {
+        match class.to_lowercase().as_str() {
+            "wizard" | "cleric" | "druid" => (level as i32 + stat_mod).max(1) as u8,
+            "paladin" => ((level as i32 / 2) + stat_mod).max(1) as u8,
+            _ => 0,
+        }
+    }
+
+    fn spell_slots(&self, class: &str, level: u8) -> HashMap<u8, u8> {
+        let caster_type = self.caster_type(class);
+        match caster_type {
+            Some(CasterType::Full) => full_caster_slots(level),
+            Some(CasterType::Half) => half_caster_slots(level),
+            Some(CasterType::Third) => third_caster_slots(level),
+            Some(CasterType::Pact) => warlock_slots(level),
+            _ => HashMap::new(),
+        }
+    }
+
+    fn cantrips_known(&self, class: &str, level: u8) -> u8 {
+        match class.to_lowercase().as_str() {
+            "wizard" => match level {
+                1..=3 => 3,
+                4..=9 => 4,
+                _ => 5,
+            },
+            "sorcerer" => match level {
+                1..=3 => 4,
+                4..=9 => 5,
+                _ => 6,
+            },
+            "bard" => match level {
+                1..=3 => 2,
+                4..=9 => 3,
+                _ => 4,
+            },
+            "cleric" | "druid" => match level {
+                1..=3 => 3,
+                4..=9 => 4,
+                _ => 5,
+            },
+            "warlock" => match level {
+                1..=3 => 2,
+                4..=9 => 3,
+                _ => 4,
+            },
+            "eldritch knight" | "arcane trickster" => match level {
+                1..=9 => 2,
+                _ => 3,
+            },
+            _ => 0,
+        }
+    }
+
+    fn spells_known(&self, class: &str, level: u8) -> Option<u8> {
+        // Only some classes track spells known
+        match class.to_lowercase().as_str() {
+            "sorcerer" => Some(SORCERER_SPELLS_KNOWN.get(level as usize).copied().unwrap_or(15)),
+            "bard" => Some(BARD_SPELLS_KNOWN.get(level as usize).copied().unwrap_or(22)),
+            "ranger" => Some(RANGER_SPELLS_KNOWN.get(level as usize).copied().unwrap_or(11)),
+            "warlock" => Some(WARLOCK_SPELLS_KNOWN.get(level as usize).copied().unwrap_or(15)),
+            "eldritch knight" => Some(
+                ELDRITCH_KNIGHT_SPELLS_KNOWN
+                    .get(level as usize)
+                    .copied()
+                    .unwrap_or(13),
+            ),
+            "arcane trickster" => Some(
+                ARCANE_TRICKSTER_SPELLS_KNOWN
+                    .get(level as usize)
+                    .copied()
+                    .unwrap_or(13),
+            ),
+            _ => None, // Prepared casters don't have a limit
+        }
+    }
+}
+
+impl CharacterSheetProvider for Dnd5eSystem {
+    fn character_sheet_schema(&self) -> CharacterSheetSchema {
+        CharacterSheetSchema {
+            system_id: "dnd5e".to_string(),
+            system_name: "D&D 5th Edition".to_string(),
+            sections: vec![
+                self.identity_section(),
+                self.ability_scores_section(),
+                self.combat_section(),
+                self.skills_section(),
+                self.saving_throws_section(),
+                self.features_section(),
+            ],
+            creation_steps: vec![
+                CreationStep {
+                    id: "identity".to_string(),
+                    label: "Basic Info".to_string(),
+                    description: "Choose your character's name, race, class, and background."
+                        .to_string(),
+                    section_ids: vec!["identity".to_string()],
+                    order: 1,
+                    required: true,
+                },
+                CreationStep {
+                    id: "abilities".to_string(),
+                    label: "Ability Scores".to_string(),
+                    description: "Set your ability scores using point buy, standard array, or rolling."
+                        .to_string(),
+                    section_ids: vec!["ability_scores".to_string()],
+                    order: 2,
+                    required: true,
+                },
+                CreationStep {
+                    id: "proficiencies".to_string(),
+                    label: "Skills & Proficiencies".to_string(),
+                    description: "Choose your skill proficiencies and saving throw proficiencies."
+                        .to_string(),
+                    section_ids: vec!["skills".to_string(), "saving_throws".to_string()],
+                    order: 3,
+                    required: true,
+                },
+                CreationStep {
+                    id: "equipment".to_string(),
+                    label: "Equipment".to_string(),
+                    description: "Select starting equipment or roll for gold.".to_string(),
+                    section_ids: vec!["combat".to_string()],
+                    order: 4,
+                    required: false,
+                },
+            ],
+        }
+    }
+
+    fn calculate_derived_values(
+        &self,
+        values: &HashMap<String, serde_json::Value>,
+    ) -> HashMap<String, serde_json::Value> {
+        let mut derived = HashMap::new();
+
+        // Get level (default to 1)
+        let level = values
+            .get("LEVEL")
+            .and_then(|v| v.as_i64())
+            .unwrap_or(1) as u8;
+
+        // Calculate proficiency bonus
+        let prof_bonus = self.proficiency_bonus(level);
+        derived.insert("PROF_BONUS".to_string(), serde_json::json!(prof_bonus));
+
+        // Calculate ability modifiers
+        for ability in &["STR", "DEX", "CON", "INT", "WIS", "CHA"] {
+            if let Some(score) = values.get(*ability).and_then(|v| v.as_i64()) {
+                let modifier = self.ability_modifier(score as i32);
+                derived.insert(format!("{}_MOD", ability), serde_json::json!(modifier));
+            }
+        }
+
+        // Calculate skill modifiers
+        for skill in self.skill_names() {
+            if let Some(ability) = skill_ability(skill) {
+                let ability_mod = derived
+                    .get(&format!("{}_MOD", ability))
+                    .and_then(|v| v.as_i64())
+                    .unwrap_or(0) as i32;
+
+                let proficiency = values
+                    .get(&format!("{}_PROF", skill.to_uppercase().replace(' ', "_")))
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("none");
+
+                let prof_mult = match proficiency {
+                    "expert" => 2.0,
+                    "proficient" => 1.0,
+                    "half" => 0.5,
+                    _ => 0.0,
+                };
+
+                let skill_mod = ability_mod + (prof_bonus as f64 * prof_mult) as i32;
+                derived.insert(
+                    format!("{}_MOD", skill.to_uppercase().replace(' ', "_")),
+                    serde_json::json!(skill_mod),
+                );
+            }
+        }
+
+        // Calculate saving throw modifiers
+        for ability in &["STR", "DEX", "CON", "INT", "WIS", "CHA"] {
+            let ability_mod = derived
+                .get(&format!("{}_MOD", ability))
+                .and_then(|v| v.as_i64())
+                .unwrap_or(0) as i32;
+
+            let proficient = values
+                .get(&format!("{}_SAVE_PROF", ability))
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false);
+
+            let save_mod = if proficient {
+                ability_mod + prof_bonus
+            } else {
+                ability_mod
+            };
+            derived.insert(format!("{}_SAVE", ability), serde_json::json!(save_mod));
+        }
+
+        // Calculate passive perception
+        let wis_mod = derived
+            .get("WIS_MOD")
+            .and_then(|v| v.as_i64())
+            .unwrap_or(0) as i32;
+        let perception_prof = values
+            .get("PERCEPTION_PROF")
+            .and_then(|v| v.as_str())
+            .unwrap_or("none");
+        let perception_bonus = match perception_prof {
+            "expert" => prof_bonus * 2,
+            "proficient" => prof_bonus,
+            "half" => prof_bonus / 2,
+            _ => 0,
+        };
+        let passive_perception = 10 + wis_mod + perception_bonus;
+        derived.insert(
+            "PASSIVE_PERCEPTION".to_string(),
+            serde_json::json!(passive_perception),
+        );
+
+        // Calculate initiative
+        let dex_mod = derived
+            .get("DEX_MOD")
+            .and_then(|v| v.as_i64())
+            .unwrap_or(0);
+        derived.insert("INITIATIVE".to_string(), serde_json::json!(dex_mod));
+
+        // Calculate max HP if class and CON are set
+        if let (Some(class), Some(con_mod)) = (
+            values.get("CLASS").and_then(|v| v.as_str()),
+            derived.get("CON_MOD").and_then(|v| v.as_i64()),
+        ) {
+            let max_hp = self.calculate_max_hp(level, class, con_mod as i32, 0);
+            derived.insert("MAX_HP".to_string(), serde_json::json!(max_hp));
+        }
+
+        derived
+    }
+
+    fn validate_field(
+        &self,
+        field_id: &str,
+        value: &serde_json::Value,
+        _all_values: &HashMap<String, serde_json::Value>,
+    ) -> Option<String> {
+        match field_id {
+            "STR" | "DEX" | "CON" | "INT" | "WIS" | "CHA" => {
+                if let Some(score) = value.as_i64() {
+                    if score < 1 || score > 30 {
+                        return Some("Ability scores must be between 1 and 30".to_string());
+                    }
+                } else {
+                    return Some("Ability score must be a number".to_string());
+                }
+            }
+            "LEVEL" => {
+                if let Some(level) = value.as_i64() {
+                    if level < 1 || level > 20 {
+                        return Some("Level must be between 1 and 20".to_string());
+                    }
+                } else {
+                    return Some("Level must be a number".to_string());
+                }
+            }
+            "NAME" => {
+                if let Some(name) = value.as_str() {
+                    if name.is_empty() {
+                        return Some("Name is required".to_string());
+                    }
+                } else {
+                    return Some("Name must be a string".to_string());
+                }
+            }
+            _ => {}
+        }
+        None
+    }
+
+    fn default_values(&self) -> HashMap<String, serde_json::Value> {
+        let mut defaults = HashMap::new();
+        defaults.insert("LEVEL".to_string(), serde_json::json!(1));
+        defaults.insert("STR".to_string(), serde_json::json!(10));
+        defaults.insert("DEX".to_string(), serde_json::json!(10));
+        defaults.insert("CON".to_string(), serde_json::json!(10));
+        defaults.insert("INT".to_string(), serde_json::json!(10));
+        defaults.insert("WIS".to_string(), serde_json::json!(10));
+        defaults.insert("CHA".to_string(), serde_json::json!(10));
+        defaults.insert("CURRENT_HP".to_string(), serde_json::json!(0));
+        defaults
+    }
+}
+
+// Helper methods for building the schema
+impl Dnd5eSystem {
+    fn identity_section(&self) -> SchemaSection {
+        SchemaSection {
+            id: "identity".to_string(),
+            label: "Character Identity".to_string(),
+            section_type: SectionType::Identity,
+            fields: vec![
+                FieldDefinition {
+                    id: "NAME".to_string(),
+                    label: "Character Name".to_string(),
+                    field_type: SchemaFieldType::Text {
+                        multiline: false,
+                        max_length: Some(100),
+                    },
+                    editable: true,
+                    required: true,
+                    derived_from: None,
+                    validation: None,
+                    layout: FieldLayout {
+                        width: Some(6),
+                        ..Default::default()
+                    },
+                    description: None,
+                    placeholder: Some("Enter character name".to_string()),
+                },
+                FieldDefinition {
+                    id: "LEVEL".to_string(),
+                    label: "Level".to_string(),
+                    field_type: SchemaFieldType::Integer {
+                        min: Some(1),
+                        max: Some(20),
+                        show_modifier: false,
+                    },
+                    editable: true,
+                    required: true,
+                    derived_from: None,
+                    validation: Some(FieldValidation {
+                        min: Some(1),
+                        max: Some(20),
+                        pattern: None,
+                        error_message: Some("Level must be 1-20".to_string()),
+                    }),
+                    layout: FieldLayout {
+                        width: Some(2),
+                        ..Default::default()
+                    },
+                    description: None,
+                    placeholder: None,
+                },
+                FieldDefinition {
+                    id: "PROF_BONUS".to_string(),
+                    label: "Proficiency Bonus".to_string(),
+                    field_type: SchemaFieldType::Integer {
+                        min: Some(2),
+                        max: Some(6),
+                        show_modifier: true,
+                    },
+                    editable: false,
+                    required: false,
+                    derived_from: Some(DerivedField {
+                        derivation_type: DerivationType::ProficiencyBonus,
+                        dependencies: vec!["LEVEL".to_string()],
+                        display_format: Some("+{}".to_string()),
+                    }),
+                    validation: None,
+                    layout: FieldLayout {
+                        width: Some(2),
+                        ..Default::default()
+                    },
+                    description: Some("Based on character level".to_string()),
+                    placeholder: None,
+                },
+                FieldDefinition {
+                    id: "CLASS".to_string(),
+                    label: "Class".to_string(),
+                    field_type: SchemaFieldType::Select {
+                        options: vec![
+                            SchemaSelectOption {
+                                value: "barbarian".to_string(),
+                                label: "Barbarian".to_string(),
+                                description: Some("A fierce warrior of primitive background".to_string()),
+                            },
+                            SchemaSelectOption {
+                                value: "bard".to_string(),
+                                label: "Bard".to_string(),
+                                description: Some("An inspiring magician".to_string()),
+                            },
+                            SchemaSelectOption {
+                                value: "cleric".to_string(),
+                                label: "Cleric".to_string(),
+                                description: Some("A priestly champion".to_string()),
+                            },
+                            SchemaSelectOption {
+                                value: "druid".to_string(),
+                                label: "Druid".to_string(),
+                                description: Some("A priest of the Old Faith".to_string()),
+                            },
+                            SchemaSelectOption {
+                                value: "fighter".to_string(),
+                                label: "Fighter".to_string(),
+                                description: Some("A master of martial combat".to_string()),
+                            },
+                            SchemaSelectOption {
+                                value: "monk".to_string(),
+                                label: "Monk".to_string(),
+                                description: Some("A master of martial arts".to_string()),
+                            },
+                            SchemaSelectOption {
+                                value: "paladin".to_string(),
+                                label: "Paladin".to_string(),
+                                description: Some("A holy warrior".to_string()),
+                            },
+                            SchemaSelectOption {
+                                value: "ranger".to_string(),
+                                label: "Ranger".to_string(),
+                                description: Some("A warrior of the wilderness".to_string()),
+                            },
+                            SchemaSelectOption {
+                                value: "rogue".to_string(),
+                                label: "Rogue".to_string(),
+                                description: Some("A scoundrel with stealth".to_string()),
+                            },
+                            SchemaSelectOption {
+                                value: "sorcerer".to_string(),
+                                label: "Sorcerer".to_string(),
+                                description: Some("A spellcaster with innate magic".to_string()),
+                            },
+                            SchemaSelectOption {
+                                value: "warlock".to_string(),
+                                label: "Warlock".to_string(),
+                                description: Some("A wielder of pact magic".to_string()),
+                            },
+                            SchemaSelectOption {
+                                value: "wizard".to_string(),
+                                label: "Wizard".to_string(),
+                                description: Some("A scholarly magic-user".to_string()),
+                            },
+                        ],
+                        allow_custom: false,
+                    },
+                    editable: true,
+                    required: true,
+                    derived_from: None,
+                    validation: None,
+                    layout: FieldLayout {
+                        width: Some(4),
+                        new_row: true,
+                        ..Default::default()
+                    },
+                    description: None,
+                    placeholder: None,
+                },
+                FieldDefinition {
+                    id: "RACE".to_string(),
+                    label: "Race".to_string(),
+                    field_type: SchemaFieldType::Select {
+                        options: vec![
+                            SchemaSelectOption {
+                                value: "human".to_string(),
+                                label: "Human".to_string(),
+                                description: None,
+                            },
+                            SchemaSelectOption {
+                                value: "elf".to_string(),
+                                label: "Elf".to_string(),
+                                description: None,
+                            },
+                            SchemaSelectOption {
+                                value: "dwarf".to_string(),
+                                label: "Dwarf".to_string(),
+                                description: None,
+                            },
+                            SchemaSelectOption {
+                                value: "halfling".to_string(),
+                                label: "Halfling".to_string(),
+                                description: None,
+                            },
+                            SchemaSelectOption {
+                                value: "dragonborn".to_string(),
+                                label: "Dragonborn".to_string(),
+                                description: None,
+                            },
+                            SchemaSelectOption {
+                                value: "gnome".to_string(),
+                                label: "Gnome".to_string(),
+                                description: None,
+                            },
+                            SchemaSelectOption {
+                                value: "half-elf".to_string(),
+                                label: "Half-Elf".to_string(),
+                                description: None,
+                            },
+                            SchemaSelectOption {
+                                value: "half-orc".to_string(),
+                                label: "Half-Orc".to_string(),
+                                description: None,
+                            },
+                            SchemaSelectOption {
+                                value: "tiefling".to_string(),
+                                label: "Tiefling".to_string(),
+                                description: None,
+                            },
+                        ],
+                        allow_custom: true,
+                    },
+                    editable: true,
+                    required: true,
+                    derived_from: None,
+                    validation: None,
+                    layout: FieldLayout {
+                        width: Some(4),
+                        ..Default::default()
+                    },
+                    description: None,
+                    placeholder: None,
+                },
+                FieldDefinition {
+                    id: "BACKGROUND".to_string(),
+                    label: "Background".to_string(),
+                    field_type: SchemaFieldType::Select {
+                        options: vec![
+                            SchemaSelectOption {
+                                value: "acolyte".to_string(),
+                                label: "Acolyte".to_string(),
+                                description: None,
+                            },
+                            SchemaSelectOption {
+                                value: "charlatan".to_string(),
+                                label: "Charlatan".to_string(),
+                                description: None,
+                            },
+                            SchemaSelectOption {
+                                value: "criminal".to_string(),
+                                label: "Criminal".to_string(),
+                                description: None,
+                            },
+                            SchemaSelectOption {
+                                value: "entertainer".to_string(),
+                                label: "Entertainer".to_string(),
+                                description: None,
+                            },
+                            SchemaSelectOption {
+                                value: "folk_hero".to_string(),
+                                label: "Folk Hero".to_string(),
+                                description: None,
+                            },
+                            SchemaSelectOption {
+                                value: "guild_artisan".to_string(),
+                                label: "Guild Artisan".to_string(),
+                                description: None,
+                            },
+                            SchemaSelectOption {
+                                value: "hermit".to_string(),
+                                label: "Hermit".to_string(),
+                                description: None,
+                            },
+                            SchemaSelectOption {
+                                value: "noble".to_string(),
+                                label: "Noble".to_string(),
+                                description: None,
+                            },
+                            SchemaSelectOption {
+                                value: "outlander".to_string(),
+                                label: "Outlander".to_string(),
+                                description: None,
+                            },
+                            SchemaSelectOption {
+                                value: "sage".to_string(),
+                                label: "Sage".to_string(),
+                                description: None,
+                            },
+                            SchemaSelectOption {
+                                value: "sailor".to_string(),
+                                label: "Sailor".to_string(),
+                                description: None,
+                            },
+                            SchemaSelectOption {
+                                value: "soldier".to_string(),
+                                label: "Soldier".to_string(),
+                                description: None,
+                            },
+                            SchemaSelectOption {
+                                value: "urchin".to_string(),
+                                label: "Urchin".to_string(),
+                                description: None,
+                            },
+                        ],
+                        allow_custom: true,
+                    },
+                    editable: true,
+                    required: false,
+                    derived_from: None,
+                    validation: None,
+                    layout: FieldLayout {
+                        width: Some(4),
+                        ..Default::default()
+                    },
+                    description: None,
+                    placeholder: None,
+                },
+            ],
+            collapsible: false,
+            collapsed_default: false,
+            description: None,
+        }
+    }
+
+    fn ability_scores_section(&self) -> SchemaSection {
+        let abilities = [
+            ("STR", "Strength", "Physical power, athletics, melee attacks"),
+            ("DEX", "Dexterity", "Agility, reflexes, ranged attacks"),
+            ("CON", "Constitution", "Endurance, health, stamina"),
+            ("INT", "Intelligence", "Reasoning, memory, knowledge"),
+            ("WIS", "Wisdom", "Perception, intuition, insight"),
+            ("CHA", "Charisma", "Force of personality, leadership"),
+        ];
+
+        let mut fields: Vec<FieldDefinition> = Vec::new();
+
+        for (id, label, description) in &abilities {
+            // Score field
+            fields.push(FieldDefinition {
+                id: id.to_string(),
+                label: label.to_string(),
+                field_type: SchemaFieldType::AbilityScore {
+                    min: Some(1),
+                    max: Some(30),
+                },
+                editable: true,
+                required: true,
+                derived_from: None,
+                validation: Some(FieldValidation {
+                    min: Some(1),
+                    max: Some(30),
+                    pattern: None,
+                    error_message: Some("Ability scores must be 1-30".to_string()),
+                }),
+                layout: FieldLayout {
+                    width: Some(2),
+                    ..Default::default()
+                },
+                description: Some(description.to_string()),
+                placeholder: None,
+            });
+        }
+
+        SchemaSection {
+            id: "ability_scores".to_string(),
+            label: "Ability Scores".to_string(),
+            section_type: SectionType::AbilityScores,
+            fields,
+            collapsible: false,
+            collapsed_default: false,
+            description: Some(
+                "Your character's six core abilities. Each has a score and derived modifier."
+                    .to_string(),
+            ),
+        }
+    }
+
+    fn combat_section(&self) -> SchemaSection {
+        SchemaSection {
+            id: "combat".to_string(),
+            label: "Combat".to_string(),
+            section_type: SectionType::Combat,
+            fields: vec![
+                FieldDefinition {
+                    id: "CURRENT_HP".to_string(),
+                    label: "Current HP".to_string(),
+                    field_type: SchemaFieldType::ResourceBar {
+                        max_field: "MAX_HP".to_string(),
+                        color: ResourceColor::Red,
+                    },
+                    editable: true,
+                    required: false,
+                    derived_from: None,
+                    validation: None,
+                    layout: FieldLayout {
+                        width: Some(4),
+                        ..Default::default()
+                    },
+                    description: None,
+                    placeholder: None,
+                },
+                FieldDefinition {
+                    id: "MAX_HP".to_string(),
+                    label: "Max HP".to_string(),
+                    field_type: SchemaFieldType::Integer {
+                        min: Some(1),
+                        max: None,
+                        show_modifier: false,
+                    },
+                    editable: false,
+                    required: false,
+                    derived_from: Some(DerivedField {
+                        derivation_type: DerivationType::Custom,
+                        dependencies: vec!["LEVEL".to_string(), "CLASS".to_string(), "CON".to_string()],
+                        display_format: None,
+                    }),
+                    validation: None,
+                    layout: FieldLayout {
+                        width: Some(2),
+                        ..Default::default()
+                    },
+                    description: Some("Calculated from class and Constitution".to_string()),
+                    placeholder: None,
+                },
+                FieldDefinition {
+                    id: "TEMP_HP".to_string(),
+                    label: "Temp HP".to_string(),
+                    field_type: SchemaFieldType::Integer {
+                        min: Some(0),
+                        max: None,
+                        show_modifier: false,
+                    },
+                    editable: true,
+                    required: false,
+                    derived_from: None,
+                    validation: None,
+                    layout: FieldLayout {
+                        width: Some(2),
+                        ..Default::default()
+                    },
+                    description: None,
+                    placeholder: None,
+                },
+                FieldDefinition {
+                    id: "AC".to_string(),
+                    label: "Armor Class".to_string(),
+                    field_type: SchemaFieldType::Integer {
+                        min: Some(1),
+                        max: None,
+                        show_modifier: false,
+                    },
+                    editable: true,
+                    required: false,
+                    derived_from: None,
+                    validation: None,
+                    layout: FieldLayout {
+                        width: Some(2),
+                        new_row: true,
+                        ..Default::default()
+                    },
+                    description: Some("Depends on armor and Dexterity".to_string()),
+                    placeholder: None,
+                },
+                FieldDefinition {
+                    id: "INITIATIVE".to_string(),
+                    label: "Initiative".to_string(),
+                    field_type: SchemaFieldType::Integer {
+                        min: None,
+                        max: None,
+                        show_modifier: true,
+                    },
+                    editable: false,
+                    required: false,
+                    derived_from: Some(DerivedField {
+                        derivation_type: DerivationType::AbilityModifier,
+                        dependencies: vec!["DEX".to_string()],
+                        display_format: Some("+{}".to_string()),
+                    }),
+                    validation: None,
+                    layout: FieldLayout {
+                        width: Some(2),
+                        ..Default::default()
+                    },
+                    description: Some("Based on Dexterity modifier".to_string()),
+                    placeholder: None,
+                },
+                FieldDefinition {
+                    id: "SPEED".to_string(),
+                    label: "Speed".to_string(),
+                    field_type: SchemaFieldType::Integer {
+                        min: Some(0),
+                        max: None,
+                        show_modifier: false,
+                    },
+                    editable: true,
+                    required: false,
+                    derived_from: None,
+                    validation: None,
+                    layout: FieldLayout {
+                        width: Some(2),
+                        ..Default::default()
+                    },
+                    description: Some("Movement speed in feet".to_string()),
+                    placeholder: Some("30".to_string()),
+                },
+                FieldDefinition {
+                    id: "PASSIVE_PERCEPTION".to_string(),
+                    label: "Passive Perception".to_string(),
+                    field_type: SchemaFieldType::Integer {
+                        min: None,
+                        max: None,
+                        show_modifier: false,
+                    },
+                    editable: false,
+                    required: false,
+                    derived_from: Some(DerivedField {
+                        derivation_type: DerivationType::Custom,
+                        dependencies: vec!["WIS".to_string(), "PERCEPTION_PROF".to_string()],
+                        display_format: None,
+                    }),
+                    validation: None,
+                    layout: FieldLayout {
+                        width: Some(2),
+                        ..Default::default()
+                    },
+                    description: Some("10 + Perception modifier".to_string()),
+                    placeholder: None,
+                },
+            ],
+            collapsible: false,
+            collapsed_default: false,
+            description: None,
+        }
+    }
+
+    fn skills_section(&self) -> SchemaSection {
+        let skill_abilities: Vec<(&str, &str)> = vec![
+            ("Acrobatics", "DEX"),
+            ("Animal Handling", "WIS"),
+            ("Arcana", "INT"),
+            ("Athletics", "STR"),
+            ("Deception", "CHA"),
+            ("History", "INT"),
+            ("Insight", "WIS"),
+            ("Intimidation", "CHA"),
+            ("Investigation", "INT"),
+            ("Medicine", "WIS"),
+            ("Nature", "INT"),
+            ("Perception", "WIS"),
+            ("Performance", "CHA"),
+            ("Persuasion", "CHA"),
+            ("Religion", "INT"),
+            ("Sleight of Hand", "DEX"),
+            ("Stealth", "DEX"),
+            ("Survival", "WIS"),
+        ];
+
+        let proficiency_options = vec![
+            ProficiencyOption {
+                value: "none".to_string(),
+                label: "Not Proficient".to_string(),
+                multiplier: 0.0,
+            },
+            ProficiencyOption {
+                value: "half".to_string(),
+                label: "Half (Jack of All Trades)".to_string(),
+                multiplier: 0.5,
+            },
+            ProficiencyOption {
+                value: "proficient".to_string(),
+                label: "Proficient".to_string(),
+                multiplier: 1.0,
+            },
+            ProficiencyOption {
+                value: "expert".to_string(),
+                label: "Expertise".to_string(),
+                multiplier: 2.0,
+            },
+        ];
+
+        let fields: Vec<FieldDefinition> = skill_abilities
+            .iter()
+            .map(|(skill, ability)| {
+                let skill_id = skill.to_uppercase().replace(' ', "_");
+                FieldDefinition {
+                    id: format!("{}_PROF", skill_id),
+                    label: skill.to_string(),
+                    field_type: SchemaFieldType::Skill {
+                        ability: ability.to_string(),
+                        proficiency_levels: proficiency_options.clone(),
+                    },
+                    editable: true,
+                    required: false,
+                    derived_from: None,
+                    validation: None,
+                    layout: FieldLayout {
+                        width: Some(6),
+                        ..Default::default()
+                    },
+                    description: Some(format!("Based on {}", ability)),
+                    placeholder: None,
+                }
+            })
+            .collect();
+
+        SchemaSection {
+            id: "skills".to_string(),
+            label: "Skills".to_string(),
+            section_type: SectionType::Skills,
+            fields,
+            collapsible: true,
+            collapsed_default: false,
+            description: Some("Choose your skill proficiencies".to_string()),
+        }
+    }
+
+    fn saving_throws_section(&self) -> SchemaSection {
+        let abilities = ["STR", "DEX", "CON", "INT", "WIS", "CHA"];
+        let ability_names = [
+            "Strength",
+            "Dexterity",
+            "Constitution",
+            "Intelligence",
+            "Wisdom",
+            "Charisma",
+        ];
+
+        let fields: Vec<FieldDefinition> = abilities
+            .iter()
+            .zip(ability_names.iter())
+            .map(|(id, name)| FieldDefinition {
+                id: format!("{}_SAVE_PROF", id),
+                label: format!("{} Save", name),
+                field_type: SchemaFieldType::SavingThrow {
+                    ability: id.to_string(),
+                },
+                editable: true,
+                required: false,
+                derived_from: None,
+                validation: None,
+                layout: FieldLayout {
+                    width: Some(4),
+                    ..Default::default()
+                },
+                description: None,
+                placeholder: None,
+            })
+            .collect();
+
+        SchemaSection {
+            id: "saving_throws".to_string(),
+            label: "Saving Throws".to_string(),
+            section_type: SectionType::Combat,
+            fields,
+            collapsible: true,
+            collapsed_default: true,
+            description: Some("Mark proficient saves from your class".to_string()),
+        }
+    }
+
+    fn features_section(&self) -> SchemaSection {
+        SchemaSection {
+            id: "features".to_string(),
+            label: "Features & Traits".to_string(),
+            section_type: SectionType::Features,
+            fields: vec![
+                FieldDefinition {
+                    id: "FEATURES".to_string(),
+                    label: "Features & Traits".to_string(),
+                    field_type: SchemaFieldType::Text {
+                        multiline: true,
+                        max_length: None,
+                    },
+                    editable: true,
+                    required: false,
+                    derived_from: None,
+                    validation: None,
+                    layout: FieldLayout {
+                        width: Some(12),
+                        ..Default::default()
+                    },
+                    description: Some("Class features, racial traits, feats, etc.".to_string()),
+                    placeholder: Some("Enter your features and traits...".to_string()),
+                },
+            ],
+            collapsible: true,
+            collapsed_default: true,
+            description: None,
+        }
+    }
+}
+
+// Spell slot progression tables
+
+fn full_caster_slots(level: u8) -> HashMap<u8, u8> {
+    let slots: &[(u8, &[u8])] = &[
+        (1, &[2]),
+        (2, &[3]),
+        (3, &[4, 2]),
+        (4, &[4, 3]),
+        (5, &[4, 3, 2]),
+        (6, &[4, 3, 3]),
+        (7, &[4, 3, 3, 1]),
+        (8, &[4, 3, 3, 2]),
+        (9, &[4, 3, 3, 3, 1]),
+        (10, &[4, 3, 3, 3, 2]),
+        (11, &[4, 3, 3, 3, 2, 1]),
+        (12, &[4, 3, 3, 3, 2, 1]),
+        (13, &[4, 3, 3, 3, 2, 1, 1]),
+        (14, &[4, 3, 3, 3, 2, 1, 1]),
+        (15, &[4, 3, 3, 3, 2, 1, 1, 1]),
+        (16, &[4, 3, 3, 3, 2, 1, 1, 1]),
+        (17, &[4, 3, 3, 3, 2, 1, 1, 1, 1]),
+        (18, &[4, 3, 3, 3, 3, 1, 1, 1, 1]),
+        (19, &[4, 3, 3, 3, 3, 2, 1, 1, 1]),
+        (20, &[4, 3, 3, 3, 3, 2, 2, 1, 1]),
+    ];
+
+    slots
+        .iter()
+        .find(|(l, _)| *l == level)
+        .map(|(_, s)| {
+            s.iter()
+                .enumerate()
+                .map(|(i, &count)| ((i + 1) as u8, count))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn half_caster_slots(level: u8) -> HashMap<u8, u8> {
+    // Half casters get slots at half rate (starting at level 2)
+    let slots: &[(u8, &[u8])] = &[
+        (2, &[2]),
+        (3, &[3]),
+        (4, &[3]),
+        (5, &[4, 2]),
+        (6, &[4, 2]),
+        (7, &[4, 3]),
+        (8, &[4, 3]),
+        (9, &[4, 3, 2]),
+        (10, &[4, 3, 2]),
+        (11, &[4, 3, 3]),
+        (12, &[4, 3, 3]),
+        (13, &[4, 3, 3, 1]),
+        (14, &[4, 3, 3, 1]),
+        (15, &[4, 3, 3, 2]),
+        (16, &[4, 3, 3, 2]),
+        (17, &[4, 3, 3, 3, 1]),
+        (18, &[4, 3, 3, 3, 1]),
+        (19, &[4, 3, 3, 3, 2]),
+        (20, &[4, 3, 3, 3, 2]),
+    ];
+
+    slots
+        .iter()
+        .find(|(l, _)| *l == level)
+        .map(|(_, s)| {
+            s.iter()
+                .enumerate()
+                .map(|(i, &count)| ((i + 1) as u8, count))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn third_caster_slots(level: u8) -> HashMap<u8, u8> {
+    // Third casters (Eldritch Knight, Arcane Trickster)
+    let slots: &[(u8, &[u8])] = &[
+        (3, &[2]),
+        (4, &[3]),
+        (5, &[3]),
+        (6, &[3]),
+        (7, &[4, 2]),
+        (8, &[4, 2]),
+        (9, &[4, 2]),
+        (10, &[4, 3]),
+        (11, &[4, 3]),
+        (12, &[4, 3]),
+        (13, &[4, 3, 2]),
+        (14, &[4, 3, 2]),
+        (15, &[4, 3, 2]),
+        (16, &[4, 3, 3]),
+        (17, &[4, 3, 3]),
+        (18, &[4, 3, 3]),
+        (19, &[4, 3, 3, 1]),
+        (20, &[4, 3, 3, 1]),
+    ];
+
+    slots
+        .iter()
+        .find(|(l, _)| *l == level)
+        .map(|(_, s)| {
+            s.iter()
+                .enumerate()
+                .map(|(i, &count)| ((i + 1) as u8, count))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn warlock_slots(level: u8) -> HashMap<u8, u8> {
+    // Warlock pact magic - fewer slots but higher level
+    let (count, slot_level) = match level {
+        1 => (1, 1),
+        2 => (2, 1),
+        3..=4 => (2, 2),
+        5..=6 => (2, 3),
+        7..=8 => (2, 4),
+        9..=10 => (2, 5),
+        11..=16 => (3, 5),
+        17..=20 => (4, 5),
+        _ => (0, 0),
+    };
+
+    if count > 0 {
+        let mut slots = HashMap::new();
+        slots.insert(slot_level, count);
+        slots
+    } else {
+        HashMap::new()
+    }
+}
+
+// Spells known tables (0-indexed, level 1 = index 1)
+const SORCERER_SPELLS_KNOWN: &[u8] = &[
+    0, // level 0 (unused)
+    2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 12, 13, 13, 14, 14, 15, 15, 15, 15,
+];
+
+const BARD_SPELLS_KNOWN: &[u8] = &[
+    0, // level 0
+    4, 5, 6, 7, 8, 9, 10, 11, 12, 14, 15, 15, 16, 18, 19, 19, 20, 22, 22, 22,
+];
+
+const RANGER_SPELLS_KNOWN: &[u8] = &[
+    0, // level 0
+    0, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10, 11, 11,
+];
+
+const WARLOCK_SPELLS_KNOWN: &[u8] = &[
+    0, // level 0
+    2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 11, 11, 12, 12, 13, 13, 14, 14, 15, 15,
+];
+
+const ELDRITCH_KNIGHT_SPELLS_KNOWN: &[u8] = &[
+    0, // level 0
+    0, 0, 3, 4, 4, 4, 5, 6, 6, 7, 8, 8, 9, 10, 10, 11, 11, 11, 12, 13,
+];
+
+const ARCANE_TRICKSTER_SPELLS_KNOWN: &[u8] = &[
+    0, // level 0
+    0, 0, 3, 4, 4, 4, 5, 6, 6, 7, 8, 8, 9, 10, 10, 11, 11, 11, 12, 13,
+];
+
+/// Get the skill's associated ability for D&D 5e.
+pub fn skill_ability(skill: &str) -> Option<&'static str> {
+    match skill.to_lowercase().as_str() {
+        "athletics" => Some("STR"),
+        "acrobatics" | "sleight of hand" | "stealth" => Some("DEX"),
+        "arcana" | "history" | "investigation" | "nature" | "religion" => Some("INT"),
+        "animal handling" | "insight" | "medicine" | "perception" | "survival" => Some("WIS"),
+        "deception" | "intimidation" | "performance" | "persuasion" => Some("CHA"),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn create_test_stats() -> StatBlock {
+        let mut stats = StatBlock::default();
+        stats.set_stat("STR", 16);
+        stats.set_stat("DEX", 14);
+        stats.set_stat("CON", 14);
+        stats.set_stat("INT", 10);
+        stats.set_stat("WIS", 12);
+        stats.set_stat("CHA", 8);
+        stats.set_stat("LEVEL", 5);
+        stats
+    }
+
+    #[test]
+    fn ability_modifier_calculation() {
+        let system = Dnd5eSystem::new();
+        assert_eq!(system.ability_modifier(1), -5);
+        assert_eq!(system.ability_modifier(8), -1);
+        assert_eq!(system.ability_modifier(10), 0);
+        assert_eq!(system.ability_modifier(11), 0);
+        assert_eq!(system.ability_modifier(12), 1);
+        assert_eq!(system.ability_modifier(14), 2);
+        assert_eq!(system.ability_modifier(16), 3);
+        assert_eq!(system.ability_modifier(18), 4);
+        assert_eq!(system.ability_modifier(20), 5);
+    }
+
+    #[test]
+    fn proficiency_bonus_progression() {
+        let system = Dnd5eSystem::new();
+        assert_eq!(system.proficiency_bonus(1), 2);
+        assert_eq!(system.proficiency_bonus(4), 2);
+        assert_eq!(system.proficiency_bonus(5), 3);
+        assert_eq!(system.proficiency_bonus(8), 3);
+        assert_eq!(system.proficiency_bonus(9), 4);
+        assert_eq!(system.proficiency_bonus(12), 4);
+        assert_eq!(system.proficiency_bonus(13), 5);
+        assert_eq!(system.proficiency_bonus(16), 5);
+        assert_eq!(system.proficiency_bonus(17), 6);
+        assert_eq!(system.proficiency_bonus(20), 6);
+    }
+
+    #[test]
+    fn spell_save_dc_calculation() {
+        let system = Dnd5eSystem::new();
+        let stats = create_test_stats(); // Level 5, WIS 12
+
+        // DC = 8 + proficiency (3) + WIS mod (1) = 12
+        assert_eq!(system.spell_save_dc(&stats, "WIS"), 12);
+
+        // DC with INT = 8 + 3 + 0 = 11
+        assert_eq!(system.spell_save_dc(&stats, "INT"), 11);
+    }
+
+    #[test]
+    fn spell_attack_bonus_calculation() {
+        let system = Dnd5eSystem::new();
+        let stats = create_test_stats();
+
+        // Attack = proficiency (3) + WIS mod (1) = 4
+        assert_eq!(system.spell_attack_bonus(&stats, "WIS"), 4);
+    }
+
+    #[test]
+    fn ac_calculation_unarmored() {
+        let system = Dnd5eSystem::new();
+        let stats = create_test_stats(); // DEX 14
+
+        // Unarmored: 10 + DEX mod (2) = 12
+        assert_eq!(system.calculate_ac(&stats, None, None, true, None), 12);
+
+        // With shield (+2): 12 + 2 = 14
+        assert_eq!(system.calculate_ac(&stats, None, Some(2), true, None), 14);
+    }
+
+    #[test]
+    fn ac_calculation_armored() {
+        let system = Dnd5eSystem::new();
+        let stats = create_test_stats(); // DEX 14
+
+        // Chain mail (AC 16, no DEX): 16
+        assert_eq!(system.calculate_ac(&stats, Some(16), None, false, None), 16);
+
+        // Half plate (AC 15, max DEX +2): 15 + 2 = 17
+        assert_eq!(
+            system.calculate_ac(&stats, Some(15), None, true, Some(2)),
+            17
+        );
+
+        // Leather (AC 11 + DEX): 11 + 2 = 13
+        assert_eq!(system.calculate_ac(&stats, Some(11), None, true, None), 13);
+    }
+
+    #[test]
+    fn skill_modifier_with_proficiency() {
+        let system = Dnd5eSystem::new();
+        let stats = create_test_stats(); // Level 5, DEX 14
+
+        // No proficiency: just DEX mod (2)
+        assert_eq!(
+            system.skill_modifier(&stats, "DEX", ProficiencyLevel::None),
+            2
+        );
+
+        // Proficient: DEX mod (2) + proficiency (3) = 5
+        assert_eq!(
+            system.skill_modifier(&stats, "DEX", ProficiencyLevel::Proficient),
+            5
+        );
+
+        // Expertise: DEX mod (2) + double proficiency (6) = 8
+        assert_eq!(
+            system.skill_modifier(&stats, "DEX", ProficiencyLevel::Expert),
+            8
+        );
+
+        // Jack of All Trades: DEX mod (2) + half proficiency (1) = 3
+        assert_eq!(
+            system.skill_modifier(&stats, "DEX", ProficiencyLevel::Half),
+            3
+        );
+    }
+
+    #[test]
+    fn passive_perception() {
+        let system = Dnd5eSystem::new();
+        let stats = create_test_stats(); // WIS 12
+
+        // 10 + WIS mod (1) = 11
+        assert_eq!(
+            system.passive_perception(&stats, ProficiencyLevel::None),
+            11
+        );
+
+        // 10 + WIS mod (1) + proficiency (3) = 14
+        assert_eq!(
+            system.passive_perception(&stats, ProficiencyLevel::Proficient),
+            14
+        );
+    }
+
+    #[test]
+    fn hit_die_by_class() {
+        let system = Dnd5eSystem::new();
+        assert_eq!(system.hit_die("barbarian"), 12);
+        assert_eq!(system.hit_die("fighter"), 10);
+        assert_eq!(system.hit_die("cleric"), 8);
+        assert_eq!(system.hit_die("wizard"), 6);
+    }
+
+    #[test]
+    fn max_hp_calculation() {
+        let system = Dnd5eSystem::new();
+
+        // Level 1 Fighter, +2 CON: 10 + 2 = 12
+        assert_eq!(system.calculate_max_hp(1, "fighter", 2, 0), 12);
+
+        // Level 5 Fighter, +2 CON:
+        // Level 1: 10 + 2 = 12
+        // Levels 2-5: 4 levels * (6 + 2) = 32
+        // Total: 44
+        assert_eq!(system.calculate_max_hp(5, "fighter", 2, 0), 44);
+
+        // With Tough feat (+10 at level 5)
+        assert_eq!(system.calculate_max_hp(5, "fighter", 2, 10), 54);
+    }
+
+    #[test]
+    fn spellcasting_stat_by_class() {
+        let system = Dnd5eSystem::new();
+        assert_eq!(system.spellcasting_stat("wizard"), Some("INT"));
+        assert_eq!(system.spellcasting_stat("cleric"), Some("WIS"));
+        assert_eq!(system.spellcasting_stat("sorcerer"), Some("CHA"));
+        assert_eq!(system.spellcasting_stat("paladin"), Some("CHA"));
+        assert_eq!(system.spellcasting_stat("fighter"), None);
+    }
+
+    #[test]
+    fn full_caster_spell_slots() {
+        let system = Dnd5eSystem::new();
+
+        let level1 = system.spell_slots("wizard", 1);
+        assert_eq!(level1.get(&1), Some(&2));
+        assert_eq!(level1.get(&2), None);
+
+        let level5 = system.spell_slots("wizard", 5);
+        assert_eq!(level5.get(&1), Some(&4));
+        assert_eq!(level5.get(&2), Some(&3));
+        assert_eq!(level5.get(&3), Some(&2));
+
+        let level20 = system.spell_slots("wizard", 20);
+        assert_eq!(level20.get(&9), Some(&1));
+    }
+
+    #[test]
+    fn half_caster_spell_slots() {
+        let system = Dnd5eSystem::new();
+
+        // Paladins don't get slots until level 2
+        let level1 = system.spell_slots("paladin", 1);
+        assert!(level1.is_empty());
+
+        let level2 = system.spell_slots("paladin", 2);
+        assert_eq!(level2.get(&1), Some(&2));
+
+        let level5 = system.spell_slots("paladin", 5);
+        assert_eq!(level5.get(&1), Some(&4));
+        assert_eq!(level5.get(&2), Some(&2));
+    }
+
+    #[test]
+    fn warlock_pact_slots() {
+        let system = Dnd5eSystem::new();
+
+        let level1 = system.spell_slots("warlock", 1);
+        assert_eq!(level1.get(&1), Some(&1));
+
+        let level5 = system.spell_slots("warlock", 5);
+        assert_eq!(level5.get(&3), Some(&2)); // 2 third-level slots
+
+        let level11 = system.spell_slots("warlock", 11);
+        assert_eq!(level11.get(&5), Some(&3)); // 3 fifth-level slots
+    }
+
+    #[test]
+    fn cantrips_known() {
+        let system = Dnd5eSystem::new();
+        assert_eq!(system.cantrips_known("wizard", 1), 3);
+        assert_eq!(system.cantrips_known("wizard", 4), 4);
+        assert_eq!(system.cantrips_known("wizard", 10), 5);
+    }
+
+    #[test]
+    fn spells_known_by_class() {
+        let system = Dnd5eSystem::new();
+        assert_eq!(system.spells_known("sorcerer", 1), Some(2));
+        assert_eq!(system.spells_known("sorcerer", 5), Some(6));
+        assert_eq!(system.spells_known("wizard", 1), None); // Prepared caster
+    }
+
+    #[test]
+    fn max_prepared_spells() {
+        let system = Dnd5eSystem::new();
+        // Wizard level 5, INT 16 (+3): 5 + 3 = 8
+        assert_eq!(system.max_prepared_spells("wizard", 5, 3), 8);
+
+        // Paladin level 6, CHA 14 (+2): 3 + 2 = 5
+        assert_eq!(system.max_prepared_spells("paladin", 6, 2), 5);
+
+        // Minimum is 1
+        assert_eq!(system.max_prepared_spells("wizard", 1, -3), 1);
+    }
+
+    #[test]
+    fn skill_ability_mapping() {
+        assert_eq!(skill_ability("Athletics"), Some("STR"));
+        assert_eq!(skill_ability("Stealth"), Some("DEX"));
+        assert_eq!(skill_ability("Arcana"), Some("INT"));
+        assert_eq!(skill_ability("Perception"), Some("WIS"));
+        assert_eq!(skill_ability("Persuasion"), Some("CHA"));
+    }
+
+    #[test]
+    fn caster_type_identification() {
+        let system = Dnd5eSystem::new();
+        assert_eq!(system.caster_type("wizard"), Some(CasterType::Full));
+        assert_eq!(system.caster_type("paladin"), Some(CasterType::Half));
+        assert_eq!(system.caster_type("warlock"), Some(CasterType::Pact));
+        assert_eq!(
+            system.caster_type("eldritch knight"),
+            Some(CasterType::Third)
+        );
+        assert_eq!(system.caster_type("fighter"), None);
+    }
+}

--- a/crates/domain/src/game_systems/fate_core.rs
+++ b/crates/domain/src/game_systems/fate_core.rs
@@ -371,6 +371,7 @@ impl CharacterSheetProvider for FateCoreSystem {
                 self.stress_section(),
                 self.consequences_section(),
                 self.resources_section(),
+                self.modifiers_section(),
             ],
             creation_steps: vec![
                 CreationStep {
@@ -1090,6 +1091,36 @@ impl FateCoreSystem {
             collapsible: false,
             collapsed_default: false,
             description: Some("Fate points let you invoke aspects for bonuses or trigger certain stunts.".to_string()),
+        }
+    }
+
+    fn modifiers_section(&self) -> SchemaSection {
+        SchemaSection {
+            id: "modifiers".to_string(),
+            label: "Active Effects".to_string(),
+            section_type: SectionType::Modifiers,
+            fields: vec![
+                FieldDefinition {
+                    id: "ACTIVE_MODIFIERS".to_string(),
+                    label: "Situational Aspects & Boosts".to_string(),
+                    field_type: SchemaFieldType::ModifierList { filter_stat: None },
+                    editable: false,
+                    required: false,
+                    derived_from: None,
+                    validation: None,
+                    layout: FieldLayout {
+                        width: Some(12),
+                        ..Default::default()
+                    },
+                    description: Some(
+                        "Active situational aspects, boosts, and temporary effects affecting your rolls.".to_string(),
+                    ),
+                    placeholder: None,
+                },
+            ],
+            collapsible: true,
+            collapsed_default: false,
+            description: Some("Aspects can be invoked for +2 or reroll. Boosts are free invokes that disappear after use. Consequences are negative aspects that can be compelled.".to_string()),
         }
     }
 }

--- a/crates/domain/src/game_systems/fate_core.rs
+++ b/crates/domain/src/game_systems/fate_core.rs
@@ -1,0 +1,1383 @@
+//! FATE Core game system implementation.
+//!
+//! FATE uses 4dF (Fudge dice) + skill vs difficulty.
+//! Key features:
+//! - Ladder-based results (-2 to +8)
+//! - Aspects as central mechanic
+//! - Fate Points for narrative control
+//! - Stress and Consequences instead of HP
+//! - Four actions: Overcome, Create Advantage, Attack, Defend
+
+use super::traits::{
+    CalculationEngine, CharacterSheetProvider, CharacterSheetSchema, CreationStep, DerivedField,
+    DerivationType, FieldDefinition, FieldLayout, FieldValidation, GameSystem, LadderLabel,
+    ProficiencyLevel, ResourceColor, SchemaFieldType, SchemaSection, SectionType,
+};
+use crate::entities::{StatBlock, StatModifier};
+use std::collections::HashMap;
+
+/// FATE ladder value to descriptor mapping.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum LadderRating {
+    Terrible = -2,
+    Poor = -1,
+    Mediocre = 0,
+    Average = 1,
+    Fair = 2,
+    Good = 3,
+    Great = 4,
+    Superb = 5,
+    Fantastic = 6,
+    Epic = 7,
+    Legendary = 8,
+}
+
+impl LadderRating {
+    pub fn from_value(value: i32) -> Option<Self> {
+        match value {
+            -2 => Some(LadderRating::Terrible),
+            -1 => Some(LadderRating::Poor),
+            0 => Some(LadderRating::Mediocre),
+            1 => Some(LadderRating::Average),
+            2 => Some(LadderRating::Fair),
+            3 => Some(LadderRating::Good),
+            4 => Some(LadderRating::Great),
+            5 => Some(LadderRating::Superb),
+            6 => Some(LadderRating::Fantastic),
+            7 => Some(LadderRating::Epic),
+            8 => Some(LadderRating::Legendary),
+            _ => None,
+        }
+    }
+
+    pub fn descriptor(&self) -> &'static str {
+        match self {
+            LadderRating::Terrible => "Terrible",
+            LadderRating::Poor => "Poor",
+            LadderRating::Mediocre => "Mediocre",
+            LadderRating::Average => "Average",
+            LadderRating::Fair => "Fair",
+            LadderRating::Good => "Good",
+            LadderRating::Great => "Great",
+            LadderRating::Superb => "Superb",
+            LadderRating::Fantastic => "Fantastic",
+            LadderRating::Epic => "Epic",
+            LadderRating::Legendary => "Legendary",
+        }
+    }
+}
+
+/// FATE roll outcome.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FateOutcome {
+    /// Shifts >= 3
+    SuccessWithStyle { shifts: i32 },
+    /// Shifts 1-2
+    Success { shifts: i32 },
+    /// Shifts = 0
+    Tie,
+    /// Shifts < 0
+    Failure { shifts: i32 },
+}
+
+impl FateOutcome {
+    /// Determine outcome from roll total vs difficulty.
+    pub fn determine(total: i32, difficulty: i32) -> Self {
+        let shifts = total - difficulty;
+        if shifts >= 3 {
+            FateOutcome::SuccessWithStyle { shifts }
+        } else if shifts >= 1 {
+            FateOutcome::Success { shifts }
+        } else if shifts == 0 {
+            FateOutcome::Tie
+        } else {
+            FateOutcome::Failure { shifts }
+        }
+    }
+
+    pub fn is_success(&self) -> bool {
+        matches!(self, FateOutcome::SuccessWithStyle { .. } | FateOutcome::Success { .. })
+    }
+}
+
+/// Consequence severity in FATE.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConsequenceSeverity {
+    /// Absorbs 2 shifts, clears after scene
+    Mild,
+    /// Absorbs 4 shifts, clears after session
+    Moderate,
+    /// Absorbs 6 shifts, clears after scenario
+    Severe,
+}
+
+impl ConsequenceSeverity {
+    pub fn shifts_absorbed(&self) -> i32 {
+        match self {
+            ConsequenceSeverity::Mild => 2,
+            ConsequenceSeverity::Moderate => 4,
+            ConsequenceSeverity::Severe => 6,
+        }
+    }
+}
+
+/// Type of aspect invocation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InvokeType {
+    /// +2 to roll
+    AddTwo,
+    /// Reroll all 4dF
+    Reroll,
+}
+
+/// FATE Core game system.
+pub struct FateCoreSystem {
+    stat_names: Vec<&'static str>,
+    skill_names: Vec<&'static str>,
+}
+
+impl FateCoreSystem {
+    pub fn new() -> Self {
+        Self {
+            // FATE Core uses skills, not stats
+            // But we can map approaches for FATE Accelerated
+            stat_names: vec![],
+            skill_names: vec![
+                "Athletics",
+                "Burglary",
+                "Contacts",
+                "Crafts",
+                "Deceive",
+                "Drive",
+                "Empathy",
+                "Fight",
+                "Investigate",
+                "Lore",
+                "Notice",
+                "Physique",
+                "Provoke",
+                "Rapport",
+                "Resources",
+                "Shoot",
+                "Stealth",
+                "Will",
+            ],
+        }
+    }
+
+    /// Create a FATE Accelerated variant.
+    pub fn accelerated() -> Self {
+        Self {
+            // FATE Accelerated uses approaches
+            stat_names: vec!["Careful", "Clever", "Flashy", "Forceful", "Quick", "Sneaky"],
+            skill_names: vec![],
+        }
+    }
+
+    /// Calculate stress boxes from skill rating.
+    pub fn stress_boxes_from_skill(skill_rating: i32) -> u8 {
+        // Base: 2 boxes
+        // +1 or +2 skill: 3 boxes
+        // +3 or +4 skill: 4 boxes
+        match skill_rating {
+            ..=0 => 2,
+            1..=2 => 3,
+            _ => 4,
+        }
+    }
+
+    /// Calculate refresh from stunt count.
+    pub fn calculate_refresh(stunt_count: u8, base_refresh: u8) -> u8 {
+        // Stunts beyond 3 reduce refresh
+        if stunt_count <= 3 {
+            base_refresh
+        } else {
+            base_refresh.saturating_sub(stunt_count - 3)
+        }
+    }
+
+    /// Validate skill pyramid.
+    pub fn validate_pyramid(skills: &[(String, i32)], max_rating: i32) -> Result<(), String> {
+        // Count skills at each level
+        let mut counts = std::collections::HashMap::new();
+        for (_, rating) in skills {
+            if *rating > 0 {
+                *counts.entry(*rating).or_insert(0) += 1;
+            }
+        }
+
+        // Verify pyramid: each level must have >= skills than level above
+        for level in (2..=max_rating).rev() {
+            let count_at_level = counts.get(&level).copied().unwrap_or(0);
+            let count_below = counts.get(&(level - 1)).copied().unwrap_or(0);
+
+            if count_below < count_at_level {
+                return Err(format!(
+                    "Invalid pyramid: {} skills at +{} but only {} at +{}",
+                    count_at_level, level, count_below, level - 1
+                ));
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl Default for FateCoreSystem {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl GameSystem for FateCoreSystem {
+    fn system_id(&self) -> &str {
+        "fate_core"
+    }
+
+    fn display_name(&self) -> &str {
+        "FATE Core"
+    }
+
+    fn calculation_engine(&self) -> &dyn CalculationEngine {
+        self
+    }
+
+    fn stat_names(&self) -> &[&str] {
+        &self.stat_names
+    }
+
+    fn skill_names(&self) -> &[&str] {
+        &self.skill_names
+    }
+}
+
+impl CalculationEngine for FateCoreSystem {
+    fn ability_modifier(&self, score: i32) -> i32 {
+        // In FATE, skills ARE the modifier (ladder value)
+        score
+    }
+
+    fn proficiency_bonus(&self, _level: u8) -> i32 {
+        // FATE has no proficiency system
+        0
+    }
+
+    fn spell_save_dc(&self, _stats: &StatBlock, _casting_stat: &str) -> i32 {
+        // FATE doesn't use spell DCs - magic is handled narratively
+        // or through Create Advantage actions
+        0
+    }
+
+    fn spell_attack_bonus(&self, _stats: &StatBlock, _casting_stat: &str) -> i32 {
+        // FATE magic typically uses a skill like Lore
+        0
+    }
+
+    fn attack_bonus(&self, stats: &StatBlock, attack_skill: &str, _proficient: bool) -> i32 {
+        // Return the skill rating directly
+        stats.get_stat(attack_skill).unwrap_or(0)
+    }
+
+    fn stack_modifiers(&self, modifiers: &[StatModifier]) -> i32 {
+        // In FATE, most bonuses don't stack
+        // Aspect invocations are +2 each but usually limited
+        // Take highest bonus, all penalties stack
+        let max_bonus = modifiers
+            .iter()
+            .filter(|m| m.active && m.value > 0)
+            .map(|m| m.value)
+            .max()
+            .unwrap_or(0);
+
+        let total_penalties: i32 = modifiers
+            .iter()
+            .filter(|m| m.active && m.value < 0)
+            .map(|m| m.value)
+            .sum();
+
+        max_bonus + total_penalties
+    }
+
+    fn calculate_ac(
+        &self,
+        stats: &StatBlock,
+        _armor_ac: Option<i32>,
+        _shield_bonus: Option<i32>,
+        _allows_dex: bool,
+        _max_dex_bonus: Option<i32>,
+    ) -> i32 {
+        // FATE uses Athletics or Fight for defense
+        stats.get_stat("Athletics").unwrap_or(0)
+    }
+
+    fn skill_modifier(
+        &self,
+        stats: &StatBlock,
+        skill: &str,
+        _proficiency_level: ProficiencyLevel,
+    ) -> i32 {
+        // Return skill rating directly
+        stats.get_stat(skill).unwrap_or(0)
+    }
+
+    fn saving_throw_modifier(
+        &self,
+        stats: &StatBlock,
+        ability: &str,
+        _proficient: bool,
+    ) -> i32 {
+        // FATE uses skills for defense
+        // Physique for physical, Will for mental
+        match ability {
+            "STR" | "DEX" | "CON" => stats.get_stat("Physique").unwrap_or(0),
+            "INT" | "WIS" | "CHA" => stats.get_stat("Will").unwrap_or(0),
+            _ => stats.get_stat(ability).unwrap_or(0),
+        }
+    }
+
+    fn passive_perception(&self, stats: &StatBlock, _proficiency_level: ProficiencyLevel) -> i32 {
+        // FATE uses Notice skill
+        stats.get_stat("Notice").unwrap_or(0)
+    }
+
+    fn hit_die(&self, _class_name: &str) -> u8 {
+        // FATE doesn't use hit dice
+        0
+    }
+
+    fn calculate_max_hp(
+        &self,
+        _level: u8,
+        _class_name: &str,
+        _constitution_modifier: i32,
+        _additional_hp: i32,
+    ) -> i32 {
+        // FATE uses stress boxes, not HP
+        // Return physical stress boxes (typically 2-4)
+        2
+    }
+}
+
+impl CharacterSheetProvider for FateCoreSystem {
+    fn character_sheet_schema(&self) -> CharacterSheetSchema {
+        CharacterSheetSchema {
+            system_id: "fate_core".to_string(),
+            system_name: "FATE Core".to_string(),
+            sections: vec![
+                self.identity_section(),
+                self.aspects_section(),
+                self.skills_section(),
+                self.stunts_section(),
+                self.stress_section(),
+                self.consequences_section(),
+                self.resources_section(),
+            ],
+            creation_steps: vec![
+                CreationStep {
+                    id: "identity".to_string(),
+                    label: "Identity".to_string(),
+                    description: "Name your character and write a brief description.".to_string(),
+                    section_ids: vec!["identity".to_string()],
+                    order: 1,
+                    required: true,
+                },
+                CreationStep {
+                    id: "aspects".to_string(),
+                    label: "Aspects".to_string(),
+                    description: "Define your High Concept, Trouble, and three additional aspects."
+                        .to_string(),
+                    section_ids: vec!["aspects".to_string()],
+                    order: 2,
+                    required: true,
+                },
+                CreationStep {
+                    id: "skills".to_string(),
+                    label: "Skills".to_string(),
+                    description: "Assign your skills using the skill pyramid.".to_string(),
+                    section_ids: vec!["skills".to_string()],
+                    order: 3,
+                    required: true,
+                },
+                CreationStep {
+                    id: "stunts".to_string(),
+                    label: "Stunts & Refresh".to_string(),
+                    description: "Choose up to 3 free stunts. Additional stunts reduce refresh."
+                        .to_string(),
+                    section_ids: vec!["stunts".to_string(), "resources".to_string()],
+                    order: 4,
+                    required: false,
+                },
+                CreationStep {
+                    id: "stress".to_string(),
+                    label: "Stress & Consequences".to_string(),
+                    description: "Calculate stress boxes based on Physique and Will.".to_string(),
+                    section_ids: vec!["stress".to_string(), "consequences".to_string()],
+                    order: 5,
+                    required: false,
+                },
+            ],
+        }
+    }
+
+    fn calculate_derived_values(
+        &self,
+        values: &HashMap<String, serde_json::Value>,
+    ) -> HashMap<String, serde_json::Value> {
+        let mut derived = HashMap::new();
+
+        // Calculate physical stress boxes based on Physique
+        let physique = values
+            .get("PHYSIQUE")
+            .and_then(|v| v.as_i64())
+            .unwrap_or(0) as i32;
+        let physical_stress_boxes = Self::stress_boxes_from_skill(physique);
+        derived.insert(
+            "PHYSICAL_STRESS_BOXES".to_string(),
+            serde_json::json!(physical_stress_boxes),
+        );
+
+        // Calculate mental stress boxes based on Will
+        let will = values
+            .get("WILL")
+            .and_then(|v| v.as_i64())
+            .unwrap_or(0) as i32;
+        let mental_stress_boxes = Self::stress_boxes_from_skill(will);
+        derived.insert(
+            "MENTAL_STRESS_BOXES".to_string(),
+            serde_json::json!(mental_stress_boxes),
+        );
+
+        // Calculate refresh based on stunt count
+        let stunt_count = self.count_stunts(values);
+        let base_refresh = values
+            .get("BASE_REFRESH")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(3) as u8;
+        let current_refresh = Self::calculate_refresh(stunt_count, base_refresh);
+        derived.insert("REFRESH".to_string(), serde_json::json!(current_refresh));
+
+        derived
+    }
+
+    fn validate_field(
+        &self,
+        field_id: &str,
+        value: &serde_json::Value,
+        _all_values: &HashMap<String, serde_json::Value>,
+    ) -> Option<String> {
+        // Validate skill ratings
+        if self.skill_names().iter().any(|s| s.to_uppercase() == field_id) {
+            if let Some(rating) = value.as_i64() {
+                if rating < -2 || rating > 8 {
+                    return Some("Skill rating must be between -2 (Terrible) and +8 (Legendary)".to_string());
+                }
+            } else {
+                return Some("Skill rating must be a number".to_string());
+            }
+        }
+
+        // Validate refresh
+        if field_id == "REFRESH" || field_id == "BASE_REFRESH" {
+            if let Some(refresh) = value.as_i64() {
+                if refresh < 1 {
+                    return Some("Refresh must be at least 1".to_string());
+                }
+            } else {
+                return Some("Refresh must be a number".to_string());
+            }
+        }
+
+        // Validate name
+        if field_id == "NAME" {
+            if let Some(name) = value.as_str() {
+                if name.is_empty() {
+                    return Some("Name is required".to_string());
+                }
+            } else {
+                return Some("Name must be a string".to_string());
+            }
+        }
+
+        // Validate high concept and trouble (required aspects)
+        if field_id == "HIGH_CONCEPT" || field_id == "TROUBLE" {
+            if let Some(aspect) = value.as_str() {
+                if aspect.is_empty() {
+                    return Some(format!("{} is required", field_id.replace('_', " ").to_lowercase()));
+                }
+            } else {
+                return Some("Aspect must be a string".to_string());
+            }
+        }
+
+        None
+    }
+
+    fn default_values(&self) -> HashMap<String, serde_json::Value> {
+        let mut defaults = HashMap::new();
+
+        // Identity
+        defaults.insert("NAME".to_string(), serde_json::json!(""));
+        defaults.insert("DESCRIPTION".to_string(), serde_json::json!(""));
+
+        // Aspects
+        defaults.insert("HIGH_CONCEPT".to_string(), serde_json::json!(""));
+        defaults.insert("TROUBLE".to_string(), serde_json::json!(""));
+        defaults.insert("ASPECT_1".to_string(), serde_json::json!(""));
+        defaults.insert("ASPECT_2".to_string(), serde_json::json!(""));
+        defaults.insert("ASPECT_3".to_string(), serde_json::json!(""));
+
+        // Skills - default to Mediocre (0)
+        for skill in self.skill_names() {
+            defaults.insert(skill.to_uppercase(), serde_json::json!(0));
+        }
+
+        // Stunts
+        defaults.insert("STUNT_1".to_string(), serde_json::json!(""));
+        defaults.insert("STUNT_2".to_string(), serde_json::json!(""));
+        defaults.insert("STUNT_3".to_string(), serde_json::json!(""));
+        defaults.insert("STUNT_4".to_string(), serde_json::json!(""));
+        defaults.insert("STUNT_5".to_string(), serde_json::json!(""));
+
+        // Stress (current values, not max)
+        defaults.insert("PHYSICAL_STRESS_1".to_string(), serde_json::json!(false));
+        defaults.insert("PHYSICAL_STRESS_2".to_string(), serde_json::json!(false));
+        defaults.insert("PHYSICAL_STRESS_3".to_string(), serde_json::json!(false));
+        defaults.insert("PHYSICAL_STRESS_4".to_string(), serde_json::json!(false));
+        defaults.insert("MENTAL_STRESS_1".to_string(), serde_json::json!(false));
+        defaults.insert("MENTAL_STRESS_2".to_string(), serde_json::json!(false));
+        defaults.insert("MENTAL_STRESS_3".to_string(), serde_json::json!(false));
+        defaults.insert("MENTAL_STRESS_4".to_string(), serde_json::json!(false));
+
+        // Consequences
+        defaults.insert("CONSEQUENCE_MILD".to_string(), serde_json::json!(""));
+        defaults.insert("CONSEQUENCE_MODERATE".to_string(), serde_json::json!(""));
+        defaults.insert("CONSEQUENCE_SEVERE".to_string(), serde_json::json!(""));
+
+        // Resources
+        defaults.insert("BASE_REFRESH".to_string(), serde_json::json!(3));
+        defaults.insert("CURRENT_FATE_POINTS".to_string(), serde_json::json!(3));
+
+        defaults
+    }
+}
+
+// Helper methods for building the schema
+impl FateCoreSystem {
+    /// Get the FATE ladder labels for skill ratings.
+    fn fate_ladder_labels() -> Vec<LadderLabel> {
+        vec![
+            LadderLabel { value: -2, label: "Terrible (-2)".to_string() },
+            LadderLabel { value: -1, label: "Poor (-1)".to_string() },
+            LadderLabel { value: 0, label: "Mediocre (+0)".to_string() },
+            LadderLabel { value: 1, label: "Average (+1)".to_string() },
+            LadderLabel { value: 2, label: "Fair (+2)".to_string() },
+            LadderLabel { value: 3, label: "Good (+3)".to_string() },
+            LadderLabel { value: 4, label: "Great (+4)".to_string() },
+            LadderLabel { value: 5, label: "Superb (+5)".to_string() },
+            LadderLabel { value: 6, label: "Fantastic (+6)".to_string() },
+            LadderLabel { value: 7, label: "Epic (+7)".to_string() },
+            LadderLabel { value: 8, label: "Legendary (+8)".to_string() },
+        ]
+    }
+
+    /// Count non-empty stunts.
+    fn count_stunts(&self, values: &HashMap<String, serde_json::Value>) -> u8 {
+        let mut count = 0;
+        for i in 1..=5 {
+            if let Some(stunt) = values.get(&format!("STUNT_{}", i)) {
+                if let Some(text) = stunt.as_str() {
+                    if !text.is_empty() {
+                        count += 1;
+                    }
+                }
+            }
+        }
+        count
+    }
+
+    fn identity_section(&self) -> SchemaSection {
+        SchemaSection {
+            id: "identity".to_string(),
+            label: "Identity".to_string(),
+            section_type: SectionType::Identity,
+            fields: vec![
+                FieldDefinition {
+                    id: "NAME".to_string(),
+                    label: "Character Name".to_string(),
+                    field_type: SchemaFieldType::Text {
+                        multiline: false,
+                        max_length: Some(100),
+                    },
+                    editable: true,
+                    required: true,
+                    derived_from: None,
+                    validation: None,
+                    layout: FieldLayout {
+                        width: Some(6),
+                        ..Default::default()
+                    },
+                    description: None,
+                    placeholder: Some("Enter character name".to_string()),
+                },
+                FieldDefinition {
+                    id: "DESCRIPTION".to_string(),
+                    label: "Description".to_string(),
+                    field_type: SchemaFieldType::Text {
+                        multiline: true,
+                        max_length: Some(1000),
+                    },
+                    editable: true,
+                    required: false,
+                    derived_from: None,
+                    validation: None,
+                    layout: FieldLayout {
+                        width: Some(12),
+                        new_row: true,
+                        ..Default::default()
+                    },
+                    description: Some("A brief description of your character".to_string()),
+                    placeholder: Some("Describe your character's appearance, background, or personality...".to_string()),
+                },
+            ],
+            collapsible: false,
+            collapsed_default: false,
+            description: None,
+        }
+    }
+
+    fn aspects_section(&self) -> SchemaSection {
+        SchemaSection {
+            id: "aspects".to_string(),
+            label: "Aspects".to_string(),
+            section_type: SectionType::Features,
+            fields: vec![
+                FieldDefinition {
+                    id: "HIGH_CONCEPT".to_string(),
+                    label: "High Concept".to_string(),
+                    field_type: SchemaFieldType::Text {
+                        multiline: false,
+                        max_length: Some(200),
+                    },
+                    editable: true,
+                    required: true,
+                    derived_from: None,
+                    validation: None,
+                    layout: FieldLayout {
+                        width: Some(12),
+                        ..Default::default()
+                    },
+                    description: Some("A phrase that sums up what your character is about - who they are and what they do.".to_string()),
+                    placeholder: Some("e.g., 'Hard-boiled Detective with a Heart of Gold'".to_string()),
+                },
+                FieldDefinition {
+                    id: "TROUBLE".to_string(),
+                    label: "Trouble".to_string(),
+                    field_type: SchemaFieldType::Text {
+                        multiline: false,
+                        max_length: Some(200),
+                    },
+                    editable: true,
+                    required: true,
+                    derived_from: None,
+                    validation: None,
+                    layout: FieldLayout {
+                        width: Some(12),
+                        new_row: true,
+                        ..Default::default()
+                    },
+                    description: Some("Something that complicates your character's existence - a weakness, rival, or obligation.".to_string()),
+                    placeholder: Some("e.g., 'The Mob Wants Me Dead'".to_string()),
+                },
+                FieldDefinition {
+                    id: "ASPECT_1".to_string(),
+                    label: "Aspect".to_string(),
+                    field_type: SchemaFieldType::Text {
+                        multiline: false,
+                        max_length: Some(200),
+                    },
+                    editable: true,
+                    required: false,
+                    derived_from: None,
+                    validation: None,
+                    layout: FieldLayout {
+                        width: Some(12),
+                        new_row: true,
+                        ..Default::default()
+                    },
+                    description: Some("An additional aspect describing your character.".to_string()),
+                    placeholder: Some("Enter an aspect...".to_string()),
+                },
+                FieldDefinition {
+                    id: "ASPECT_2".to_string(),
+                    label: "Aspect".to_string(),
+                    field_type: SchemaFieldType::Text {
+                        multiline: false,
+                        max_length: Some(200),
+                    },
+                    editable: true,
+                    required: false,
+                    derived_from: None,
+                    validation: None,
+                    layout: FieldLayout {
+                        width: Some(12),
+                        new_row: true,
+                        ..Default::default()
+                    },
+                    description: None,
+                    placeholder: Some("Enter an aspect...".to_string()),
+                },
+                FieldDefinition {
+                    id: "ASPECT_3".to_string(),
+                    label: "Aspect".to_string(),
+                    field_type: SchemaFieldType::Text {
+                        multiline: false,
+                        max_length: Some(200),
+                    },
+                    editable: true,
+                    required: false,
+                    derived_from: None,
+                    validation: None,
+                    layout: FieldLayout {
+                        width: Some(12),
+                        new_row: true,
+                        ..Default::default()
+                    },
+                    description: None,
+                    placeholder: Some("Enter an aspect...".to_string()),
+                },
+            ],
+            collapsible: false,
+            collapsed_default: false,
+            description: Some("Aspects are phrases that describe something unique or important about your character.".to_string()),
+        }
+    }
+
+    fn skills_section(&self) -> SchemaSection {
+        let ladder_labels = Self::fate_ladder_labels();
+
+        let fields: Vec<FieldDefinition> = self
+            .skill_names()
+            .iter()
+            .map(|skill| {
+                FieldDefinition {
+                    id: skill.to_uppercase(),
+                    label: skill.to_string(),
+                    field_type: SchemaFieldType::LadderRating {
+                        min: -2,
+                        max: 8,
+                        labels: ladder_labels.clone(),
+                    },
+                    editable: true,
+                    required: false,
+                    derived_from: None,
+                    validation: Some(FieldValidation {
+                        min: Some(-2),
+                        max: Some(8),
+                        pattern: None,
+                        error_message: Some("Rating must be between -2 and +8".to_string()),
+                    }),
+                    layout: FieldLayout {
+                        width: Some(6),
+                        ..Default::default()
+                    },
+                    description: None,
+                    placeholder: None,
+                }
+            })
+            .collect();
+
+        SchemaSection {
+            id: "skills".to_string(),
+            label: "Skills".to_string(),
+            section_type: SectionType::Skills,
+            fields,
+            collapsible: true,
+            collapsed_default: false,
+            description: Some("Rate your skills using the FATE ladder. Build a skill pyramid: 1 Great (+4), 2 Good (+3), 3 Fair (+2), 4 Average (+1).".to_string()),
+        }
+    }
+
+    fn stunts_section(&self) -> SchemaSection {
+        let mut fields = Vec::new();
+
+        for i in 1..=5 {
+            let required = i <= 3; // First 3 stunts are free
+            fields.push(FieldDefinition {
+                id: format!("STUNT_{}", i),
+                label: format!("Stunt {}", i),
+                field_type: SchemaFieldType::Text {
+                    multiline: true,
+                    max_length: Some(500),
+                },
+                editable: true,
+                required: false,
+                derived_from: None,
+                validation: None,
+                layout: FieldLayout {
+                    width: Some(12),
+                    new_row: true,
+                    ..Default::default()
+                },
+                description: if required {
+                    Some("Free stunt slot".to_string())
+                } else {
+                    Some("Additional stunt (costs 1 Refresh)".to_string())
+                },
+                placeholder: Some("Describe your stunt and its mechanical effect...".to_string()),
+            });
+        }
+
+        SchemaSection {
+            id: "stunts".to_string(),
+            label: "Stunts".to_string(),
+            section_type: SectionType::Features,
+            fields,
+            collapsible: true,
+            collapsed_default: false,
+            description: Some("Stunts are special abilities that give you a bonus in specific circumstances. You get 3 free stunts; additional stunts cost 1 Refresh each.".to_string()),
+        }
+    }
+
+    fn stress_section(&self) -> SchemaSection {
+        let mut fields = Vec::new();
+
+        // Physical stress boxes
+        fields.push(FieldDefinition {
+            id: "PHYSICAL_STRESS_BOXES".to_string(),
+            label: "Physical Stress Boxes".to_string(),
+            field_type: SchemaFieldType::Integer {
+                min: Some(2),
+                max: Some(4),
+                show_modifier: false,
+            },
+            editable: false,
+            required: false,
+            derived_from: Some(DerivedField {
+                derivation_type: DerivationType::Custom,
+                dependencies: vec!["PHYSIQUE".to_string()],
+                display_format: None,
+            }),
+            validation: None,
+            layout: FieldLayout {
+                width: Some(3),
+                ..Default::default()
+            },
+            description: Some("Based on Physique skill".to_string()),
+            placeholder: None,
+        });
+
+        for i in 1..=4 {
+            fields.push(FieldDefinition {
+                id: format!("PHYSICAL_STRESS_{}", i),
+                label: format!("[{}]", i),
+                field_type: SchemaFieldType::Boolean {
+                    checked_label: Some("Marked".to_string()),
+                    unchecked_label: Some("Clear".to_string()),
+                },
+                editable: true,
+                required: false,
+                derived_from: None,
+                validation: None,
+                layout: FieldLayout {
+                    width: Some(2),
+                    ..Default::default()
+                },
+                description: Some(format!("{}-shift stress box", i)),
+                placeholder: None,
+            });
+        }
+
+        // Mental stress boxes
+        fields.push(FieldDefinition {
+            id: "MENTAL_STRESS_BOXES".to_string(),
+            label: "Mental Stress Boxes".to_string(),
+            field_type: SchemaFieldType::Integer {
+                min: Some(2),
+                max: Some(4),
+                show_modifier: false,
+            },
+            editable: false,
+            required: false,
+            derived_from: Some(DerivedField {
+                derivation_type: DerivationType::Custom,
+                dependencies: vec!["WILL".to_string()],
+                display_format: None,
+            }),
+            validation: None,
+            layout: FieldLayout {
+                width: Some(3),
+                new_row: true,
+                ..Default::default()
+            },
+            description: Some("Based on Will skill".to_string()),
+            placeholder: None,
+        });
+
+        for i in 1..=4 {
+            fields.push(FieldDefinition {
+                id: format!("MENTAL_STRESS_{}", i),
+                label: format!("[{}]", i),
+                field_type: SchemaFieldType::Boolean {
+                    checked_label: Some("Marked".to_string()),
+                    unchecked_label: Some("Clear".to_string()),
+                },
+                editable: true,
+                required: false,
+                derived_from: None,
+                validation: None,
+                layout: FieldLayout {
+                    width: Some(2),
+                    ..Default::default()
+                },
+                description: Some(format!("{}-shift stress box", i)),
+                placeholder: None,
+            });
+        }
+
+        SchemaSection {
+            id: "stress".to_string(),
+            label: "Stress".to_string(),
+            section_type: SectionType::Resources,
+            fields,
+            collapsible: false,
+            collapsed_default: false,
+            description: Some("Stress represents minor hits. Physical stress boxes are based on Physique, mental on Will. Mark boxes to absorb shifts of harm.".to_string()),
+        }
+    }
+
+    fn consequences_section(&self) -> SchemaSection {
+        SchemaSection {
+            id: "consequences".to_string(),
+            label: "Consequences".to_string(),
+            section_type: SectionType::Resources,
+            fields: vec![
+                FieldDefinition {
+                    id: "CONSEQUENCE_MILD".to_string(),
+                    label: "Mild (2)".to_string(),
+                    field_type: SchemaFieldType::Text {
+                        multiline: false,
+                        max_length: Some(200),
+                    },
+                    editable: true,
+                    required: false,
+                    derived_from: None,
+                    validation: None,
+                    layout: FieldLayout {
+                        width: Some(12),
+                        ..Default::default()
+                    },
+                    description: Some("Absorbs 2 shifts. Clears at end of scene with successful overcome action.".to_string()),
+                    placeholder: Some("e.g., 'Bruised Ribs', 'Rattled'".to_string()),
+                },
+                FieldDefinition {
+                    id: "CONSEQUENCE_MODERATE".to_string(),
+                    label: "Moderate (4)".to_string(),
+                    field_type: SchemaFieldType::Text {
+                        multiline: false,
+                        max_length: Some(200),
+                    },
+                    editable: true,
+                    required: false,
+                    derived_from: None,
+                    validation: None,
+                    layout: FieldLayout {
+                        width: Some(12),
+                        new_row: true,
+                        ..Default::default()
+                    },
+                    description: Some("Absorbs 4 shifts. Clears at end of session.".to_string()),
+                    placeholder: Some("e.g., 'Deep Gash', 'Shaken to the Core'".to_string()),
+                },
+                FieldDefinition {
+                    id: "CONSEQUENCE_SEVERE".to_string(),
+                    label: "Severe (6)".to_string(),
+                    field_type: SchemaFieldType::Text {
+                        multiline: false,
+                        max_length: Some(200),
+                    },
+                    editable: true,
+                    required: false,
+                    derived_from: None,
+                    validation: None,
+                    layout: FieldLayout {
+                        width: Some(12),
+                        new_row: true,
+                        ..Default::default()
+                    },
+                    description: Some("Absorbs 6 shifts. Clears at end of scenario.".to_string()),
+                    placeholder: Some("e.g., 'Broken Leg', 'Complete Mental Breakdown'".to_string()),
+                },
+            ],
+            collapsible: false,
+            collapsed_default: false,
+            description: Some("Consequences are lasting injuries or trauma. They absorb shifts but can be compelled as aspects.".to_string()),
+        }
+    }
+
+    fn resources_section(&self) -> SchemaSection {
+        SchemaSection {
+            id: "resources".to_string(),
+            label: "Refresh & Fate Points".to_string(),
+            section_type: SectionType::Resources,
+            fields: vec![
+                FieldDefinition {
+                    id: "BASE_REFRESH".to_string(),
+                    label: "Base Refresh".to_string(),
+                    field_type: SchemaFieldType::Integer {
+                        min: Some(1),
+                        max: Some(10),
+                        show_modifier: false,
+                    },
+                    editable: true,
+                    required: true,
+                    derived_from: None,
+                    validation: Some(FieldValidation {
+                        min: Some(1),
+                        max: Some(10),
+                        pattern: None,
+                        error_message: Some("Base refresh must be at least 1".to_string()),
+                    }),
+                    layout: FieldLayout {
+                        width: Some(3),
+                        ..Default::default()
+                    },
+                    description: Some("Starting refresh value (default 3)".to_string()),
+                    placeholder: None,
+                },
+                FieldDefinition {
+                    id: "REFRESH".to_string(),
+                    label: "Current Refresh".to_string(),
+                    field_type: SchemaFieldType::Integer {
+                        min: Some(1),
+                        max: Some(10),
+                        show_modifier: false,
+                    },
+                    editable: false,
+                    required: false,
+                    derived_from: Some(DerivedField {
+                        derivation_type: DerivationType::Custom,
+                        dependencies: vec!["BASE_REFRESH".to_string(), "STUNT_1".to_string(), "STUNT_2".to_string(), "STUNT_3".to_string(), "STUNT_4".to_string(), "STUNT_5".to_string()],
+                        display_format: None,
+                    }),
+                    validation: None,
+                    layout: FieldLayout {
+                        width: Some(3),
+                        ..Default::default()
+                    },
+                    description: Some("Refresh after stunt costs (3 free, then -1 per additional)".to_string()),
+                    placeholder: None,
+                },
+                FieldDefinition {
+                    id: "CURRENT_FATE_POINTS".to_string(),
+                    label: "Fate Points".to_string(),
+                    field_type: SchemaFieldType::ResourceBar {
+                        max_field: "REFRESH".to_string(),
+                        color: ResourceColor::Blue,
+                    },
+                    editable: true,
+                    required: false,
+                    derived_from: None,
+                    validation: None,
+                    layout: FieldLayout {
+                        width: Some(6),
+                        new_row: true,
+                        ..Default::default()
+                    },
+                    description: Some("Spend to invoke aspects or power stunts. Resets to refresh at session start.".to_string()),
+                    placeholder: None,
+                },
+            ],
+            collapsible: false,
+            collapsed_default: false,
+            description: Some("Fate points let you invoke aspects for bonuses or trigger certain stunts.".to_string()),
+        }
+    }
+}
+
+/// Four actions in FATE.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FateAction {
+    /// Get past obstacles
+    Overcome,
+    /// Create or discover aspects
+    CreateAdvantage,
+    /// Deal stress to opponents
+    Attack,
+    /// Prevent Attack or Create Advantage
+    Defend,
+}
+
+/// Simulate rolling 4dF (4 Fudge dice).
+/// Each die: -1, 0, or +1
+/// Returns sum (-4 to +4)
+pub fn roll_4df(results: &[i8; 4]) -> i32 {
+    results.iter().map(|&d| d as i32).sum()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ladder_ratings() {
+        assert_eq!(LadderRating::from_value(4), Some(LadderRating::Great));
+        assert_eq!(LadderRating::Great.descriptor(), "Great");
+        assert_eq!(LadderRating::from_value(-2), Some(LadderRating::Terrible));
+    }
+
+    #[test]
+    fn fate_outcomes() {
+        // Success with style (3+ shifts)
+        assert!(matches!(
+            FateOutcome::determine(7, 4),
+            FateOutcome::SuccessWithStyle { shifts: 3 }
+        ));
+
+        // Success (1-2 shifts)
+        assert!(matches!(
+            FateOutcome::determine(5, 4),
+            FateOutcome::Success { shifts: 1 }
+        ));
+
+        // Tie (0 shifts)
+        assert_eq!(FateOutcome::determine(4, 4), FateOutcome::Tie);
+
+        // Failure (negative shifts)
+        assert!(matches!(
+            FateOutcome::determine(2, 4),
+            FateOutcome::Failure { shifts: -2 }
+        ));
+    }
+
+    #[test]
+    fn consequence_absorption() {
+        assert_eq!(ConsequenceSeverity::Mild.shifts_absorbed(), 2);
+        assert_eq!(ConsequenceSeverity::Moderate.shifts_absorbed(), 4);
+        assert_eq!(ConsequenceSeverity::Severe.shifts_absorbed(), 6);
+    }
+
+    #[test]
+    fn stress_boxes_calculation() {
+        assert_eq!(FateCoreSystem::stress_boxes_from_skill(0), 2);
+        assert_eq!(FateCoreSystem::stress_boxes_from_skill(2), 3);
+        assert_eq!(FateCoreSystem::stress_boxes_from_skill(4), 4);
+    }
+
+    #[test]
+    fn refresh_calculation() {
+        assert_eq!(FateCoreSystem::calculate_refresh(3, 3), 3);
+        assert_eq!(FateCoreSystem::calculate_refresh(4, 3), 2);
+        assert_eq!(FateCoreSystem::calculate_refresh(5, 3), 1);
+    }
+
+    #[test]
+    fn pyramid_validation() {
+        // Valid pyramid: 1 at +4, 2 at +3, 3 at +2, 4 at +1
+        let valid_skills = vec![
+            ("Fight".to_string(), 4),
+            ("Athletics".to_string(), 3),
+            ("Will".to_string(), 3),
+            ("Notice".to_string(), 2),
+            ("Physique".to_string(), 2),
+            ("Shoot".to_string(), 2),
+            ("Investigate".to_string(), 1),
+            ("Lore".to_string(), 1),
+            ("Empathy".to_string(), 1),
+            ("Rapport".to_string(), 1),
+        ];
+        assert!(FateCoreSystem::validate_pyramid(&valid_skills, 4).is_ok());
+
+        // Invalid: 2 at +4, only 1 at +3
+        let invalid_skills = vec![
+            ("Fight".to_string(), 4),
+            ("Athletics".to_string(), 4),
+            ("Will".to_string(), 3),
+        ];
+        assert!(FateCoreSystem::validate_pyramid(&invalid_skills, 4).is_err());
+    }
+
+    #[test]
+    fn roll_4df_sums() {
+        assert_eq!(roll_4df(&[1, 1, 1, 1]), 4);
+        assert_eq!(roll_4df(&[-1, -1, -1, -1]), -4);
+        assert_eq!(roll_4df(&[1, -1, 0, 0]), 0);
+        assert_eq!(roll_4df(&[1, 1, -1, 0]), 1);
+    }
+
+    #[test]
+    fn system_identification() {
+        let system = FateCoreSystem::new();
+        assert_eq!(system.system_id(), "fate_core");
+        assert_eq!(system.display_name(), "FATE Core");
+    }
+
+    #[test]
+    fn character_sheet_schema_structure() {
+        use super::CharacterSheetProvider;
+
+        let system = FateCoreSystem::new();
+        let schema = system.character_sheet_schema();
+
+        assert_eq!(schema.system_id, "fate_core");
+        assert_eq!(schema.system_name, "FATE Core");
+        assert_eq!(schema.sections.len(), 7);
+
+        // Verify section IDs
+        let section_ids: Vec<&str> = schema.sections.iter().map(|s| s.id.as_str()).collect();
+        assert!(section_ids.contains(&"identity"));
+        assert!(section_ids.contains(&"aspects"));
+        assert!(section_ids.contains(&"skills"));
+        assert!(section_ids.contains(&"stunts"));
+        assert!(section_ids.contains(&"stress"));
+        assert!(section_ids.contains(&"consequences"));
+        assert!(section_ids.contains(&"resources"));
+
+        // Verify creation steps
+        assert_eq!(schema.creation_steps.len(), 5);
+    }
+
+    #[test]
+    fn character_sheet_skills_section() {
+        use super::CharacterSheetProvider;
+
+        let system = FateCoreSystem::new();
+        let schema = system.character_sheet_schema();
+
+        let skills_section = schema.sections.iter().find(|s| s.id == "skills").unwrap();
+        assert_eq!(skills_section.fields.len(), 18); // 18 FATE Core skills
+
+        // Verify skill field types are LadderRating
+        for field in &skills_section.fields {
+            match &field.field_type {
+                super::SchemaFieldType::LadderRating { min, max, labels } => {
+                    assert_eq!(*min, -2);
+                    assert_eq!(*max, 8);
+                    assert_eq!(labels.len(), 11); // -2 to +8
+                }
+                _ => panic!("Expected LadderRating field type for skill: {}", field.id),
+            }
+        }
+    }
+
+    #[test]
+    fn character_sheet_aspects_section() {
+        use super::CharacterSheetProvider;
+
+        let system = FateCoreSystem::new();
+        let schema = system.character_sheet_schema();
+
+        let aspects_section = schema.sections.iter().find(|s| s.id == "aspects").unwrap();
+        assert_eq!(aspects_section.fields.len(), 5); // High Concept, Trouble, 3 additional
+
+        // High Concept and Trouble are required
+        let high_concept = aspects_section.fields.iter().find(|f| f.id == "HIGH_CONCEPT").unwrap();
+        assert!(high_concept.required);
+
+        let trouble = aspects_section.fields.iter().find(|f| f.id == "TROUBLE").unwrap();
+        assert!(trouble.required);
+    }
+
+    #[test]
+    fn calculate_derived_stress_boxes() {
+        use super::CharacterSheetProvider;
+
+        let system = FateCoreSystem::new();
+        let mut values = HashMap::new();
+
+        // Test with Physique +0 (Mediocre) and Will +0 (Mediocre)
+        values.insert("PHYSIQUE".to_string(), serde_json::json!(0));
+        values.insert("WILL".to_string(), serde_json::json!(0));
+
+        let derived = system.calculate_derived_values(&values);
+        assert_eq!(derived.get("PHYSICAL_STRESS_BOXES"), Some(&serde_json::json!(2)));
+        assert_eq!(derived.get("MENTAL_STRESS_BOXES"), Some(&serde_json::json!(2)));
+
+        // Test with Physique +3 (Good) and Will +4 (Great)
+        values.insert("PHYSIQUE".to_string(), serde_json::json!(3));
+        values.insert("WILL".to_string(), serde_json::json!(4));
+
+        let derived = system.calculate_derived_values(&values);
+        assert_eq!(derived.get("PHYSICAL_STRESS_BOXES"), Some(&serde_json::json!(4)));
+        assert_eq!(derived.get("MENTAL_STRESS_BOXES"), Some(&serde_json::json!(4)));
+    }
+
+    #[test]
+    fn calculate_refresh_from_stunts() {
+        use super::CharacterSheetProvider;
+
+        let system = FateCoreSystem::new();
+        let mut values = HashMap::new();
+
+        // Base refresh 3, no stunts
+        values.insert("BASE_REFRESH".to_string(), serde_json::json!(3));
+
+        let derived = system.calculate_derived_values(&values);
+        assert_eq!(derived.get("REFRESH"), Some(&serde_json::json!(3)));
+
+        // Add 3 stunts (all free, no reduction)
+        values.insert("STUNT_1".to_string(), serde_json::json!("Stunt One"));
+        values.insert("STUNT_2".to_string(), serde_json::json!("Stunt Two"));
+        values.insert("STUNT_3".to_string(), serde_json::json!("Stunt Three"));
+
+        let derived = system.calculate_derived_values(&values);
+        assert_eq!(derived.get("REFRESH"), Some(&serde_json::json!(3)));
+
+        // Add a 4th stunt (costs 1 refresh)
+        values.insert("STUNT_4".to_string(), serde_json::json!("Stunt Four"));
+
+        let derived = system.calculate_derived_values(&values);
+        assert_eq!(derived.get("REFRESH"), Some(&serde_json::json!(2)));
+
+        // Add a 5th stunt (costs another refresh)
+        values.insert("STUNT_5".to_string(), serde_json::json!("Stunt Five"));
+
+        let derived = system.calculate_derived_values(&values);
+        assert_eq!(derived.get("REFRESH"), Some(&serde_json::json!(1)));
+    }
+
+    #[test]
+    fn validate_skill_ratings() {
+        use super::CharacterSheetProvider;
+
+        let system = FateCoreSystem::new();
+        let values = HashMap::new();
+
+        // Valid rating
+        assert!(system.validate_field("ATHLETICS", &serde_json::json!(4), &values).is_none());
+        assert!(system.validate_field("ATHLETICS", &serde_json::json!(-2), &values).is_none());
+
+        // Invalid ratings
+        assert!(system.validate_field("ATHLETICS", &serde_json::json!(9), &values).is_some());
+        assert!(system.validate_field("ATHLETICS", &serde_json::json!(-3), &values).is_some());
+    }
+
+    #[test]
+    fn default_values_structure() {
+        use super::CharacterSheetProvider;
+
+        let system = FateCoreSystem::new();
+        let defaults = system.default_values();
+
+        // Check identity defaults
+        assert_eq!(defaults.get("NAME"), Some(&serde_json::json!("")));
+
+        // Check aspect defaults
+        assert_eq!(defaults.get("HIGH_CONCEPT"), Some(&serde_json::json!("")));
+        assert_eq!(defaults.get("TROUBLE"), Some(&serde_json::json!("")));
+
+        // Check skill defaults (should be 0 = Mediocre)
+        assert_eq!(defaults.get("ATHLETICS"), Some(&serde_json::json!(0)));
+        assert_eq!(defaults.get("WILL"), Some(&serde_json::json!(0)));
+
+        // Check resource defaults
+        assert_eq!(defaults.get("BASE_REFRESH"), Some(&serde_json::json!(3)));
+        assert_eq!(defaults.get("CURRENT_FATE_POINTS"), Some(&serde_json::json!(3)));
+
+        // Check stress box defaults
+        assert_eq!(defaults.get("PHYSICAL_STRESS_1"), Some(&serde_json::json!(false)));
+        assert_eq!(defaults.get("MENTAL_STRESS_1"), Some(&serde_json::json!(false)));
+
+        // Check consequence defaults
+        assert_eq!(defaults.get("CONSEQUENCE_MILD"), Some(&serde_json::json!("")));
+    }
+}

--- a/crates/domain/src/game_systems/mod.rs
+++ b/crates/domain/src/game_systems/mod.rs
@@ -1,0 +1,194 @@
+//! Game system implementations for various TTRPGs.
+//!
+//! This module provides system-specific calculation engines and mechanics
+//! for different tabletop roleplaying games. Each system implements the
+//! core traits defined in `traits.rs`.
+//!
+//! # Supported Systems
+//!
+//! - D&D 5th Edition (`dnd5e`)
+//! - Pathfinder 2e (`pf2e`)
+//! - Call of Cthulhu 7e (`coc7e`)
+//! - FATE Core (`fate_core`)
+//! - Blades in the Dark (`blades`)
+//! - Powered by the Apocalypse (`pbta`, `pbta_aw`, `pbta_dw`, `pbta_motw`)
+
+mod blades;
+mod coc7e;
+mod dnd5e;
+mod fate_core;
+mod pbta;
+mod pf2e;
+mod traits;
+
+// D&D 5e exports
+pub use dnd5e::{skill_ability as dnd5e_skill_ability, Dnd5eSystem};
+
+// Pathfinder 2e exports
+pub use pf2e::{
+    determine_success as pf2e_determine_success, multiple_attack_penalty, skill_ability as pf2e_skill_ability,
+    DegreeOfSuccess, Pf2eProficiencyRank, Pf2eSystem,
+};
+
+// Call of Cthulhu 7e exports
+pub use coc7e::{
+    check_success as coc_check_success, get_skill_base as coc_skill_base, is_critical, is_fumble,
+    sanity_check, Coc7eSystem, Lifestyle, SanityCheckResult, SuccessLevel,
+};
+
+// FATE Core exports
+pub use fate_core::{
+    roll_4df, ConsequenceSeverity, FateAction, FateCoreSystem, FateOutcome, InvokeType,
+    LadderRating,
+};
+
+// Blades in the Dark exports
+pub use blades::{
+    BladesOutcome, BladesSystem, CrewType, EffectLevel, HarmLevel, LoadLevel, Playbook, Position,
+    ProgressClock, TraumaCondition,
+};
+
+// Powered by the Apocalypse exports
+pub use pbta::{
+    HarmSystem as PbtaHarmSystem, ModifierType, MoveHold, PbtaModifier, PbtaMove, PbtaOutcome,
+    PbtaStatSet, PbtaSystem, PbtaVariant,
+};
+
+// Core traits
+pub use traits::{
+    CalculationEngine, CasterType, CharacterSheetProvider, GameSystem, ProficiencyLevel,
+    RestType, SpellcastingSystem,
+};
+
+
+use std::sync::Arc;
+
+/// Registry of available game systems.
+pub struct GameSystemRegistry {
+    systems: Vec<Arc<dyn GameSystem>>,
+}
+
+impl Default for GameSystemRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl GameSystemRegistry {
+    /// Create a new registry with all built-in game systems.
+    pub fn new() -> Self {
+        let mut registry = Self {
+            systems: Vec::new(),
+        };
+        // Register built-in systems
+        registry.register(Arc::new(Dnd5eSystem::new()));
+        registry.register(Arc::new(Pf2eSystem::new()));
+        registry.register(Arc::new(Coc7eSystem::new()));
+        registry.register(Arc::new(FateCoreSystem::new()));
+        registry.register(Arc::new(BladesSystem::new()));
+        registry.register(Arc::new(PbtaSystem::generic()));
+        registry.register(Arc::new(PbtaSystem::apocalypse_world()));
+        registry.register(Arc::new(PbtaSystem::dungeon_world()));
+        registry.register(Arc::new(PbtaSystem::monster_of_the_week()));
+        registry
+    }
+
+    /// Create an empty registry without built-in systems.
+    pub fn empty() -> Self {
+        Self {
+            systems: Vec::new(),
+        }
+    }
+
+    /// Register a game system.
+    pub fn register(&mut self, system: Arc<dyn GameSystem>) {
+        self.systems.push(system);
+    }
+
+    /// Get a game system by its ID.
+    pub fn get(&self, system_id: &str) -> Option<Arc<dyn GameSystem>> {
+        self.systems
+            .iter()
+            .find(|s| s.system_id() == system_id)
+            .cloned()
+    }
+
+    /// List all registered system IDs.
+    pub fn list_systems(&self) -> Vec<&str> {
+        self.systems.iter().map(|s| s.system_id()).collect()
+    }
+
+    /// List all registered systems with their display names.
+    pub fn list_systems_with_names(&self) -> Vec<(&str, &str)> {
+        self.systems
+            .iter()
+            .map(|s| (s.system_id(), s.display_name()))
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn registry_includes_dnd5e() {
+        let registry = GameSystemRegistry::new();
+        assert!(registry.list_systems().contains(&"dnd5e"));
+        assert!(registry.get("dnd5e").is_some());
+    }
+
+    #[test]
+    fn registry_includes_all_systems() {
+        let registry = GameSystemRegistry::new();
+        let systems = registry.list_systems();
+
+        // Check all systems are registered
+        assert!(systems.contains(&"dnd5e"));
+        assert!(systems.contains(&"pf2e"));
+        assert!(systems.contains(&"coc7e"));
+        assert!(systems.contains(&"fate_core"));
+        assert!(systems.contains(&"blades"));
+        assert!(systems.contains(&"pbta"));
+        assert!(systems.contains(&"pbta_aw"));
+        assert!(systems.contains(&"pbta_dw"));
+        assert!(systems.contains(&"pbta_motw"));
+
+        // Total should be 9 systems
+        assert_eq!(systems.len(), 9);
+    }
+
+    #[test]
+    fn empty_registry_has_no_systems() {
+        let registry = GameSystemRegistry::empty();
+        assert!(registry.list_systems().is_empty());
+    }
+
+    #[test]
+    fn registry_list_with_names() {
+        let registry = GameSystemRegistry::new();
+        let systems = registry.list_systems_with_names();
+        assert!(systems.iter().any(|(id, name)| *id == "dnd5e" && *name == "D&D 5th Edition"));
+        assert!(systems.iter().any(|(id, name)| *id == "pf2e" && *name == "Pathfinder 2nd Edition"));
+        assert!(systems.iter().any(|(id, name)| *id == "coc7e" && *name == "Call of Cthulhu 7th Edition"));
+        assert!(systems.iter().any(|(id, name)| *id == "fate_core" && *name == "FATE Core"));
+        assert!(systems.iter().any(|(id, name)| *id == "blades" && *name == "Blades in the Dark"));
+    }
+
+    #[test]
+    fn can_get_each_system_by_id() {
+        let registry = GameSystemRegistry::new();
+
+        let pf2e = registry.get("pf2e").expect("PF2e should be registered");
+        assert_eq!(pf2e.display_name(), "Pathfinder 2nd Edition");
+
+        let coc = registry.get("coc7e").expect("CoC should be registered");
+        assert_eq!(coc.display_name(), "Call of Cthulhu 7th Edition");
+
+        let fate = registry.get("fate_core").expect("FATE should be registered");
+        assert_eq!(fate.display_name(), "FATE Core");
+
+        let blades = registry.get("blades").expect("Blades should be registered");
+        assert_eq!(blades.display_name(), "Blades in the Dark");
+    }
+}

--- a/crates/domain/src/game_systems/pbta.rs
+++ b/crates/domain/src/game_systems/pbta.rs
@@ -558,6 +558,9 @@ impl PbtaSystem {
         // Add bonds section
         sections.push(self.bonds_section());
 
+        // Add modifiers/conditions section
+        sections.push(self.modifiers_section());
+
         sections
     }
 
@@ -1614,6 +1617,43 @@ impl PbtaSystem {
             }
             PbtaVariant::MonsterOfTheWeek => "History with other hunters in your team.",
             PbtaVariant::Generic => "Your relationships with other characters.",
+        }
+    }
+
+    fn modifiers_section(&self) -> SchemaSection {
+        let description = match self.variant {
+            PbtaVariant::ApocalypseWorld => "Track debilities (Shattered, Crippled, Disfigured, Broken) and ongoing effects affecting your moves.",
+            PbtaVariant::DungeonWorld => "Track debilities (Weak, Shaky, Sick, Stunned, Confused, Scarred) affecting your stat modifiers.",
+            PbtaVariant::MonsterOfTheWeek => "Track conditions and ongoing effects affecting your hunter.",
+            PbtaVariant::Generic => "Track conditions and ongoing effects affecting your character.",
+        };
+
+        SchemaSection {
+            id: "modifiers".to_string(),
+            label: "Conditions & Effects".to_string(),
+            section_type: SectionType::Modifiers,
+            fields: vec![
+                FieldDefinition {
+                    id: "ACTIVE_MODIFIERS".to_string(),
+                    label: "Active Conditions".to_string(),
+                    field_type: SchemaFieldType::ModifierList { filter_stat: None },
+                    editable: false,
+                    required: false,
+                    derived_from: None,
+                    validation: None,
+                    layout: FieldLayout {
+                        width: Some(12),
+                        ..Default::default()
+                    },
+                    description: Some(
+                        "Active conditions, debilities, and ongoing effects modifying your rolls.".to_string(),
+                    ),
+                    placeholder: None,
+                },
+            ],
+            collapsible: true,
+            collapsed_default: false,
+            description: Some(description.to_string()),
         }
     }
 }

--- a/crates/domain/src/game_systems/pbta.rs
+++ b/crates/domain/src/game_systems/pbta.rs
@@ -1,0 +1,2190 @@
+//! Powered by the Apocalypse game system implementation.
+//!
+//! PbtA uses 2d6 + stat with move-based resolution.
+//! Key features:
+//! - Three-tier outcomes: 6- (miss), 7-9 (partial), 10+ (full success)
+//! - Moves as core mechanic
+//! - Forward/Ongoing modifiers
+//! - Hold mechanic
+//! - Playbook-based characters
+
+use super::traits::{
+    CalculationEngine, CharacterSheetProvider, CharacterSheetSchema, CreationStep, DerivedField,
+    DerivationType, FieldDefinition, FieldLayout, FieldValidation, GameSystem, ProficiencyLevel,
+    ResourceColor, SchemaFieldType, SchemaSection, SchemaSelectOption, SectionType,
+};
+use crate::entities::{StatBlock, StatModifier};
+use std::collections::HashMap;
+
+/// PbtA roll outcome.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PbtaOutcome {
+    /// 10+ - Full success, you do it
+    FullSuccess,
+    /// 7-9 - Partial success, you do it but with cost/complication
+    PartialSuccess,
+    /// 6- - Miss, GM makes a move
+    Miss,
+}
+
+impl PbtaOutcome {
+    /// Determine outcome from total (2d6 + stat).
+    pub fn from_total(total: i32) -> Self {
+        if total >= 10 {
+            PbtaOutcome::FullSuccess
+        } else if total >= 7 {
+            PbtaOutcome::PartialSuccess
+        } else {
+            PbtaOutcome::Miss
+        }
+    }
+
+    pub fn is_success(&self) -> bool {
+        matches!(self, PbtaOutcome::FullSuccess | PbtaOutcome::PartialSuccess)
+    }
+}
+
+/// Common stats used across PbtA games.
+/// Different games use different stat sets.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PbtaStatSet {
+    /// Apocalypse World: Cool, Hard, Hot, Sharp, Weird
+    ApocalypseWorld,
+    /// Dungeon World: STR, DEX, CON, INT, WIS, CHA
+    DungeonWorld,
+    /// Monster of the Week: Charm, Cool, Sharp, Tough, Weird
+    MonsterOfTheWeek,
+    /// Custom stats defined per game
+    Custom,
+}
+
+/// Harm system variant.
+#[derive(Debug, Clone)]
+pub enum HarmSystem {
+    /// Apocalypse World style: 6-segment clock
+    Clock { segments: u8, current: u8 },
+    /// Dungeon World style: HP
+    HitPoints { max: i32, current: i32 },
+    /// Monster of the Week style: harm track
+    HarmTrack { boxes: u8, filled: u8, unstable_at: u8 },
+    /// Masks/Monsterhearts style: conditions
+    Conditions { active: Vec<String> },
+}
+
+/// A PbtA move.
+#[derive(Debug, Clone)]
+pub struct PbtaMove {
+    pub id: String,
+    pub name: String,
+    pub trigger: String,
+    pub stat: Option<String>,
+    pub full_success: String,
+    pub partial_success: String,
+    pub miss: Option<String>,
+}
+
+impl PbtaMove {
+    pub fn new(
+        id: impl Into<String>,
+        name: impl Into<String>,
+        trigger: impl Into<String>,
+        stat: Option<impl Into<String>>,
+        full_success: impl Into<String>,
+        partial_success: impl Into<String>,
+    ) -> Self {
+        Self {
+            id: id.into(),
+            name: name.into(),
+            trigger: trigger.into(),
+            stat: stat.map(|s| s.into()),
+            full_success: full_success.into(),
+            partial_success: partial_success.into(),
+            miss: None,
+        }
+    }
+
+    pub fn with_miss(mut self, miss: impl Into<String>) -> Self {
+        self.miss = Some(miss.into());
+        self
+    }
+
+    pub fn requires_roll(&self) -> bool {
+        self.stat.is_some()
+    }
+}
+
+/// Powered by the Apocalypse game system.
+pub struct PbtaSystem {
+    variant: PbtaVariant,
+    stat_names: Vec<&'static str>,
+}
+
+/// PbtA game variant.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PbtaVariant {
+    ApocalypseWorld,
+    DungeonWorld,
+    MonsterOfTheWeek,
+    Generic,
+}
+
+impl PbtaSystem {
+    /// Create a generic PbtA system.
+    pub fn new() -> Self {
+        Self::generic()
+    }
+
+    /// Create Apocalypse World variant.
+    pub fn apocalypse_world() -> Self {
+        Self {
+            variant: PbtaVariant::ApocalypseWorld,
+            stat_names: vec!["Cool", "Hard", "Hot", "Sharp", "Weird"],
+        }
+    }
+
+    /// Create Dungeon World variant.
+    pub fn dungeon_world() -> Self {
+        Self {
+            variant: PbtaVariant::DungeonWorld,
+            stat_names: vec!["STR", "DEX", "CON", "INT", "WIS", "CHA"],
+        }
+    }
+
+    /// Create Monster of the Week variant.
+    pub fn monster_of_the_week() -> Self {
+        Self {
+            variant: PbtaVariant::MonsterOfTheWeek,
+            stat_names: vec!["Charm", "Cool", "Sharp", "Tough", "Weird"],
+        }
+    }
+
+    /// Create generic PbtA system.
+    pub fn generic() -> Self {
+        Self {
+            variant: PbtaVariant::Generic,
+            stat_names: vec!["Stat1", "Stat2", "Stat3", "Stat4", "Stat5"],
+        }
+    }
+
+    pub fn variant(&self) -> PbtaVariant {
+        self.variant
+    }
+
+    /// Get basic moves for this variant.
+    pub fn basic_moves(&self) -> Vec<PbtaMove> {
+        match self.variant {
+            PbtaVariant::ApocalypseWorld => apocalypse_world_basic_moves(),
+            PbtaVariant::DungeonWorld => dungeon_world_basic_moves(),
+            PbtaVariant::MonsterOfTheWeek => monster_of_the_week_basic_moves(),
+            PbtaVariant::Generic => vec![],
+        }
+    }
+}
+
+impl Default for PbtaSystem {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl GameSystem for PbtaSystem {
+    fn system_id(&self) -> &str {
+        match self.variant {
+            PbtaVariant::ApocalypseWorld => "pbta_aw",
+            PbtaVariant::DungeonWorld => "pbta_dw",
+            PbtaVariant::MonsterOfTheWeek => "pbta_motw",
+            PbtaVariant::Generic => "pbta",
+        }
+    }
+
+    fn display_name(&self) -> &str {
+        match self.variant {
+            PbtaVariant::ApocalypseWorld => "Apocalypse World",
+            PbtaVariant::DungeonWorld => "Dungeon World",
+            PbtaVariant::MonsterOfTheWeek => "Monster of the Week",
+            PbtaVariant::Generic => "Powered by the Apocalypse",
+        }
+    }
+
+    fn calculation_engine(&self) -> &dyn CalculationEngine {
+        self
+    }
+
+    fn stat_names(&self) -> &[&str] {
+        &self.stat_names
+    }
+
+    fn skill_names(&self) -> &[&str] {
+        // PbtA doesn't have skills - moves replace them
+        &[]
+    }
+}
+
+impl CalculationEngine for PbtaSystem {
+    fn ability_modifier(&self, score: i32) -> i32 {
+        // PbtA stats are already modifiers (-2 to +3 typically)
+        // For Dungeon World, convert from D&D-style scores
+        if self.variant == PbtaVariant::DungeonWorld {
+            // Dungeon World uses D&D-style ability scores
+            let diff = score - 10;
+            if diff >= 0 {
+                diff / 2
+            } else {
+                (diff - 1) / 2
+            }
+        } else {
+            // Other PbtA games use direct stat values
+            score
+        }
+    }
+
+    fn proficiency_bonus(&self, _level: u8) -> i32 {
+        // PbtA has no proficiency system
+        0
+    }
+
+    fn spell_save_dc(&self, _stats: &StatBlock, _casting_stat: &str) -> i32 {
+        // PbtA magic uses moves, not DCs
+        0
+    }
+
+    fn spell_attack_bonus(&self, _stats: &StatBlock, _casting_stat: &str) -> i32 {
+        // PbtA magic uses moves
+        0
+    }
+
+    fn attack_bonus(&self, stats: &StatBlock, attack_stat: &str, _proficient: bool) -> i32 {
+        // Return stat value directly
+        let value = stats.get_stat(attack_stat).unwrap_or(0);
+        self.ability_modifier(value)
+    }
+
+    fn stack_modifiers(&self, modifiers: &[StatModifier]) -> i32 {
+        // PbtA modifiers stack (forward, ongoing, etc.)
+        modifiers
+            .iter()
+            .filter(|m| m.active)
+            .map(|m| m.value)
+            .sum()
+    }
+
+    fn calculate_ac(
+        &self,
+        stats: &StatBlock,
+        armor_value: Option<i32>,
+        _shield_bonus: Option<i32>,
+        _allows_dex: bool,
+        _max_dex_bonus: Option<i32>,
+    ) -> i32 {
+        // Only Dungeon World has armor
+        if self.variant == PbtaVariant::DungeonWorld {
+            armor_value.unwrap_or(0)
+        } else {
+            stats.get_stat("Armor").unwrap_or(0)
+        }
+    }
+
+    fn skill_modifier(
+        &self,
+        stats: &StatBlock,
+        stat: &str,
+        _proficiency_level: ProficiencyLevel,
+    ) -> i32 {
+        let value = stats.get_stat(stat).unwrap_or(0);
+        self.ability_modifier(value)
+    }
+
+    fn saving_throw_modifier(
+        &self,
+        stats: &StatBlock,
+        ability: &str,
+        _proficient: bool,
+    ) -> i32 {
+        let value = stats.get_stat(ability).unwrap_or(0);
+        self.ability_modifier(value)
+    }
+
+    fn passive_perception(&self, stats: &StatBlock, _proficiency_level: ProficiencyLevel) -> i32 {
+        // Use Sharp/WIS equivalent
+        let stat = match self.variant {
+            PbtaVariant::ApocalypseWorld => "Sharp",
+            PbtaVariant::DungeonWorld => "WIS",
+            PbtaVariant::MonsterOfTheWeek => "Sharp",
+            PbtaVariant::Generic => "Stat4",
+        };
+        let value = stats.get_stat(stat).unwrap_or(0);
+        10 + self.ability_modifier(value)
+    }
+
+    fn hit_die(&self, class_name: &str) -> u8 {
+        // Only Dungeon World uses hit dice
+        if self.variant == PbtaVariant::DungeonWorld {
+            match class_name.to_lowercase().as_str() {
+                "fighter" | "paladin" => 10,
+                "wizard" => 4,
+                "cleric" | "druid" | "ranger" | "thief" | "bard" => 8,
+                _ => 6,
+            }
+        } else {
+            0
+        }
+    }
+
+    fn calculate_max_hp(
+        &self,
+        _level: u8,
+        class_name: &str,
+        constitution: i32,
+        _additional_hp: i32,
+    ) -> i32 {
+        // Only Dungeon World uses HP
+        if self.variant == PbtaVariant::DungeonWorld {
+            // DW: Class base + CON score
+            let class_base = match class_name.to_lowercase().as_str() {
+                "fighter" | "paladin" => 10,
+                "cleric" | "ranger" => 8,
+                "thief" | "bard" | "druid" => 6,
+                "wizard" => 4,
+                _ => 6,
+            };
+            class_base + constitution
+        } else {
+            // Other PbtA games use harm tracks
+            0
+        }
+    }
+}
+
+impl CharacterSheetProvider for PbtaSystem {
+    fn character_sheet_schema(&self) -> CharacterSheetSchema {
+        CharacterSheetSchema {
+            system_id: self.system_id().to_string(),
+            system_name: self.display_name().to_string(),
+            sections: self.build_sections(),
+            creation_steps: self.build_creation_steps(),
+        }
+    }
+
+    fn calculate_derived_values(
+        &self,
+        values: &HashMap<String, serde_json::Value>,
+    ) -> HashMap<String, serde_json::Value> {
+        let mut derived = HashMap::new();
+
+        match self.variant {
+            PbtaVariant::DungeonWorld => {
+                // Dungeon World uses D&D-style ability scores -> modifiers
+                for stat in &["STR", "DEX", "CON", "INT", "WIS", "CHA"] {
+                    if let Some(score) = values.get(*stat).and_then(|v| v.as_i64()) {
+                        let modifier = self.ability_modifier(score as i32);
+                        derived.insert(format!("{}_MOD", stat), serde_json::json!(modifier));
+                    }
+                }
+
+                // Calculate HP if class and CON are set
+                if let (Some(class), Some(con)) = (
+                    values.get("PLAYBOOK").and_then(|v| v.as_str()),
+                    values.get("CON").and_then(|v| v.as_i64()),
+                ) {
+                    let max_hp = self.calculate_max_hp(1, class, con as i32, 0);
+                    derived.insert("MAX_HP".to_string(), serde_json::json!(max_hp));
+                }
+            }
+            _ => {
+                // For non-DW PbtA games, stats ARE the modifiers (no conversion needed)
+                // But we still track them for consistency
+                for stat in self.stat_names() {
+                    if let Some(value) = values.get(*stat).and_then(|v| v.as_i64()) {
+                        derived.insert(format!("{}_MOD", stat), serde_json::json!(value));
+                    }
+                }
+            }
+        }
+
+        // Calculate total XP (if tracking advancement)
+        if let Some(xp) = values.get("XP").and_then(|v| v.as_i64()) {
+            let xp_max = match self.variant {
+                PbtaVariant::DungeonWorld => {
+                    // DW: Level + 7
+                    let level = values
+                        .get("LEVEL")
+                        .and_then(|v| v.as_i64())
+                        .unwrap_or(1);
+                    level + 7
+                }
+                _ => 5, // Most PbtA games use 5 XP to advance
+            };
+            derived.insert("XP_MAX".to_string(), serde_json::json!(xp_max));
+            let xp_remaining = (xp_max - xp).max(0);
+            derived.insert("XP_REMAINING".to_string(), serde_json::json!(xp_remaining));
+        }
+
+        derived
+    }
+
+    fn validate_field(
+        &self,
+        field_id: &str,
+        value: &serde_json::Value,
+        _all_values: &HashMap<String, serde_json::Value>,
+    ) -> Option<String> {
+        match self.variant {
+            PbtaVariant::DungeonWorld => {
+                // DW uses D&D-style ability scores
+                match field_id {
+                    "STR" | "DEX" | "CON" | "INT" | "WIS" | "CHA" => {
+                        if let Some(score) = value.as_i64() {
+                            if score < 3 || score > 18 {
+                                return Some(
+                                    "Ability scores must be between 3 and 18".to_string(),
+                                );
+                            }
+                        } else {
+                            return Some("Ability score must be a number".to_string());
+                        }
+                    }
+                    _ => {}
+                }
+            }
+            _ => {
+                // Other PbtA games use stats from -1 to +3 (sometimes -2 to +3)
+                let stat_names: Vec<&str> = self.stat_names().to_vec();
+                if stat_names.contains(&field_id) {
+                    if let Some(stat) = value.as_i64() {
+                        if stat < -2 || stat > 3 {
+                            return Some("Stats must be between -2 and +3".to_string());
+                        }
+                    } else {
+                        return Some("Stat must be a number".to_string());
+                    }
+                }
+            }
+        }
+
+        // Common validations
+        match field_id {
+            "NAME" => {
+                if let Some(name) = value.as_str() {
+                    if name.is_empty() {
+                        return Some("Name is required".to_string());
+                    }
+                } else {
+                    return Some("Name must be a string".to_string());
+                }
+            }
+            "XP" => {
+                if let Some(xp) = value.as_i64() {
+                    if xp < 0 {
+                        return Some("XP cannot be negative".to_string());
+                    }
+                }
+            }
+            "HOLD" => {
+                if let Some(hold) = value.as_i64() {
+                    if hold < 0 {
+                        return Some("Hold cannot be negative".to_string());
+                    }
+                }
+            }
+            _ => {}
+        }
+
+        None
+    }
+
+    fn default_values(&self) -> HashMap<String, serde_json::Value> {
+        let mut defaults = HashMap::new();
+
+        match self.variant {
+            PbtaVariant::DungeonWorld => {
+                // DW uses D&D-style scores, default to 10
+                defaults.insert("STR".to_string(), serde_json::json!(10));
+                defaults.insert("DEX".to_string(), serde_json::json!(10));
+                defaults.insert("CON".to_string(), serde_json::json!(10));
+                defaults.insert("INT".to_string(), serde_json::json!(10));
+                defaults.insert("WIS".to_string(), serde_json::json!(10));
+                defaults.insert("CHA".to_string(), serde_json::json!(10));
+                defaults.insert("LEVEL".to_string(), serde_json::json!(1));
+                defaults.insert("ARMOR".to_string(), serde_json::json!(0));
+            }
+            PbtaVariant::ApocalypseWorld => {
+                defaults.insert("Cool".to_string(), serde_json::json!(0));
+                defaults.insert("Hard".to_string(), serde_json::json!(0));
+                defaults.insert("Hot".to_string(), serde_json::json!(0));
+                defaults.insert("Sharp".to_string(), serde_json::json!(0));
+                defaults.insert("Weird".to_string(), serde_json::json!(0));
+            }
+            PbtaVariant::MonsterOfTheWeek => {
+                defaults.insert("Charm".to_string(), serde_json::json!(0));
+                defaults.insert("Cool".to_string(), serde_json::json!(0));
+                defaults.insert("Sharp".to_string(), serde_json::json!(0));
+                defaults.insert("Tough".to_string(), serde_json::json!(0));
+                defaults.insert("Weird".to_string(), serde_json::json!(0));
+            }
+            PbtaVariant::Generic => {
+                for stat in self.stat_names() {
+                    defaults.insert(stat.to_string(), serde_json::json!(0));
+                }
+            }
+        }
+
+        // Common defaults
+        defaults.insert("XP".to_string(), serde_json::json!(0));
+        defaults.insert("HOLD".to_string(), serde_json::json!(0));
+        defaults.insert("HARM".to_string(), serde_json::json!(0));
+        defaults.insert("CURRENT_HP".to_string(), serde_json::json!(0));
+
+        defaults
+    }
+}
+
+// Helper methods for building the character sheet schema
+impl PbtaSystem {
+    fn build_sections(&self) -> Vec<SchemaSection> {
+        let mut sections = vec![
+            self.identity_section(),
+            self.stats_section(),
+        ];
+
+        // Add harm/HP section based on variant
+        sections.push(self.harm_section());
+
+        // Add moves section
+        sections.push(self.moves_section());
+
+        // Add resources section
+        sections.push(self.resources_section());
+
+        // Add bonds section
+        sections.push(self.bonds_section());
+
+        sections
+    }
+
+    fn build_creation_steps(&self) -> Vec<CreationStep> {
+        vec![
+            CreationStep {
+                id: "identity".to_string(),
+                label: "Who Are You?".to_string(),
+                description: "Choose your name, playbook, and look.".to_string(),
+                section_ids: vec!["identity".to_string()],
+                order: 1,
+                required: true,
+            },
+            CreationStep {
+                id: "stats".to_string(),
+                label: "Stats".to_string(),
+                description: "Assign your stats according to your playbook.".to_string(),
+                section_ids: vec!["stats".to_string()],
+                order: 2,
+                required: true,
+            },
+            CreationStep {
+                id: "moves".to_string(),
+                label: "Moves".to_string(),
+                description: "Choose your starting moves.".to_string(),
+                section_ids: vec!["moves".to_string()],
+                order: 3,
+                required: true,
+            },
+            CreationStep {
+                id: "bonds".to_string(),
+                label: "Bonds".to_string(),
+                description: "Establish your relationships with other characters.".to_string(),
+                section_ids: vec!["bonds".to_string()],
+                order: 4,
+                required: false,
+            },
+        ]
+    }
+
+    fn identity_section(&self) -> SchemaSection {
+        let playbook_options = self.get_playbook_options();
+
+        SchemaSection {
+            id: "identity".to_string(),
+            label: "Character Identity".to_string(),
+            section_type: SectionType::Identity,
+            fields: vec![
+                FieldDefinition {
+                    id: "NAME".to_string(),
+                    label: "Name".to_string(),
+                    field_type: SchemaFieldType::Text {
+                        multiline: false,
+                        max_length: Some(100),
+                    },
+                    editable: true,
+                    required: true,
+                    derived_from: None,
+                    validation: None,
+                    layout: FieldLayout {
+                        width: Some(6),
+                        ..Default::default()
+                    },
+                    description: None,
+                    placeholder: Some("Enter character name".to_string()),
+                },
+                FieldDefinition {
+                    id: "PLAYBOOK".to_string(),
+                    label: self.playbook_label().to_string(),
+                    field_type: SchemaFieldType::Select {
+                        options: playbook_options,
+                        allow_custom: true,
+                    },
+                    editable: true,
+                    required: true,
+                    derived_from: None,
+                    validation: None,
+                    layout: FieldLayout {
+                        width: Some(6),
+                        ..Default::default()
+                    },
+                    description: Some(self.playbook_description().to_string()),
+                    placeholder: None,
+                },
+                FieldDefinition {
+                    id: "LOOK".to_string(),
+                    label: "Look".to_string(),
+                    field_type: SchemaFieldType::Text {
+                        multiline: true,
+                        max_length: Some(500),
+                    },
+                    editable: true,
+                    required: false,
+                    derived_from: None,
+                    validation: None,
+                    layout: FieldLayout {
+                        width: Some(12),
+                        new_row: true,
+                        ..Default::default()
+                    },
+                    description: Some("Describe your character's appearance".to_string()),
+                    placeholder: Some("Describe your look...".to_string()),
+                },
+            ],
+            collapsible: false,
+            collapsed_default: false,
+            description: None,
+        }
+    }
+
+    fn stats_section(&self) -> SchemaSection {
+        let fields = match self.variant {
+            PbtaVariant::DungeonWorld => self.dungeon_world_stats_fields(),
+            _ => self.standard_pbta_stats_fields(),
+        };
+
+        SchemaSection {
+            id: "stats".to_string(),
+            label: "Stats".to_string(),
+            section_type: SectionType::AbilityScores,
+            fields,
+            collapsible: false,
+            collapsed_default: false,
+            description: Some(self.stats_description().to_string()),
+        }
+    }
+
+    fn standard_pbta_stats_fields(&self) -> Vec<FieldDefinition> {
+        self.stat_names()
+            .iter()
+            .map(|stat| FieldDefinition {
+                id: stat.to_string(),
+                label: stat.to_string(),
+                field_type: SchemaFieldType::Integer {
+                    min: Some(-2),
+                    max: Some(3),
+                    show_modifier: true,
+                },
+                editable: true,
+                required: true,
+                derived_from: None,
+                validation: Some(FieldValidation {
+                    min: Some(-2),
+                    max: Some(3),
+                    pattern: None,
+                    error_message: Some("Stats must be between -2 and +3".to_string()),
+                }),
+                layout: FieldLayout {
+                    width: Some(2),
+                    ..Default::default()
+                },
+                description: self.stat_description(stat).map(|s| s.to_string()),
+                placeholder: None,
+            })
+            .collect()
+    }
+
+    fn dungeon_world_stats_fields(&self) -> Vec<FieldDefinition> {
+        let stats = [
+            ("STR", "Strength", "Physical power, melee attacks"),
+            ("DEX", "Dexterity", "Agility, ranged attacks, defense"),
+            ("CON", "Constitution", "Endurance, health"),
+            ("INT", "Intelligence", "Knowledge, spout lore"),
+            ("WIS", "Wisdom", "Perception, discern realities"),
+            ("CHA", "Charisma", "Influence, parley"),
+        ];
+
+        let mut fields: Vec<FieldDefinition> = stats
+            .iter()
+            .map(|(id, label, desc)| FieldDefinition {
+                id: id.to_string(),
+                label: label.to_string(),
+                field_type: SchemaFieldType::AbilityScore {
+                    min: Some(3),
+                    max: Some(18),
+                },
+                editable: true,
+                required: true,
+                derived_from: None,
+                validation: Some(FieldValidation {
+                    min: Some(3),
+                    max: Some(18),
+                    pattern: None,
+                    error_message: Some("Ability scores must be 3-18".to_string()),
+                }),
+                layout: FieldLayout {
+                    width: Some(2),
+                    ..Default::default()
+                },
+                description: Some(desc.to_string()),
+                placeholder: None,
+            })
+            .collect();
+
+        // Add Level field for Dungeon World
+        fields.push(FieldDefinition {
+            id: "LEVEL".to_string(),
+            label: "Level".to_string(),
+            field_type: SchemaFieldType::Integer {
+                min: Some(1),
+                max: Some(10),
+                show_modifier: false,
+            },
+            editable: true,
+            required: true,
+            derived_from: None,
+            validation: Some(FieldValidation {
+                min: Some(1),
+                max: Some(10),
+                pattern: None,
+                error_message: Some("Level must be 1-10".to_string()),
+            }),
+            layout: FieldLayout {
+                width: Some(2),
+                new_row: true,
+                ..Default::default()
+            },
+            description: Some("Character level".to_string()),
+            placeholder: None,
+        });
+
+        // Add Armor field for Dungeon World
+        fields.push(FieldDefinition {
+            id: "ARMOR".to_string(),
+            label: "Armor".to_string(),
+            field_type: SchemaFieldType::Integer {
+                min: Some(0),
+                max: Some(5),
+                show_modifier: false,
+            },
+            editable: true,
+            required: false,
+            derived_from: None,
+            validation: None,
+            layout: FieldLayout {
+                width: Some(2),
+                ..Default::default()
+            },
+            description: Some("Damage reduction from armor".to_string()),
+            placeholder: None,
+        });
+
+        fields
+    }
+
+    fn harm_section(&self) -> SchemaSection {
+        let fields = match self.variant {
+            PbtaVariant::ApocalypseWorld => self.apocalypse_world_harm_fields(),
+            PbtaVariant::DungeonWorld => self.dungeon_world_hp_fields(),
+            PbtaVariant::MonsterOfTheWeek => self.monster_of_the_week_harm_fields(),
+            PbtaVariant::Generic => self.generic_harm_fields(),
+        };
+
+        SchemaSection {
+            id: "harm".to_string(),
+            label: self.harm_label().to_string(),
+            section_type: SectionType::Combat,
+            fields,
+            collapsible: false,
+            collapsed_default: false,
+            description: Some(self.harm_description().to_string()),
+        }
+    }
+
+    fn apocalypse_world_harm_fields(&self) -> Vec<FieldDefinition> {
+        vec![
+            FieldDefinition {
+                id: "HARM".to_string(),
+                label: "Harm".to_string(),
+                field_type: SchemaFieldType::Clock { segments: 6 },
+                editable: true,
+                required: false,
+                derived_from: None,
+                validation: Some(FieldValidation {
+                    min: Some(0),
+                    max: Some(6),
+                    pattern: None,
+                    error_message: Some("Harm must be 0-6".to_string()),
+                }),
+                layout: FieldLayout {
+                    width: Some(6),
+                    ..Default::default()
+                },
+                description: Some(
+                    "When you take harm, mark segments. At 6, you're at death's door.".to_string(),
+                ),
+                placeholder: None,
+            },
+            FieldDefinition {
+                id: "STABILIZED".to_string(),
+                label: "Stabilized".to_string(),
+                field_type: SchemaFieldType::Boolean {
+                    checked_label: Some("Stabilized".to_string()),
+                    unchecked_label: Some("Unstable".to_string()),
+                },
+                editable: true,
+                required: false,
+                derived_from: None,
+                validation: None,
+                layout: FieldLayout {
+                    width: Some(3),
+                    ..Default::default()
+                },
+                description: Some("Whether you've been stabilized after taking harm".to_string()),
+                placeholder: None,
+            },
+        ]
+    }
+
+    fn dungeon_world_hp_fields(&self) -> Vec<FieldDefinition> {
+        vec![
+            FieldDefinition {
+                id: "CURRENT_HP".to_string(),
+                label: "Current HP".to_string(),
+                field_type: SchemaFieldType::ResourceBar {
+                    max_field: "MAX_HP".to_string(),
+                    color: ResourceColor::Red,
+                },
+                editable: true,
+                required: false,
+                derived_from: None,
+                validation: None,
+                layout: FieldLayout {
+                    width: Some(6),
+                    ..Default::default()
+                },
+                description: None,
+                placeholder: None,
+            },
+            FieldDefinition {
+                id: "MAX_HP".to_string(),
+                label: "Max HP".to_string(),
+                field_type: SchemaFieldType::Integer {
+                    min: Some(1),
+                    max: None,
+                    show_modifier: false,
+                },
+                editable: false,
+                required: false,
+                derived_from: Some(DerivedField {
+                    derivation_type: DerivationType::Custom,
+                    dependencies: vec!["PLAYBOOK".to_string(), "CON".to_string()],
+                    display_format: None,
+                }),
+                validation: None,
+                layout: FieldLayout {
+                    width: Some(3),
+                    ..Default::default()
+                },
+                description: Some("Class base + Constitution score".to_string()),
+                placeholder: None,
+            },
+            FieldDefinition {
+                id: "DAMAGE_DIE".to_string(),
+                label: "Damage".to_string(),
+                field_type: SchemaFieldType::Text {
+                    multiline: false,
+                    max_length: Some(10),
+                },
+                editable: true,
+                required: false,
+                derived_from: None,
+                validation: None,
+                layout: FieldLayout {
+                    width: Some(3),
+                    ..Default::default()
+                },
+                description: Some("Your class damage die".to_string()),
+                placeholder: Some("d8".to_string()),
+            },
+        ]
+    }
+
+    fn monster_of_the_week_harm_fields(&self) -> Vec<FieldDefinition> {
+        vec![
+            FieldDefinition {
+                id: "HARM".to_string(),
+                label: "Harm".to_string(),
+                field_type: SchemaFieldType::Clock { segments: 7 },
+                editable: true,
+                required: false,
+                derived_from: None,
+                validation: Some(FieldValidation {
+                    min: Some(0),
+                    max: Some(7),
+                    pattern: None,
+                    error_message: Some("Harm must be 0-7".to_string()),
+                }),
+                layout: FieldLayout {
+                    width: Some(6),
+                    ..Default::default()
+                },
+                description: Some(
+                    "Mark harm as you take it. At 4+, you're unstable. At 7, you're dying."
+                        .to_string(),
+                ),
+                placeholder: None,
+            },
+            FieldDefinition {
+                id: "UNSTABLE".to_string(),
+                label: "Unstable".to_string(),
+                field_type: SchemaFieldType::Boolean {
+                    checked_label: Some("Unstable".to_string()),
+                    unchecked_label: Some("Stable".to_string()),
+                },
+                editable: true,
+                required: false,
+                derived_from: None,
+                validation: None,
+                layout: FieldLayout {
+                    width: Some(3),
+                    ..Default::default()
+                },
+                description: Some("At 4+ harm, you become unstable".to_string()),
+                placeholder: None,
+            },
+            FieldDefinition {
+                id: "LUCK".to_string(),
+                label: "Luck".to_string(),
+                field_type: SchemaFieldType::Clock { segments: 7 },
+                editable: true,
+                required: false,
+                derived_from: None,
+                validation: Some(FieldValidation {
+                    min: Some(0),
+                    max: Some(7),
+                    pattern: None,
+                    error_message: Some("Luck must be 0-7".to_string()),
+                }),
+                layout: FieldLayout {
+                    width: Some(6),
+                    new_row: true,
+                    ..Default::default()
+                },
+                description: Some("Spend luck to change a roll or avoid harm".to_string()),
+                placeholder: None,
+            },
+        ]
+    }
+
+    fn generic_harm_fields(&self) -> Vec<FieldDefinition> {
+        vec![
+            FieldDefinition {
+                id: "HARM".to_string(),
+                label: "Harm".to_string(),
+                field_type: SchemaFieldType::Clock { segments: 6 },
+                editable: true,
+                required: false,
+                derived_from: None,
+                validation: Some(FieldValidation {
+                    min: Some(0),
+                    max: Some(6),
+                    pattern: None,
+                    error_message: Some("Harm must be 0-6".to_string()),
+                }),
+                layout: FieldLayout {
+                    width: Some(6),
+                    ..Default::default()
+                },
+                description: Some("Track harm as you take damage".to_string()),
+                placeholder: None,
+            },
+        ]
+    }
+
+    fn moves_section(&self) -> SchemaSection {
+        SchemaSection {
+            id: "moves".to_string(),
+            label: "Moves".to_string(),
+            section_type: SectionType::Moves,
+            fields: vec![
+                FieldDefinition {
+                    id: "BASIC_MOVES".to_string(),
+                    label: "Basic Moves".to_string(),
+                    field_type: SchemaFieldType::Text {
+                        multiline: true,
+                        max_length: None,
+                    },
+                    editable: false,
+                    required: false,
+                    derived_from: None,
+                    validation: None,
+                    layout: FieldLayout {
+                        width: Some(12),
+                        ..Default::default()
+                    },
+                    description: Some("Moves available to all characters".to_string()),
+                    placeholder: None,
+                },
+                FieldDefinition {
+                    id: "PLAYBOOK_MOVES".to_string(),
+                    label: "Playbook Moves".to_string(),
+                    field_type: SchemaFieldType::Text {
+                        multiline: true,
+                        max_length: None,
+                    },
+                    editable: true,
+                    required: false,
+                    derived_from: None,
+                    validation: None,
+                    layout: FieldLayout {
+                        width: Some(12),
+                        new_row: true,
+                        ..Default::default()
+                    },
+                    description: Some("Moves from your playbook".to_string()),
+                    placeholder: Some("Enter your playbook moves...".to_string()),
+                },
+                FieldDefinition {
+                    id: "ADVANCED_MOVES".to_string(),
+                    label: "Advanced Moves".to_string(),
+                    field_type: SchemaFieldType::Text {
+                        multiline: true,
+                        max_length: None,
+                    },
+                    editable: true,
+                    required: false,
+                    derived_from: None,
+                    validation: None,
+                    layout: FieldLayout {
+                        width: Some(12),
+                        new_row: true,
+                        ..Default::default()
+                    },
+                    description: Some("Moves gained through advancement".to_string()),
+                    placeholder: Some("Enter advanced moves...".to_string()),
+                },
+            ],
+            collapsible: true,
+            collapsed_default: false,
+            description: Some("Your character's moves".to_string()),
+        }
+    }
+
+    fn resources_section(&self) -> SchemaSection {
+        let mut fields = vec![
+            FieldDefinition {
+                id: "XP".to_string(),
+                label: "Experience".to_string(),
+                field_type: SchemaFieldType::Clock {
+                    segments: self.xp_track_size(),
+                },
+                editable: true,
+                required: false,
+                derived_from: None,
+                validation: Some(FieldValidation {
+                    min: Some(0),
+                    max: Some(self.xp_track_size() as i32),
+                    pattern: None,
+                    error_message: None,
+                }),
+                layout: FieldLayout {
+                    width: Some(6),
+                    ..Default::default()
+                },
+                description: Some(self.xp_description().to_string()),
+                placeholder: None,
+            },
+            FieldDefinition {
+                id: "HOLD".to_string(),
+                label: "Hold".to_string(),
+                field_type: SchemaFieldType::Integer {
+                    min: Some(0),
+                    max: None,
+                    show_modifier: false,
+                },
+                editable: true,
+                required: false,
+                derived_from: None,
+                validation: None,
+                layout: FieldLayout {
+                    width: Some(3),
+                    ..Default::default()
+                },
+                description: Some("Spend hold from moves".to_string()),
+                placeholder: None,
+            },
+        ];
+
+        // Add Forward/Ongoing for all PbtA games
+        fields.push(FieldDefinition {
+            id: "FORWARD".to_string(),
+            label: "Forward".to_string(),
+            field_type: SchemaFieldType::Integer {
+                min: Some(-3),
+                max: Some(3),
+                show_modifier: true,
+            },
+            editable: true,
+            required: false,
+            derived_from: None,
+            validation: None,
+            layout: FieldLayout {
+                width: Some(3),
+                ..Default::default()
+            },
+            description: Some("One-time bonus to your next roll".to_string()),
+            placeholder: None,
+        });
+
+        fields.push(FieldDefinition {
+            id: "ONGOING".to_string(),
+            label: "Ongoing".to_string(),
+            field_type: SchemaFieldType::Integer {
+                min: Some(-3),
+                max: Some(3),
+                show_modifier: true,
+            },
+            editable: true,
+            required: false,
+            derived_from: None,
+            validation: None,
+            layout: FieldLayout {
+                width: Some(3),
+                new_row: true,
+                ..Default::default()
+            },
+            description: Some("Persistent bonus until condition ends".to_string()),
+            placeholder: None,
+        });
+
+        // Add variant-specific resources
+        match self.variant {
+            PbtaVariant::ApocalypseWorld => {
+                fields.push(FieldDefinition {
+                    id: "BARTER".to_string(),
+                    label: "Barter".to_string(),
+                    field_type: SchemaFieldType::Integer {
+                        min: Some(0),
+                        max: None,
+                        show_modifier: false,
+                    },
+                    editable: true,
+                    required: false,
+                    derived_from: None,
+                    validation: None,
+                    layout: FieldLayout {
+                        width: Some(3),
+                        ..Default::default()
+                    },
+                    description: Some("Trade goods and currency".to_string()),
+                    placeholder: None,
+                });
+            }
+            PbtaVariant::DungeonWorld => {
+                fields.push(FieldDefinition {
+                    id: "COIN".to_string(),
+                    label: "Coin".to_string(),
+                    field_type: SchemaFieldType::Integer {
+                        min: Some(0),
+                        max: None,
+                        show_modifier: false,
+                    },
+                    editable: true,
+                    required: false,
+                    derived_from: None,
+                    validation: None,
+                    layout: FieldLayout {
+                        width: Some(3),
+                        ..Default::default()
+                    },
+                    description: Some("Gold coins".to_string()),
+                    placeholder: None,
+                });
+                fields.push(FieldDefinition {
+                    id: "LOAD".to_string(),
+                    label: "Load".to_string(),
+                    field_type: SchemaFieldType::Text {
+                        multiline: false,
+                        max_length: Some(20),
+                    },
+                    editable: true,
+                    required: false,
+                    derived_from: None,
+                    validation: None,
+                    layout: FieldLayout {
+                        width: Some(3),
+                        ..Default::default()
+                    },
+                    description: Some("Current / Max load".to_string()),
+                    placeholder: Some("0 / 12".to_string()),
+                });
+            }
+            _ => {}
+        }
+
+        SchemaSection {
+            id: "resources".to_string(),
+            label: "Resources".to_string(),
+            section_type: SectionType::Resources,
+            fields,
+            collapsible: true,
+            collapsed_default: false,
+            description: None,
+        }
+    }
+
+    fn bonds_section(&self) -> SchemaSection {
+        let bond_label = match self.variant {
+            PbtaVariant::ApocalypseWorld => "Hx",
+            PbtaVariant::DungeonWorld => "Bonds",
+            PbtaVariant::MonsterOfTheWeek => "History",
+            PbtaVariant::Generic => "Bonds",
+        };
+
+        SchemaSection {
+            id: "bonds".to_string(),
+            label: bond_label.to_string(),
+            section_type: SectionType::Custom,
+            fields: vec![
+                FieldDefinition {
+                    id: "BOND_1".to_string(),
+                    label: format!("{} 1", bond_label),
+                    field_type: SchemaFieldType::Text {
+                        multiline: false,
+                        max_length: Some(200),
+                    },
+                    editable: true,
+                    required: false,
+                    derived_from: None,
+                    validation: None,
+                    layout: FieldLayout {
+                        width: Some(12),
+                        ..Default::default()
+                    },
+                    description: None,
+                    placeholder: Some("Relationship with another character...".to_string()),
+                },
+                FieldDefinition {
+                    id: "BOND_2".to_string(),
+                    label: format!("{} 2", bond_label),
+                    field_type: SchemaFieldType::Text {
+                        multiline: false,
+                        max_length: Some(200),
+                    },
+                    editable: true,
+                    required: false,
+                    derived_from: None,
+                    validation: None,
+                    layout: FieldLayout {
+                        width: Some(12),
+                        ..Default::default()
+                    },
+                    description: None,
+                    placeholder: Some("Relationship with another character...".to_string()),
+                },
+                FieldDefinition {
+                    id: "BOND_3".to_string(),
+                    label: format!("{} 3", bond_label),
+                    field_type: SchemaFieldType::Text {
+                        multiline: false,
+                        max_length: Some(200),
+                    },
+                    editable: true,
+                    required: false,
+                    derived_from: None,
+                    validation: None,
+                    layout: FieldLayout {
+                        width: Some(12),
+                        ..Default::default()
+                    },
+                    description: None,
+                    placeholder: Some("Relationship with another character...".to_string()),
+                },
+                FieldDefinition {
+                    id: "BOND_4".to_string(),
+                    label: format!("{} 4", bond_label),
+                    field_type: SchemaFieldType::Text {
+                        multiline: false,
+                        max_length: Some(200),
+                    },
+                    editable: true,
+                    required: false,
+                    derived_from: None,
+                    validation: None,
+                    layout: FieldLayout {
+                        width: Some(12),
+                        ..Default::default()
+                    },
+                    description: None,
+                    placeholder: Some("Relationship with another character...".to_string()),
+                },
+            ],
+            collapsible: true,
+            collapsed_default: false,
+            description: Some(self.bonds_description().to_string()),
+        }
+    }
+
+    // Helper methods for variant-specific content
+
+    fn playbook_label(&self) -> &str {
+        match self.variant {
+            PbtaVariant::DungeonWorld => "Class",
+            _ => "Playbook",
+        }
+    }
+
+    fn playbook_description(&self) -> &str {
+        match self.variant {
+            PbtaVariant::ApocalypseWorld => "Your character archetype in the apocalypse",
+            PbtaVariant::DungeonWorld => "Your adventuring class",
+            PbtaVariant::MonsterOfTheWeek => "Your hunter type",
+            PbtaVariant::Generic => "Your character archetype",
+        }
+    }
+
+    fn get_playbook_options(&self) -> Vec<SchemaSelectOption> {
+        match self.variant {
+            PbtaVariant::ApocalypseWorld => vec![
+                SchemaSelectOption {
+                    value: "angel".to_string(),
+                    label: "The Angel".to_string(),
+                    description: Some("A healer and medic".to_string()),
+                },
+                SchemaSelectOption {
+                    value: "battlebabe".to_string(),
+                    label: "The Battlebabe".to_string(),
+                    description: Some("A dangerous and sexy warrior".to_string()),
+                },
+                SchemaSelectOption {
+                    value: "brainer".to_string(),
+                    label: "The Brainer".to_string(),
+                    description: Some("A psychic weirdo".to_string()),
+                },
+                SchemaSelectOption {
+                    value: "chopper".to_string(),
+                    label: "The Chopper".to_string(),
+                    description: Some("A biker gang leader".to_string()),
+                },
+                SchemaSelectOption {
+                    value: "driver".to_string(),
+                    label: "The Driver".to_string(),
+                    description: Some("A road warrior".to_string()),
+                },
+                SchemaSelectOption {
+                    value: "gunlugger".to_string(),
+                    label: "The Gunlugger".to_string(),
+                    description: Some("A walking armory".to_string()),
+                },
+                SchemaSelectOption {
+                    value: "hardholder".to_string(),
+                    label: "The Hardholder".to_string(),
+                    description: Some("A warlord with a holding".to_string()),
+                },
+                SchemaSelectOption {
+                    value: "hocus".to_string(),
+                    label: "The Hocus".to_string(),
+                    description: Some("A cult leader".to_string()),
+                },
+                SchemaSelectOption {
+                    value: "maestrod".to_string(),
+                    label: "The Maestro D'".to_string(),
+                    description: Some("A proprietor of entertainment".to_string()),
+                },
+                SchemaSelectOption {
+                    value: "savvyhead".to_string(),
+                    label: "The Savvyhead".to_string(),
+                    description: Some("A techie and mechanic".to_string()),
+                },
+                SchemaSelectOption {
+                    value: "skinner".to_string(),
+                    label: "The Skinner".to_string(),
+                    description: Some("An artist and performer".to_string()),
+                },
+            ],
+            PbtaVariant::DungeonWorld => vec![
+                SchemaSelectOption {
+                    value: "bard".to_string(),
+                    label: "Bard".to_string(),
+                    description: Some("A storyteller and performer".to_string()),
+                },
+                SchemaSelectOption {
+                    value: "cleric".to_string(),
+                    label: "Cleric".to_string(),
+                    description: Some("A servant of the gods".to_string()),
+                },
+                SchemaSelectOption {
+                    value: "druid".to_string(),
+                    label: "Druid".to_string(),
+                    description: Some("A shapeshifter and nature's champion".to_string()),
+                },
+                SchemaSelectOption {
+                    value: "fighter".to_string(),
+                    label: "Fighter".to_string(),
+                    description: Some("A master of combat".to_string()),
+                },
+                SchemaSelectOption {
+                    value: "paladin".to_string(),
+                    label: "Paladin".to_string(),
+                    description: Some("A holy warrior".to_string()),
+                },
+                SchemaSelectOption {
+                    value: "ranger".to_string(),
+                    label: "Ranger".to_string(),
+                    description: Some("A tracker and hunter".to_string()),
+                },
+                SchemaSelectOption {
+                    value: "thief".to_string(),
+                    label: "Thief".to_string(),
+                    description: Some("A cunning rogue".to_string()),
+                },
+                SchemaSelectOption {
+                    value: "wizard".to_string(),
+                    label: "Wizard".to_string(),
+                    description: Some("A wielder of arcane magic".to_string()),
+                },
+            ],
+            PbtaVariant::MonsterOfTheWeek => vec![
+                SchemaSelectOption {
+                    value: "chosen".to_string(),
+                    label: "The Chosen".to_string(),
+                    description: Some("Destined to fight evil".to_string()),
+                },
+                SchemaSelectOption {
+                    value: "crooked".to_string(),
+                    label: "The Crooked".to_string(),
+                    description: Some("A criminal with a past".to_string()),
+                },
+                SchemaSelectOption {
+                    value: "divine".to_string(),
+                    label: "The Divine".to_string(),
+                    description: Some("An agent of a higher power".to_string()),
+                },
+                SchemaSelectOption {
+                    value: "expert".to_string(),
+                    label: "The Expert".to_string(),
+                    description: Some("The one who knows things".to_string()),
+                },
+                SchemaSelectOption {
+                    value: "flake".to_string(),
+                    label: "The Flake".to_string(),
+                    description: Some("A conspiracy theorist who's right".to_string()),
+                },
+                SchemaSelectOption {
+                    value: "initiate".to_string(),
+                    label: "The Initiate".to_string(),
+                    description: Some("Member of a secret society".to_string()),
+                },
+                SchemaSelectOption {
+                    value: "monstrous".to_string(),
+                    label: "The Monstrous".to_string(),
+                    description: Some("A monster fighting for good".to_string()),
+                },
+                SchemaSelectOption {
+                    value: "mundane".to_string(),
+                    label: "The Mundane".to_string(),
+                    description: Some("An ordinary person in an extraordinary world".to_string()),
+                },
+                SchemaSelectOption {
+                    value: "professional".to_string(),
+                    label: "The Professional".to_string(),
+                    description: Some("A monster hunting organization member".to_string()),
+                },
+                SchemaSelectOption {
+                    value: "spellslinger".to_string(),
+                    label: "The Spell-slinger".to_string(),
+                    description: Some("A practitioner of magic".to_string()),
+                },
+                SchemaSelectOption {
+                    value: "spooky".to_string(),
+                    label: "The Spooky".to_string(),
+                    description: Some("Touched by dark powers".to_string()),
+                },
+                SchemaSelectOption {
+                    value: "wronged".to_string(),
+                    label: "The Wronged".to_string(),
+                    description: Some("Seeking vengeance for a loss".to_string()),
+                },
+            ],
+            PbtaVariant::Generic => vec![
+                SchemaSelectOption {
+                    value: "custom".to_string(),
+                    label: "Custom Playbook".to_string(),
+                    description: Some("Define your own archetype".to_string()),
+                },
+            ],
+        }
+    }
+
+    fn stats_description(&self) -> &str {
+        match self.variant {
+            PbtaVariant::DungeonWorld => {
+                "Assign scores using the standard array: 16, 15, 13, 12, 9, 8"
+            }
+            _ => "Assign stats according to your playbook. Stats range from -1 to +3.",
+        }
+    }
+
+    fn stat_description(&self, stat: &str) -> Option<&str> {
+        match self.variant {
+            PbtaVariant::ApocalypseWorld => match stat {
+                "Cool" => Some("Keep your cool under pressure"),
+                "Hard" => Some("Use violence and intimidation"),
+                "Hot" => Some("Seduce and manipulate"),
+                "Sharp" => Some("Perceive and understand"),
+                "Weird" => Some("Connect to the psychic maelstrom"),
+                _ => None,
+            },
+            PbtaVariant::MonsterOfTheWeek => match stat {
+                "Charm" => Some("Manipulate and influence"),
+                "Cool" => Some("Stay calm under pressure"),
+                "Sharp" => Some("Investigate and perceive"),
+                "Tough" => Some("Fight and endure"),
+                "Weird" => Some("Use magic and the supernatural"),
+                _ => None,
+            },
+            _ => None,
+        }
+    }
+
+    fn harm_label(&self) -> &str {
+        match self.variant {
+            PbtaVariant::DungeonWorld => "Hit Points",
+            _ => "Harm",
+        }
+    }
+
+    fn harm_description(&self) -> &str {
+        match self.variant {
+            PbtaVariant::ApocalypseWorld => {
+                "Track harm on the clock. At 6, you're at death's door."
+            }
+            PbtaVariant::DungeonWorld => "Your hit points. When you reach 0, take your Last Breath.",
+            PbtaVariant::MonsterOfTheWeek => {
+                "Track harm. At 4+, you're unstable. At 7, you're dying."
+            }
+            PbtaVariant::Generic => "Track harm as you take damage.",
+        }
+    }
+
+    fn xp_track_size(&self) -> u8 {
+        match self.variant {
+            PbtaVariant::DungeonWorld => 8, // Level + 7 at level 1
+            _ => 5,                         // Most PbtA games use 5
+        }
+    }
+
+    fn xp_description(&self) -> &str {
+        match self.variant {
+            PbtaVariant::DungeonWorld => "Mark XP when you fail a roll or at end of session",
+            PbtaVariant::MonsterOfTheWeek => "Mark XP on a miss or end of mystery",
+            _ => "Mark XP when you fail a roll",
+        }
+    }
+
+    fn bonds_description(&self) -> &str {
+        match self.variant {
+            PbtaVariant::ApocalypseWorld => {
+                "Hx represents how well you know other characters. Higher is better for helping."
+            }
+            PbtaVariant::DungeonWorld => {
+                "Bonds describe your relationships with other characters."
+            }
+            PbtaVariant::MonsterOfTheWeek => "History with other hunters in your team.",
+            PbtaVariant::Generic => "Your relationships with other characters.",
+        }
+    }
+}
+
+/// Get Apocalypse World basic moves.
+fn apocalypse_world_basic_moves() -> Vec<PbtaMove> {
+    vec![
+        PbtaMove::new(
+            "act_under_fire",
+            "Act Under Fire",
+            "When you do something under fire, or dig in to endure fire",
+            Some("Cool"),
+            "You do it",
+            "You stumble, hesitate, or flinch: the MC offers you a worse outcome, a hard bargain, or an ugly choice",
+        ),
+        PbtaMove::new(
+            "go_aggro",
+            "Go Aggro",
+            "When you go aggro on someone",
+            Some("Hard"),
+            "They have to choose: force your hand and suffer, or comply",
+            "They can instead choose: get the hell out, barricade themselves in, give you something they think you want, or back off calmly",
+        ),
+        PbtaMove::new(
+            "seize_by_force",
+            "Seize by Force",
+            "When you try to seize something by force, or to secure your hold on something",
+            Some("Hard"),
+            "Choose 3 from the list",
+            "Choose 2 from the list",
+        ),
+        PbtaMove::new(
+            "seduce_manipulate",
+            "Seduce or Manipulate",
+            "When you try to seduce or manipulate someone",
+            Some("Hot"),
+            "For NPCs: They do it. For PCs: They mark XP if they do it",
+            "For NPCs: They'll do it, but need something first. For PCs: They mark XP if they do it",
+        ),
+        PbtaMove::new(
+            "read_person",
+            "Read a Person",
+            "When you read a person in a charged interaction",
+            Some("Sharp"),
+            "Hold 3, ask questions",
+            "Hold 1, ask questions",
+        ),
+        PbtaMove::new(
+            "read_sitch",
+            "Read a Sitch",
+            "When you read a charged situation",
+            Some("Sharp"),
+            "Ask the MC 3 questions",
+            "Ask the MC 1 question",
+        ),
+        PbtaMove::new(
+            "open_brain",
+            "Open Your Brain",
+            "When you open your brain to the world's psychic maelstrom",
+            Some("Weird"),
+            "The MC tells you something new and interesting, and might ask you a question",
+            "The MC tells you something new and interesting, and it's probably distressing or alarming",
+        ),
+    ]
+}
+
+/// Get Dungeon World basic moves.
+fn dungeon_world_basic_moves() -> Vec<PbtaMove> {
+    vec![
+        PbtaMove::new(
+            "hack_slash",
+            "Hack and Slash",
+            "When you attack an enemy in melee",
+            Some("STR"),
+            "You deal your damage to the enemy and avoid their attack",
+            "You deal your damage to the enemy and the enemy makes an attack against you",
+        ),
+        PbtaMove::new(
+            "volley",
+            "Volley",
+            "When you take aim and shoot at an enemy at range",
+            Some("DEX"),
+            "You deal your damage",
+            "Choose one: move to avoid fire, take what you can get (-1d6 damage), or spend ammo",
+        ),
+        PbtaMove::new(
+            "defy_danger",
+            "Defy Danger",
+            "When you act despite an imminent threat or suffer a calamity",
+            None::<String>, // Varies by approach
+            "You do what you set out to, the threat doesn't come to bear",
+            "You stumble, hesitate, or flinch: the GM offers a worse outcome, hard bargain, or ugly choice",
+        ),
+        PbtaMove::new(
+            "defend",
+            "Defend",
+            "When you stand in defense of a person, item, or location under attack",
+            Some("CON"),
+            "Hold 3",
+            "Hold 1",
+        ),
+        PbtaMove::new(
+            "spout_lore",
+            "Spout Lore",
+            "When you consult your accumulated knowledge about something",
+            Some("INT"),
+            "The GM tells you something interesting and useful",
+            "The GM tells you something interesting—it's on you to make it useful",
+        ),
+        PbtaMove::new(
+            "discern_realities",
+            "Discern Realities",
+            "When you closely study a situation or person",
+            Some("WIS"),
+            "Ask the GM 3 questions from the list",
+            "Ask the GM 1 question from the list",
+        ),
+        PbtaMove::new(
+            "parley",
+            "Parley",
+            "When you have leverage on an NPC and manipulate them",
+            Some("CHA"),
+            "They do what you ask if you first promise what they ask of you",
+            "They'll do what you ask, but need concrete assurance first",
+        ),
+        PbtaMove::new(
+            "aid_interfere",
+            "Aid or Interfere",
+            "When you help or hinder someone",
+            Some("Bond"),
+            "They take +1 or -2 to their roll (your choice)",
+            "They take +1 or -2, but you expose yourself to danger, retribution, or cost",
+        ),
+    ]
+}
+
+/// Get Monster of the Week basic moves.
+fn monster_of_the_week_basic_moves() -> Vec<PbtaMove> {
+    vec![
+        PbtaMove::new(
+            "act_under_pressure",
+            "Act Under Pressure",
+            "When you act under pressure, do something difficult or dangerous",
+            Some("Cool"),
+            "You do it",
+            "The Keeper tells you something bad happens or offers a hard choice",
+        ),
+        PbtaMove::new(
+            "help_out",
+            "Help Out",
+            "When you help another hunter",
+            Some("Cool"),
+            "They get +1 to their roll",
+            "They get +1, but you also expose yourself to trouble",
+        ),
+        PbtaMove::new(
+            "investigate_mystery",
+            "Investigate a Mystery",
+            "When you investigate a mystery",
+            Some("Sharp"),
+            "Hold 2. Ask the Keeper questions.",
+            "Hold 1. Ask the Keeper one question.",
+        ),
+        PbtaMove::new(
+            "kick_ass",
+            "Kick Some Ass",
+            "When you get into a fight",
+            Some("Tough"),
+            "You and the enemy inflict harm on each other",
+            "You and the enemy inflict harm, plus pick one bad thing from the list",
+        ),
+        PbtaMove::new(
+            "manipulate",
+            "Manipulate Someone",
+            "When you try to manipulate someone",
+            Some("Charm"),
+            "They do what you want",
+            "They'll do it but need something in return",
+        ),
+        PbtaMove::new(
+            "protect",
+            "Protect Someone",
+            "When you protect someone from harm",
+            Some("Tough"),
+            "You protect them. Choose an extra benefit.",
+            "You protect them, but you suffer harm or are put in danger",
+        ),
+        PbtaMove::new(
+            "read_bad_situation",
+            "Read a Bad Situation",
+            "When you look around to work out what's going on",
+            Some("Sharp"),
+            "Hold 3. Ask questions.",
+            "Hold 1. Ask one question.",
+        ),
+        PbtaMove::new(
+            "use_magic",
+            "Use Magic",
+            "When you use magic",
+            Some("Weird"),
+            "The magic works without issues",
+            "It works imperfectly—the Keeper picks one drawback",
+        ),
+    ]
+}
+
+/// Forward/Ongoing modifier.
+#[derive(Debug, Clone)]
+pub struct PbtaModifier {
+    pub value: i8,
+    pub modifier_type: ModifierType,
+    pub source: String,
+    pub applies_to: Option<String>, // Specific move or stat, None = any
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ModifierType {
+    /// One-time bonus, consumed after use
+    Forward,
+    /// Persistent bonus until condition ends
+    Ongoing,
+}
+
+/// Hold from a move.
+#[derive(Debug, Clone)]
+pub struct MoveHold {
+    pub move_id: String,
+    pub amount: u8,
+    pub options: Vec<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn outcome_determination() {
+        assert_eq!(PbtaOutcome::from_total(12), PbtaOutcome::FullSuccess);
+        assert_eq!(PbtaOutcome::from_total(10), PbtaOutcome::FullSuccess);
+        assert_eq!(PbtaOutcome::from_total(9), PbtaOutcome::PartialSuccess);
+        assert_eq!(PbtaOutcome::from_total(7), PbtaOutcome::PartialSuccess);
+        assert_eq!(PbtaOutcome::from_total(6), PbtaOutcome::Miss);
+        assert_eq!(PbtaOutcome::from_total(2), PbtaOutcome::Miss);
+    }
+
+    #[test]
+    fn outcome_is_success() {
+        assert!(PbtaOutcome::FullSuccess.is_success());
+        assert!(PbtaOutcome::PartialSuccess.is_success());
+        assert!(!PbtaOutcome::Miss.is_success());
+    }
+
+    #[test]
+    fn variant_system_ids() {
+        assert_eq!(PbtaSystem::apocalypse_world().system_id(), "pbta_aw");
+        assert_eq!(PbtaSystem::dungeon_world().system_id(), "pbta_dw");
+        assert_eq!(PbtaSystem::monster_of_the_week().system_id(), "pbta_motw");
+        assert_eq!(PbtaSystem::generic().system_id(), "pbta");
+    }
+
+    #[test]
+    fn variant_stat_names() {
+        let aw = PbtaSystem::apocalypse_world();
+        assert!(aw.stat_names().contains(&"Cool"));
+        assert!(aw.stat_names().contains(&"Weird"));
+
+        let dw = PbtaSystem::dungeon_world();
+        assert!(dw.stat_names().contains(&"STR"));
+        assert!(dw.stat_names().contains(&"CHA"));
+
+        let motw = PbtaSystem::monster_of_the_week();
+        assert!(motw.stat_names().contains(&"Charm"));
+        assert!(motw.stat_names().contains(&"Tough"));
+    }
+
+    #[test]
+    fn dungeon_world_hp() {
+        let system = PbtaSystem::dungeon_world();
+        // Fighter: base 10 + CON
+        assert_eq!(system.calculate_max_hp(1, "Fighter", 16, 0), 26);
+        // Wizard: base 4 + CON
+        assert_eq!(system.calculate_max_hp(1, "Wizard", 8, 0), 12);
+    }
+
+    #[test]
+    fn move_creation() {
+        let mv = PbtaMove::new(
+            "test",
+            "Test Move",
+            "When you test",
+            Some("Cool"),
+            "You succeed",
+            "You succeed at a cost",
+        )
+        .with_miss("The GM makes a hard move");
+
+        assert!(mv.requires_roll());
+        assert_eq!(mv.stat, Some("Cool".to_string()));
+        assert!(mv.miss.is_some());
+    }
+
+    #[test]
+    fn basic_moves_exist() {
+        let aw = PbtaSystem::apocalypse_world();
+        let moves = aw.basic_moves();
+        assert!(!moves.is_empty());
+        assert!(moves.iter().any(|m| m.id == "act_under_fire"));
+
+        let dw = PbtaSystem::dungeon_world();
+        let moves = dw.basic_moves();
+        assert!(moves.iter().any(|m| m.id == "hack_slash"));
+    }
+
+    // CharacterSheetProvider tests
+
+    #[test]
+    fn character_sheet_schema_has_correct_system_info() {
+        let aw = PbtaSystem::apocalypse_world();
+        let schema = aw.character_sheet_schema();
+        assert_eq!(schema.system_id, "pbta_aw");
+        assert_eq!(schema.system_name, "Apocalypse World");
+
+        let dw = PbtaSystem::dungeon_world();
+        let schema = dw.character_sheet_schema();
+        assert_eq!(schema.system_id, "pbta_dw");
+        assert_eq!(schema.system_name, "Dungeon World");
+
+        let motw = PbtaSystem::monster_of_the_week();
+        let schema = motw.character_sheet_schema();
+        assert_eq!(schema.system_id, "pbta_motw");
+        assert_eq!(schema.system_name, "Monster of the Week");
+    }
+
+    #[test]
+    fn character_sheet_has_required_sections() {
+        let system = PbtaSystem::apocalypse_world();
+        let schema = system.character_sheet_schema();
+
+        let section_ids: Vec<&str> = schema.sections.iter().map(|s| s.id.as_str()).collect();
+        assert!(section_ids.contains(&"identity"));
+        assert!(section_ids.contains(&"stats"));
+        assert!(section_ids.contains(&"harm"));
+        assert!(section_ids.contains(&"moves"));
+        assert!(section_ids.contains(&"resources"));
+        assert!(section_ids.contains(&"bonds"));
+    }
+
+    #[test]
+    fn apocalypse_world_has_correct_stats() {
+        let system = PbtaSystem::apocalypse_world();
+        let schema = system.character_sheet_schema();
+
+        let stats_section = schema.sections.iter().find(|s| s.id == "stats").unwrap();
+        let stat_ids: Vec<&str> = stats_section.fields.iter().map(|f| f.id.as_str()).collect();
+
+        assert!(stat_ids.contains(&"Cool"));
+        assert!(stat_ids.contains(&"Hard"));
+        assert!(stat_ids.contains(&"Hot"));
+        assert!(stat_ids.contains(&"Sharp"));
+        assert!(stat_ids.contains(&"Weird"));
+    }
+
+    #[test]
+    fn dungeon_world_has_dnd_style_stats() {
+        let system = PbtaSystem::dungeon_world();
+        let schema = system.character_sheet_schema();
+
+        let stats_section = schema.sections.iter().find(|s| s.id == "stats").unwrap();
+        let stat_ids: Vec<&str> = stats_section.fields.iter().map(|f| f.id.as_str()).collect();
+
+        assert!(stat_ids.contains(&"STR"));
+        assert!(stat_ids.contains(&"DEX"));
+        assert!(stat_ids.contains(&"CON"));
+        assert!(stat_ids.contains(&"INT"));
+        assert!(stat_ids.contains(&"WIS"));
+        assert!(stat_ids.contains(&"CHA"));
+        assert!(stat_ids.contains(&"LEVEL"));
+        assert!(stat_ids.contains(&"ARMOR"));
+    }
+
+    #[test]
+    fn monster_of_the_week_has_luck_field() {
+        let system = PbtaSystem::monster_of_the_week();
+        let schema = system.character_sheet_schema();
+
+        let harm_section = schema.sections.iter().find(|s| s.id == "harm").unwrap();
+        let field_ids: Vec<&str> = harm_section.fields.iter().map(|f| f.id.as_str()).collect();
+
+        assert!(field_ids.contains(&"HARM"));
+        assert!(field_ids.contains(&"LUCK"));
+        assert!(field_ids.contains(&"UNSTABLE"));
+    }
+
+    #[test]
+    fn dungeon_world_has_hp_fields() {
+        let system = PbtaSystem::dungeon_world();
+        let schema = system.character_sheet_schema();
+
+        let harm_section = schema.sections.iter().find(|s| s.id == "harm").unwrap();
+        let field_ids: Vec<&str> = harm_section.fields.iter().map(|f| f.id.as_str()).collect();
+
+        assert!(field_ids.contains(&"CURRENT_HP"));
+        assert!(field_ids.contains(&"MAX_HP"));
+        assert!(field_ids.contains(&"DAMAGE_DIE"));
+    }
+
+    #[test]
+    fn default_values_are_set_correctly() {
+        let aw = PbtaSystem::apocalypse_world();
+        let defaults = aw.default_values();
+
+        assert_eq!(defaults.get("Cool"), Some(&serde_json::json!(0)));
+        assert_eq!(defaults.get("Hard"), Some(&serde_json::json!(0)));
+        assert_eq!(defaults.get("XP"), Some(&serde_json::json!(0)));
+        assert_eq!(defaults.get("HOLD"), Some(&serde_json::json!(0)));
+
+        let dw = PbtaSystem::dungeon_world();
+        let defaults = dw.default_values();
+
+        assert_eq!(defaults.get("STR"), Some(&serde_json::json!(10)));
+        assert_eq!(defaults.get("LEVEL"), Some(&serde_json::json!(1)));
+        assert_eq!(defaults.get("ARMOR"), Some(&serde_json::json!(0)));
+    }
+
+    #[test]
+    fn validate_pbta_stats() {
+        let system = PbtaSystem::apocalypse_world();
+        let all_values = HashMap::new();
+
+        // Valid stat
+        assert!(system.validate_field("Cool", &serde_json::json!(2), &all_values).is_none());
+        assert!(system.validate_field("Cool", &serde_json::json!(-1), &all_values).is_none());
+
+        // Invalid stat (out of range)
+        assert!(system.validate_field("Cool", &serde_json::json!(5), &all_values).is_some());
+        assert!(system.validate_field("Cool", &serde_json::json!(-3), &all_values).is_some());
+    }
+
+    #[test]
+    fn validate_dungeon_world_ability_scores() {
+        let system = PbtaSystem::dungeon_world();
+        let all_values = HashMap::new();
+
+        // Valid score
+        assert!(system.validate_field("STR", &serde_json::json!(16), &all_values).is_none());
+
+        // Invalid score (out of range)
+        assert!(system.validate_field("STR", &serde_json::json!(20), &all_values).is_some());
+        assert!(system.validate_field("STR", &serde_json::json!(2), &all_values).is_some());
+    }
+
+    #[test]
+    fn calculate_derived_values_aw() {
+        let system = PbtaSystem::apocalypse_world();
+        let mut values = HashMap::new();
+        values.insert("Cool".to_string(), serde_json::json!(2));
+        values.insert("XP".to_string(), serde_json::json!(3));
+
+        let derived = system.calculate_derived_values(&values);
+
+        assert_eq!(derived.get("Cool_MOD"), Some(&serde_json::json!(2)));
+        assert_eq!(derived.get("XP_MAX"), Some(&serde_json::json!(5)));
+        assert_eq!(derived.get("XP_REMAINING"), Some(&serde_json::json!(2)));
+    }
+
+    #[test]
+    fn calculate_derived_values_dw() {
+        let system = PbtaSystem::dungeon_world();
+        let mut values = HashMap::new();
+        values.insert("STR".to_string(), serde_json::json!(16));
+        values.insert("CON".to_string(), serde_json::json!(14));
+        values.insert("PLAYBOOK".to_string(), serde_json::json!("fighter"));
+        values.insert("LEVEL".to_string(), serde_json::json!(1));
+        values.insert("XP".to_string(), serde_json::json!(2));
+
+        let derived = system.calculate_derived_values(&values);
+
+        // STR 16 -> modifier +3
+        assert_eq!(derived.get("STR_MOD"), Some(&serde_json::json!(3)));
+        // CON 14 -> modifier +2
+        assert_eq!(derived.get("CON_MOD"), Some(&serde_json::json!(2)));
+        // Fighter base 10 + CON 14 = 24
+        assert_eq!(derived.get("MAX_HP"), Some(&serde_json::json!(24)));
+        // Level 1 + 7 = 8 XP to level
+        assert_eq!(derived.get("XP_MAX"), Some(&serde_json::json!(8)));
+    }
+
+    #[test]
+    fn creation_steps_are_ordered() {
+        let system = PbtaSystem::generic();
+        let schema = system.character_sheet_schema();
+
+        assert!(!schema.creation_steps.is_empty());
+
+        let mut prev_order = 0;
+        for step in &schema.creation_steps {
+            assert!(step.order > prev_order);
+            prev_order = step.order;
+        }
+    }
+
+    #[test]
+    fn playbook_options_vary_by_variant() {
+        let aw = PbtaSystem::apocalypse_world();
+        let aw_options = aw.get_playbook_options();
+        assert!(aw_options.iter().any(|o| o.value == "angel"));
+        assert!(aw_options.iter().any(|o| o.value == "battlebabe"));
+
+        let dw = PbtaSystem::dungeon_world();
+        let dw_options = dw.get_playbook_options();
+        assert!(dw_options.iter().any(|o| o.value == "fighter"));
+        assert!(dw_options.iter().any(|o| o.value == "wizard"));
+
+        let motw = PbtaSystem::monster_of_the_week();
+        let motw_options = motw.get_playbook_options();
+        assert!(motw_options.iter().any(|o| o.value == "chosen"));
+        assert!(motw_options.iter().any(|o| o.value == "spooky"));
+    }
+
+    #[test]
+    fn resources_section_has_forward_and_ongoing() {
+        let system = PbtaSystem::apocalypse_world();
+        let schema = system.character_sheet_schema();
+
+        let resources = schema.sections.iter().find(|s| s.id == "resources").unwrap();
+        let field_ids: Vec<&str> = resources.fields.iter().map(|f| f.id.as_str()).collect();
+
+        assert!(field_ids.contains(&"XP"));
+        assert!(field_ids.contains(&"HOLD"));
+        assert!(field_ids.contains(&"FORWARD"));
+        assert!(field_ids.contains(&"ONGOING"));
+    }
+
+    #[test]
+    fn apocalypse_world_has_barter() {
+        let system = PbtaSystem::apocalypse_world();
+        let schema = system.character_sheet_schema();
+
+        let resources = schema.sections.iter().find(|s| s.id == "resources").unwrap();
+        let field_ids: Vec<&str> = resources.fields.iter().map(|f| f.id.as_str()).collect();
+
+        assert!(field_ids.contains(&"BARTER"));
+    }
+
+    #[test]
+    fn dungeon_world_has_coin_and_load() {
+        let system = PbtaSystem::dungeon_world();
+        let schema = system.character_sheet_schema();
+
+        let resources = schema.sections.iter().find(|s| s.id == "resources").unwrap();
+        let field_ids: Vec<&str> = resources.fields.iter().map(|f| f.id.as_str()).collect();
+
+        assert!(field_ids.contains(&"COIN"));
+        assert!(field_ids.contains(&"LOAD"));
+    }
+
+    #[test]
+    fn bonds_section_varies_by_variant() {
+        let aw = PbtaSystem::apocalypse_world();
+        let aw_schema = aw.character_sheet_schema();
+        let aw_bonds = aw_schema.sections.iter().find(|s| s.id == "bonds").unwrap();
+        assert_eq!(aw_bonds.label, "Hx");
+
+        let dw = PbtaSystem::dungeon_world();
+        let dw_schema = dw.character_sheet_schema();
+        let dw_bonds = dw_schema.sections.iter().find(|s| s.id == "bonds").unwrap();
+        assert_eq!(dw_bonds.label, "Bonds");
+
+        let motw = PbtaSystem::monster_of_the_week();
+        let motw_schema = motw.character_sheet_schema();
+        let motw_bonds = motw_schema.sections.iter().find(|s| s.id == "bonds").unwrap();
+        assert_eq!(motw_bonds.label, "History");
+    }
+}

--- a/crates/domain/src/game_systems/pf2e.rs
+++ b/crates/domain/src/game_systems/pf2e.rs
@@ -1,0 +1,1952 @@
+//! Pathfinder 2nd Edition game system implementation.
+//!
+//! PF2e uses a d20 + modifier vs DC system with four degrees of success.
+//! Key differences from D&D 5e:
+//! - Proficiency is level-dependent (level + rank bonus)
+//! - Four degrees of success (Critical Success, Success, Failure, Critical Failure)
+//! - Three-action economy per turn
+//! - Multiple Attack Penalty (MAP)
+//! - Conditions have numeric values
+
+use super::traits::{
+    CalculationEngine, CasterType, CharacterSheetProvider, CharacterSheetSchema, CreationStep,
+    DerivedField, DerivationType, FieldDefinition, FieldLayout, FieldValidation, GameSystem,
+    ProficiencyLevel, ProficiencyOption, ResourceColor, SchemaFieldType, SchemaSection,
+    SchemaSelectOption, SectionType, SpellcastingSystem,
+};
+use crate::entities::{StatBlock, StatModifier};
+use std::collections::HashMap;
+
+/// Pathfinder 2e proficiency ranks.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum Pf2eProficiencyRank {
+    /// Not trained in the skill
+    Untrained,
+    /// Basic training (+2 + level)
+    Trained,
+    /// Advanced training (+4 + level)
+    Expert,
+    /// Mastery (+6 + level)
+    Master,
+    /// Ultimate mastery (+8 + level)
+    Legendary,
+}
+
+impl Pf2eProficiencyRank {
+    /// Get the rank bonus (before adding level).
+    pub fn rank_bonus(&self) -> i32 {
+        match self {
+            Pf2eProficiencyRank::Untrained => 0,
+            Pf2eProficiencyRank::Trained => 2,
+            Pf2eProficiencyRank::Expert => 4,
+            Pf2eProficiencyRank::Master => 6,
+            Pf2eProficiencyRank::Legendary => 8,
+        }
+    }
+
+    /// Calculate full proficiency bonus including level.
+    pub fn proficiency_bonus(&self, level: u8) -> i32 {
+        match self {
+            Pf2eProficiencyRank::Untrained => 0, // Untrained doesn't add level
+            _ => self.rank_bonus() + level as i32,
+        }
+    }
+}
+
+impl From<ProficiencyLevel> for Pf2eProficiencyRank {
+    fn from(level: ProficiencyLevel) -> Self {
+        match level {
+            ProficiencyLevel::None => Pf2eProficiencyRank::Untrained,
+            ProficiencyLevel::Half => Pf2eProficiencyRank::Trained, // Approximate
+            ProficiencyLevel::Proficient => Pf2eProficiencyRank::Trained,
+            ProficiencyLevel::Expert => Pf2eProficiencyRank::Expert,
+        }
+    }
+}
+
+/// Four degrees of success in PF2e.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DegreeOfSuccess {
+    /// Beat DC by 10+ OR natural 20 that succeeds
+    CriticalSuccess,
+    /// Meet or beat DC
+    Success,
+    /// Below DC
+    Failure,
+    /// Miss DC by 10+ OR natural 1 that fails
+    CriticalFailure,
+}
+
+impl DegreeOfSuccess {
+    /// Upgrade the degree by one step (e.g., nat 20).
+    pub fn upgrade(self) -> Self {
+        match self {
+            DegreeOfSuccess::CriticalFailure => DegreeOfSuccess::Failure,
+            DegreeOfSuccess::Failure => DegreeOfSuccess::Success,
+            DegreeOfSuccess::Success => DegreeOfSuccess::CriticalSuccess,
+            DegreeOfSuccess::CriticalSuccess => DegreeOfSuccess::CriticalSuccess,
+        }
+    }
+
+    /// Downgrade the degree by one step (e.g., nat 1).
+    pub fn downgrade(self) -> Self {
+        match self {
+            DegreeOfSuccess::CriticalSuccess => DegreeOfSuccess::Success,
+            DegreeOfSuccess::Success => DegreeOfSuccess::Failure,
+            DegreeOfSuccess::Failure => DegreeOfSuccess::CriticalFailure,
+            DegreeOfSuccess::CriticalFailure => DegreeOfSuccess::CriticalFailure,
+        }
+    }
+}
+
+/// Determine success level for a PF2e roll.
+pub fn determine_success(roll: i32, modifier: i32, dc: i32, is_nat_20: bool, is_nat_1: bool) -> DegreeOfSuccess {
+    let total = roll + modifier;
+    let diff = total - dc;
+
+    // Base success level from difference
+    let base = if diff >= 0 {
+        DegreeOfSuccess::Success
+    } else {
+        DegreeOfSuccess::Failure
+    };
+
+    // Apply +/- 10 rule
+    let adjusted = if diff >= 10 {
+        base.upgrade()
+    } else if diff <= -10 {
+        base.downgrade()
+    } else {
+        base
+    };
+
+    // Natural 20/1 adjustments
+    if is_nat_20 {
+        adjusted.upgrade()
+    } else if is_nat_1 {
+        adjusted.downgrade()
+    } else {
+        adjusted
+    }
+}
+
+/// Pathfinder 2nd Edition game system.
+pub struct Pf2eSystem {
+    stat_names: Vec<&'static str>,
+    skill_names: Vec<&'static str>,
+}
+
+impl Pf2eSystem {
+    pub fn new() -> Self {
+        Self {
+            stat_names: vec!["STR", "DEX", "CON", "INT", "WIS", "CHA"],
+            skill_names: vec![
+                "Acrobatics",
+                "Arcana",
+                "Athletics",
+                "Crafting",
+                "Deception",
+                "Diplomacy",
+                "Intimidation",
+                "Lore",
+                "Medicine",
+                "Nature",
+                "Occultism",
+                "Performance",
+                "Religion",
+                "Society",
+                "Stealth",
+                "Survival",
+                "Thievery",
+            ],
+        }
+    }
+}
+
+impl Default for Pf2eSystem {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl GameSystem for Pf2eSystem {
+    fn system_id(&self) -> &str {
+        "pf2e"
+    }
+
+    fn display_name(&self) -> &str {
+        "Pathfinder 2nd Edition"
+    }
+
+    fn calculation_engine(&self) -> &dyn CalculationEngine {
+        self
+    }
+
+    fn spellcasting_system(&self) -> Option<&dyn SpellcastingSystem> {
+        Some(self)
+    }
+
+    fn stat_names(&self) -> &[&str] {
+        &self.stat_names
+    }
+
+    fn skill_names(&self) -> &[&str] {
+        &self.skill_names
+    }
+}
+
+impl CalculationEngine for Pf2eSystem {
+    fn ability_modifier(&self, score: i32) -> i32 {
+        // Same formula as D&D 5e: (score - 10) / 2
+        let diff = score - 10;
+        if diff >= 0 {
+            diff / 2
+        } else {
+            (diff - 1) / 2 // Floor division for negative
+        }
+    }
+
+    fn proficiency_bonus(&self, level: u8) -> i32 {
+        // In PF2e, proficiency bonus depends on rank AND level
+        // This returns just level for use with Trained rank
+        // Real calculation uses Pf2eProficiencyRank::proficiency_bonus()
+        level as i32 + 2 // Trained baseline
+    }
+
+    fn spell_save_dc(&self, stats: &StatBlock, casting_stat: &str) -> i32 {
+        // PF2e: 10 + proficiency + casting stat modifier
+        let stat_value = stats.get_stat(casting_stat).unwrap_or(10);
+        let modifier = self.ability_modifier(stat_value);
+        let level = stats.get_stat("LEVEL").unwrap_or(1) as u8;
+        // Assume trained spellcasting proficiency
+        let prof = Pf2eProficiencyRank::Trained.proficiency_bonus(level);
+        10 + prof + modifier
+    }
+
+    fn spell_attack_bonus(&self, stats: &StatBlock, casting_stat: &str) -> i32 {
+        let stat_value = stats.get_stat(casting_stat).unwrap_or(10);
+        let modifier = self.ability_modifier(stat_value);
+        let level = stats.get_stat("LEVEL").unwrap_or(1) as u8;
+        let prof = Pf2eProficiencyRank::Trained.proficiency_bonus(level);
+        prof + modifier
+    }
+
+    fn attack_bonus(&self, stats: &StatBlock, attack_stat: &str, proficient: bool) -> i32 {
+        let stat_value = stats.get_stat(attack_stat).unwrap_or(10);
+        let modifier = self.ability_modifier(stat_value);
+        let level = stats.get_stat("LEVEL").unwrap_or(1) as u8;
+
+        if proficient {
+            let prof = Pf2eProficiencyRank::Trained.proficiency_bonus(level);
+            prof + modifier
+        } else {
+            modifier // Untrained doesn't add level
+        }
+    }
+
+    fn stack_modifiers(&self, modifiers: &[StatModifier]) -> i32 {
+        // PF2e stacking rules: bonuses stack by TYPE (circumstance, item, status)
+        // Since our StatModifier doesn't have a type field, we group by source prefix
+        // as a heuristic: bonuses from same source category don't stack (take highest)
+        // Penalties all stack
+
+        use std::collections::HashMap;
+        let mut source_bonuses: HashMap<String, i32> = HashMap::new();
+        let mut total_penalties = 0;
+
+        for modifier in modifiers.iter().filter(|m| m.active) {
+            if modifier.value >= 0 {
+                // Extract source category (first word) as a proxy for type
+                let source_type = modifier
+                    .source
+                    .split_whitespace()
+                    .next()
+                    .unwrap_or("untyped")
+                    .to_lowercase();
+                let current = source_bonuses.entry(source_type).or_insert(0);
+                *current = (*current).max(modifier.value);
+            } else {
+                // Penalty - all stack
+                total_penalties += modifier.value;
+            }
+        }
+
+        source_bonuses.values().sum::<i32>() + total_penalties
+    }
+
+    fn calculate_ac(
+        &self,
+        stats: &StatBlock,
+        armor_ac: Option<i32>,
+        shield_bonus: Option<i32>,
+        allows_dex: bool,
+        max_dex_bonus: Option<i32>,
+    ) -> i32 {
+        // PF2e AC = 10 + DEX mod (with cap) + proficiency + armor bonus + shield bonus
+        let dex_value = stats.get_stat("DEX").unwrap_or(10);
+        let dex_mod = self.ability_modifier(dex_value);
+        let level = stats.get_stat("LEVEL").unwrap_or(1) as u8;
+
+        let dex_contribution = if allows_dex {
+            match max_dex_bonus {
+                Some(cap) => dex_mod.min(cap),
+                None => dex_mod,
+            }
+        } else {
+            0
+        };
+
+        // Assume trained armor proficiency
+        let armor_prof = Pf2eProficiencyRank::Trained.proficiency_bonus(level);
+        let armor_item_bonus = armor_ac.unwrap_or(0);
+        let shield = shield_bonus.unwrap_or(0);
+
+        10 + dex_contribution + armor_prof + armor_item_bonus + shield
+    }
+
+    fn skill_modifier(
+        &self,
+        stats: &StatBlock,
+        ability: &str,
+        proficiency_level: ProficiencyLevel,
+    ) -> i32 {
+        let stat_value = stats.get_stat(ability).unwrap_or(10);
+        let ability_mod = self.ability_modifier(stat_value);
+        let level = stats.get_stat("LEVEL").unwrap_or(1) as u8;
+        let rank = Pf2eProficiencyRank::from(proficiency_level);
+        let prof = rank.proficiency_bonus(level);
+
+        ability_mod + prof
+    }
+
+    fn saving_throw_modifier(
+        &self,
+        stats: &StatBlock,
+        ability: &str,
+        proficient: bool,
+    ) -> i32 {
+        let stat_value = stats.get_stat(ability).unwrap_or(10);
+        let ability_mod = self.ability_modifier(stat_value);
+        let level = stats.get_stat("LEVEL").unwrap_or(1) as u8;
+
+        if proficient {
+            let prof = Pf2eProficiencyRank::Trained.proficiency_bonus(level);
+            ability_mod + prof
+        } else {
+            ability_mod
+        }
+    }
+
+    fn passive_perception(&self, stats: &StatBlock, proficiency_level: ProficiencyLevel) -> i32 {
+        // PF2e: 10 + Perception modifier
+        let wis_value = stats.get_stat("WIS").unwrap_or(10);
+        let ability_mod = self.ability_modifier(wis_value);
+        let level = stats.get_stat("LEVEL").unwrap_or(1) as u8;
+        let rank = Pf2eProficiencyRank::from(proficiency_level);
+        let prof = rank.proficiency_bonus(level);
+
+        10 + ability_mod + prof
+    }
+
+    fn hit_die(&self, class_name: &str) -> u8 {
+        // PF2e hit points per level (not dice, but fixed values)
+        match class_name.to_lowercase().as_str() {
+            "wizard" | "sorcerer" => 6,
+            "alchemist" | "bard" | "cleric" | "druid" | "investigator"
+            | "oracle" | "rogue" | "swashbuckler" | "witch" => 8,
+            "barbarian" | "champion" | "fighter" | "magus" | "monk" | "ranger" => 10,
+            _ => 8, // Default
+        }
+    }
+
+    fn calculate_max_hp(
+        &self,
+        level: u8,
+        class_name: &str,
+        constitution_modifier: i32,
+        additional_hp: i32,
+    ) -> i32 {
+        // PF2e: Ancestry HP + (Class HP + CON mod) per level
+        // Simplified: Just class HP + CON per level
+        let hp_per_level = self.hit_die(class_name) as i32;
+        let level_hp = (hp_per_level + constitution_modifier) * level as i32;
+
+        // Ancestry HP varies (typically 6-10), assume 8
+        let ancestry_hp = 8;
+
+        ancestry_hp + level_hp + additional_hp
+    }
+}
+
+impl SpellcastingSystem for Pf2eSystem {
+    fn caster_type(&self, class: &str) -> Option<CasterType> {
+        match class.to_lowercase().as_str() {
+            "wizard" | "cleric" | "druid" | "sorcerer" | "bard" | "witch" | "oracle" => {
+                Some(CasterType::Full)
+            }
+            "magus" | "summoner" => Some(CasterType::Half),
+            "champion" => Some(CasterType::Half), // Focus spells
+            _ => None,
+        }
+    }
+
+    fn spellcasting_stat(&self, class: &str) -> Option<&str> {
+        match class.to_lowercase().as_str() {
+            "wizard" | "witch" | "alchemist" | "investigator" => Some("INT"),
+            "cleric" | "druid" | "ranger" | "monk" => Some("WIS"),
+            "sorcerer" | "bard" | "oracle" | "summoner" | "swashbuckler" => Some("CHA"),
+            "magus" | "champion" | "fighter" => Some("CHA"), // Varies
+            _ => None,
+        }
+    }
+
+    fn uses_spell_preparation(&self, class: &str) -> bool {
+        matches!(
+            class.to_lowercase().as_str(),
+            "wizard" | "cleric" | "druid" | "witch" | "magus"
+        )
+    }
+
+    fn max_prepared_spells(&self, class: &str, _level: u8, _stat_mod: i32) -> u8 {
+        // PF2e prepared casters prepare a fixed number based on slots
+        // This is simplified - actual is slots per level
+        match class.to_lowercase().as_str() {
+            "wizard" => 3, // Per spell level
+            "cleric" | "druid" => 3,
+            "witch" => 2,
+            _ => 0,
+        }
+    }
+
+    fn spell_slots(&self, class: &str, level: u8) -> HashMap<u8, u8> {
+        // PF2e spell slot progression (full casters)
+        // Format: spell_level -> number of slots
+        let mut slots = HashMap::new();
+
+        if self.caster_type(class).is_none() {
+            return slots;
+        }
+
+        // Full caster progression (simplified)
+        // Gets slots for spell levels up to (level + 1) / 2
+        let max_spell_level = ((level + 1) / 2).min(10);
+
+        for spell_level in 1..=max_spell_level {
+            let slot_count = if spell_level == max_spell_level {
+                2 // Highest available level
+            } else {
+                3 // Lower levels
+            };
+            slots.insert(spell_level, slot_count);
+        }
+
+        slots
+    }
+
+    fn cantrips_known(&self, class: &str, _level: u8) -> u8 {
+        match class.to_lowercase().as_str() {
+            "wizard" => 5,
+            "sorcerer" | "bard" | "cleric" | "druid" => 5,
+            "witch" => 3,
+            "magus" => 3,
+            _ => 0,
+        }
+    }
+
+    fn spells_known(&self, class: &str, level: u8) -> Option<u8> {
+        // PF2e spontaneous casters (sorcerer, bard)
+        match class.to_lowercase().as_str() {
+            "sorcerer" | "bard" | "oracle" => Some(level * 2 + 2),
+            _ => None, // Prepared casters don't have "spells known"
+        }
+    }
+}
+
+impl CharacterSheetProvider for Pf2eSystem {
+    fn character_sheet_schema(&self) -> CharacterSheetSchema {
+        CharacterSheetSchema {
+            system_id: "pf2e".to_string(),
+            system_name: "Pathfinder 2nd Edition".to_string(),
+            sections: vec![
+                self.identity_section(),
+                self.ability_scores_section(),
+                self.skills_section(),
+                self.saves_section(),
+                self.combat_section(),
+                self.resources_section(),
+            ],
+            creation_steps: vec![
+                CreationStep {
+                    id: "basic_info".to_string(),
+                    label: "Basic Info".to_string(),
+                    description: "Choose your character's ancestry, class, and background."
+                        .to_string(),
+                    section_ids: vec!["identity".to_string()],
+                    order: 1,
+                    required: true,
+                },
+                CreationStep {
+                    id: "ability_boosts".to_string(),
+                    label: "Ability Boosts".to_string(),
+                    description: "Apply ability boosts from ancestry, background, and class."
+                        .to_string(),
+                    section_ids: vec!["ability_scores".to_string()],
+                    order: 2,
+                    required: true,
+                },
+                CreationStep {
+                    id: "skills".to_string(),
+                    label: "Skills".to_string(),
+                    description: "Choose your skill training from class and background."
+                        .to_string(),
+                    section_ids: vec!["skills".to_string()],
+                    order: 3,
+                    required: true,
+                },
+                CreationStep {
+                    id: "equipment".to_string(),
+                    label: "Equipment".to_string(),
+                    description: "Select starting equipment and gear.".to_string(),
+                    section_ids: vec!["combat".to_string()],
+                    order: 4,
+                    required: false,
+                },
+            ],
+        }
+    }
+
+    fn calculate_derived_values(
+        &self,
+        values: &HashMap<String, serde_json::Value>,
+    ) -> HashMap<String, serde_json::Value> {
+        let mut derived = HashMap::new();
+
+        // Get level (default to 1)
+        let level = values
+            .get("LEVEL")
+            .and_then(|v| v.as_i64())
+            .unwrap_or(1) as u8;
+
+        // Calculate ability modifiers
+        for ability in &["STR", "DEX", "CON", "INT", "WIS", "CHA"] {
+            if let Some(score) = values.get(*ability).and_then(|v| v.as_i64()) {
+                let modifier = self.ability_modifier(score as i32);
+                derived.insert(format!("{}_MOD", ability), serde_json::json!(modifier));
+            }
+        }
+
+        // Calculate skill modifiers using PF2e proficiency formula: level + rank_bonus
+        for skill in self.skill_names() {
+            let ability = skill_ability(skill);
+            let ability_mod = derived
+                .get(&format!("{}_MOD", ability))
+                .and_then(|v| v.as_i64())
+                .unwrap_or(0) as i32;
+
+            let skill_id = skill.to_uppercase().replace(' ', "_");
+            let proficiency_rank = values
+                .get(&format!("{}_RANK", skill_id))
+                .and_then(|v| v.as_str())
+                .unwrap_or("untrained");
+
+            let rank = match proficiency_rank {
+                "legendary" => Pf2eProficiencyRank::Legendary,
+                "master" => Pf2eProficiencyRank::Master,
+                "expert" => Pf2eProficiencyRank::Expert,
+                "trained" => Pf2eProficiencyRank::Trained,
+                _ => Pf2eProficiencyRank::Untrained,
+            };
+
+            let prof_bonus = rank.proficiency_bonus(level);
+            let skill_mod = ability_mod + prof_bonus;
+            derived.insert(format!("{}_MOD", skill_id), serde_json::json!(skill_mod));
+        }
+
+        // Calculate saving throw modifiers
+        let save_abilities = [("FORTITUDE", "CON"), ("REFLEX", "DEX"), ("WILL", "WIS")];
+        for (save, ability) in &save_abilities {
+            let ability_mod = derived
+                .get(&format!("{}_MOD", ability))
+                .and_then(|v| v.as_i64())
+                .unwrap_or(0) as i32;
+
+            let proficiency_rank = values
+                .get(&format!("{}_RANK", save))
+                .and_then(|v| v.as_str())
+                .unwrap_or("trained");
+
+            let rank = match proficiency_rank {
+                "legendary" => Pf2eProficiencyRank::Legendary,
+                "master" => Pf2eProficiencyRank::Master,
+                "expert" => Pf2eProficiencyRank::Expert,
+                "trained" => Pf2eProficiencyRank::Trained,
+                _ => Pf2eProficiencyRank::Untrained,
+            };
+
+            let prof_bonus = rank.proficiency_bonus(level);
+            let save_mod = ability_mod + prof_bonus;
+            derived.insert(format!("{}_MOD", save), serde_json::json!(save_mod));
+        }
+
+        // Calculate Perception
+        let wis_mod = derived
+            .get("WIS_MOD")
+            .and_then(|v| v.as_i64())
+            .unwrap_or(0) as i32;
+        let perception_rank = values
+            .get("PERCEPTION_RANK")
+            .and_then(|v| v.as_str())
+            .unwrap_or("trained");
+        let perception_prof_rank = match perception_rank {
+            "legendary" => Pf2eProficiencyRank::Legendary,
+            "master" => Pf2eProficiencyRank::Master,
+            "expert" => Pf2eProficiencyRank::Expert,
+            "trained" => Pf2eProficiencyRank::Trained,
+            _ => Pf2eProficiencyRank::Untrained,
+        };
+        let perception_bonus = perception_prof_rank.proficiency_bonus(level);
+        let perception_mod = wis_mod + perception_bonus;
+        derived.insert("PERCEPTION_MOD".to_string(), serde_json::json!(perception_mod));
+
+        // Calculate AC: 10 + DEX + proficiency + armor bonus
+        let dex_mod = derived
+            .get("DEX_MOD")
+            .and_then(|v| v.as_i64())
+            .unwrap_or(0) as i32;
+        let armor_rank = values
+            .get("ARMOR_RANK")
+            .and_then(|v| v.as_str())
+            .unwrap_or("trained");
+        let armor_prof_rank = match armor_rank {
+            "legendary" => Pf2eProficiencyRank::Legendary,
+            "master" => Pf2eProficiencyRank::Master,
+            "expert" => Pf2eProficiencyRank::Expert,
+            "trained" => Pf2eProficiencyRank::Trained,
+            _ => Pf2eProficiencyRank::Untrained,
+        };
+        let armor_prof_bonus = armor_prof_rank.proficiency_bonus(level);
+        let armor_item_bonus = values
+            .get("ARMOR_BONUS")
+            .and_then(|v| v.as_i64())
+            .unwrap_or(0) as i32;
+        let dex_cap = values
+            .get("DEX_CAP")
+            .and_then(|v| v.as_i64())
+            .map(|v| v as i32);
+        let effective_dex = match dex_cap {
+            Some(cap) => dex_mod.min(cap),
+            None => dex_mod,
+        };
+        let ac = 10 + effective_dex + armor_prof_bonus + armor_item_bonus;
+        derived.insert("AC".to_string(), serde_json::json!(ac));
+
+        // Calculate Max HP: Ancestry HP + (Class HP + CON) per level
+        let con_mod = derived
+            .get("CON_MOD")
+            .and_then(|v| v.as_i64())
+            .unwrap_or(0) as i32;
+        let ancestry_hp = values
+            .get("ANCESTRY_HP")
+            .and_then(|v| v.as_i64())
+            .unwrap_or(8) as i32;
+        let class_hp = values
+            .get("CLASS_HP")
+            .and_then(|v| v.as_i64())
+            .unwrap_or(8) as i32;
+        let max_hp = ancestry_hp + (class_hp + con_mod) * level as i32;
+        derived.insert("MAX_HP".to_string(), serde_json::json!(max_hp.max(1)));
+
+        derived
+    }
+
+    fn validate_field(
+        &self,
+        field_id: &str,
+        value: &serde_json::Value,
+        _all_values: &HashMap<String, serde_json::Value>,
+    ) -> Option<String> {
+        match field_id {
+            "STR" | "DEX" | "CON" | "INT" | "WIS" | "CHA" => {
+                if let Some(score) = value.as_i64() {
+                    if score < 1 || score > 30 {
+                        return Some("Ability scores must be between 1 and 30".to_string());
+                    }
+                } else {
+                    return Some("Ability score must be a number".to_string());
+                }
+            }
+            "LEVEL" => {
+                if let Some(level) = value.as_i64() {
+                    if level < 1 || level > 20 {
+                        return Some("Level must be between 1 and 20".to_string());
+                    }
+                } else {
+                    return Some("Level must be a number".to_string());
+                }
+            }
+            "NAME" => {
+                if let Some(name) = value.as_str() {
+                    if name.is_empty() {
+                        return Some("Name is required".to_string());
+                    }
+                } else {
+                    return Some("Name must be a string".to_string());
+                }
+            }
+            "HERO_POINTS" => {
+                if let Some(points) = value.as_i64() {
+                    if points < 0 || points > 3 {
+                        return Some("Hero Points must be between 0 and 3".to_string());
+                    }
+                } else {
+                    return Some("Hero Points must be a number".to_string());
+                }
+            }
+            _ => {}
+        }
+        None
+    }
+
+    fn default_values(&self) -> HashMap<String, serde_json::Value> {
+        let mut defaults = HashMap::new();
+        defaults.insert("LEVEL".to_string(), serde_json::json!(1));
+        defaults.insert("STR".to_string(), serde_json::json!(10));
+        defaults.insert("DEX".to_string(), serde_json::json!(10));
+        defaults.insert("CON".to_string(), serde_json::json!(10));
+        defaults.insert("INT".to_string(), serde_json::json!(10));
+        defaults.insert("WIS".to_string(), serde_json::json!(10));
+        defaults.insert("CHA".to_string(), serde_json::json!(10));
+        defaults.insert("CURRENT_HP".to_string(), serde_json::json!(0));
+        defaults.insert("HERO_POINTS".to_string(), serde_json::json!(1));
+        defaults.insert("SPEED".to_string(), serde_json::json!(25));
+        defaults.insert("ANCESTRY_HP".to_string(), serde_json::json!(8));
+        defaults.insert("CLASS_HP".to_string(), serde_json::json!(8));
+        defaults
+    }
+}
+
+// Helper methods for building the schema
+impl Pf2eSystem {
+    fn identity_section(&self) -> SchemaSection {
+        SchemaSection {
+            id: "identity".to_string(),
+            label: "Character Identity".to_string(),
+            section_type: SectionType::Identity,
+            fields: vec![
+                FieldDefinition {
+                    id: "NAME".to_string(),
+                    label: "Character Name".to_string(),
+                    field_type: SchemaFieldType::Text {
+                        multiline: false,
+                        max_length: Some(100),
+                    },
+                    editable: true,
+                    required: true,
+                    derived_from: None,
+                    validation: None,
+                    layout: FieldLayout {
+                        width: Some(6),
+                        ..Default::default()
+                    },
+                    description: None,
+                    placeholder: Some("Enter character name".to_string()),
+                },
+                FieldDefinition {
+                    id: "LEVEL".to_string(),
+                    label: "Level".to_string(),
+                    field_type: SchemaFieldType::Integer {
+                        min: Some(1),
+                        max: Some(20),
+                        show_modifier: false,
+                    },
+                    editable: true,
+                    required: true,
+                    derived_from: None,
+                    validation: Some(FieldValidation {
+                        min: Some(1),
+                        max: Some(20),
+                        pattern: None,
+                        error_message: Some("Level must be 1-20".to_string()),
+                    }),
+                    layout: FieldLayout {
+                        width: Some(2),
+                        ..Default::default()
+                    },
+                    description: None,
+                    placeholder: None,
+                },
+                FieldDefinition {
+                    id: "ANCESTRY".to_string(),
+                    label: "Ancestry".to_string(),
+                    field_type: SchemaFieldType::Select {
+                        options: vec![
+                            SchemaSelectOption {
+                                value: "human".to_string(),
+                                label: "Human".to_string(),
+                                description: Some("Versatile and ambitious".to_string()),
+                            },
+                            SchemaSelectOption {
+                                value: "elf".to_string(),
+                                label: "Elf".to_string(),
+                                description: Some("Long-lived and graceful".to_string()),
+                            },
+                            SchemaSelectOption {
+                                value: "dwarf".to_string(),
+                                label: "Dwarf".to_string(),
+                                description: Some("Stout and tradition-bound".to_string()),
+                            },
+                            SchemaSelectOption {
+                                value: "gnome".to_string(),
+                                label: "Gnome".to_string(),
+                                description: Some("Curious and whimsical".to_string()),
+                            },
+                            SchemaSelectOption {
+                                value: "goblin".to_string(),
+                                label: "Goblin".to_string(),
+                                description: Some("Scrappy and resourceful".to_string()),
+                            },
+                            SchemaSelectOption {
+                                value: "halfling".to_string(),
+                                label: "Halfling".to_string(),
+                                description: Some("Lucky and optimistic".to_string()),
+                            },
+                            SchemaSelectOption {
+                                value: "leshy".to_string(),
+                                label: "Leshy".to_string(),
+                                description: Some("Plant spirits with humanoid forms".to_string()),
+                            },
+                            SchemaSelectOption {
+                                value: "orc".to_string(),
+                                label: "Orc".to_string(),
+                                description: Some("Strong and proud".to_string()),
+                            },
+                        ],
+                        allow_custom: true,
+                    },
+                    editable: true,
+                    required: true,
+                    derived_from: None,
+                    validation: None,
+                    layout: FieldLayout {
+                        width: Some(4),
+                        new_row: true,
+                        ..Default::default()
+                    },
+                    description: None,
+                    placeholder: None,
+                },
+                FieldDefinition {
+                    id: "HERITAGE".to_string(),
+                    label: "Heritage".to_string(),
+                    field_type: SchemaFieldType::Text {
+                        multiline: false,
+                        max_length: Some(100),
+                    },
+                    editable: true,
+                    required: false,
+                    derived_from: None,
+                    validation: None,
+                    layout: FieldLayout {
+                        width: Some(4),
+                        ..Default::default()
+                    },
+                    description: Some("Your ancestry's specific lineage".to_string()),
+                    placeholder: Some("e.g., Skilled Human, Cavern Elf".to_string()),
+                },
+                FieldDefinition {
+                    id: "CLASS".to_string(),
+                    label: "Class".to_string(),
+                    field_type: SchemaFieldType::Select {
+                        options: vec![
+                            SchemaSelectOption {
+                                value: "alchemist".to_string(),
+                                label: "Alchemist".to_string(),
+                                description: Some("Master of alchemical creations".to_string()),
+                            },
+                            SchemaSelectOption {
+                                value: "barbarian".to_string(),
+                                label: "Barbarian".to_string(),
+                                description: Some("Raging warrior".to_string()),
+                            },
+                            SchemaSelectOption {
+                                value: "bard".to_string(),
+                                label: "Bard".to_string(),
+                                description: Some("Occult spellcaster and performer".to_string()),
+                            },
+                            SchemaSelectOption {
+                                value: "champion".to_string(),
+                                label: "Champion".to_string(),
+                                description: Some("Divine warrior of a cause".to_string()),
+                            },
+                            SchemaSelectOption {
+                                value: "cleric".to_string(),
+                                label: "Cleric".to_string(),
+                                description: Some("Divine spellcaster".to_string()),
+                            },
+                            SchemaSelectOption {
+                                value: "druid".to_string(),
+                                label: "Druid".to_string(),
+                                description: Some("Primal spellcaster".to_string()),
+                            },
+                            SchemaSelectOption {
+                                value: "fighter".to_string(),
+                                label: "Fighter".to_string(),
+                                description: Some("Master of martial combat".to_string()),
+                            },
+                            SchemaSelectOption {
+                                value: "investigator".to_string(),
+                                label: "Investigator".to_string(),
+                                description: Some("Analytical detective".to_string()),
+                            },
+                            SchemaSelectOption {
+                                value: "magus".to_string(),
+                                label: "Magus".to_string(),
+                                description: Some("Combines martial and arcane".to_string()),
+                            },
+                            SchemaSelectOption {
+                                value: "monk".to_string(),
+                                label: "Monk".to_string(),
+                                description: Some("Martial artist".to_string()),
+                            },
+                            SchemaSelectOption {
+                                value: "oracle".to_string(),
+                                label: "Oracle".to_string(),
+                                description: Some("Cursed divine spellcaster".to_string()),
+                            },
+                            SchemaSelectOption {
+                                value: "ranger".to_string(),
+                                label: "Ranger".to_string(),
+                                description: Some("Wilderness warrior".to_string()),
+                            },
+                            SchemaSelectOption {
+                                value: "rogue".to_string(),
+                                label: "Rogue".to_string(),
+                                description: Some("Skilled and stealthy".to_string()),
+                            },
+                            SchemaSelectOption {
+                                value: "sorcerer".to_string(),
+                                label: "Sorcerer".to_string(),
+                                description: Some("Bloodline spellcaster".to_string()),
+                            },
+                            SchemaSelectOption {
+                                value: "swashbuckler".to_string(),
+                                label: "Swashbuckler".to_string(),
+                                description: Some("Daring combatant".to_string()),
+                            },
+                            SchemaSelectOption {
+                                value: "witch".to_string(),
+                                label: "Witch".to_string(),
+                                description: Some("Patron-bound spellcaster".to_string()),
+                            },
+                            SchemaSelectOption {
+                                value: "wizard".to_string(),
+                                label: "Wizard".to_string(),
+                                description: Some("Arcane scholar".to_string()),
+                            },
+                        ],
+                        allow_custom: false,
+                    },
+                    editable: true,
+                    required: true,
+                    derived_from: None,
+                    validation: None,
+                    layout: FieldLayout {
+                        width: Some(4),
+                        new_row: true,
+                        ..Default::default()
+                    },
+                    description: None,
+                    placeholder: None,
+                },
+                FieldDefinition {
+                    id: "BACKGROUND".to_string(),
+                    label: "Background".to_string(),
+                    field_type: SchemaFieldType::Select {
+                        options: vec![
+                            SchemaSelectOption {
+                                value: "acolyte".to_string(),
+                                label: "Acolyte".to_string(),
+                                description: None,
+                            },
+                            SchemaSelectOption {
+                                value: "acrobat".to_string(),
+                                label: "Acrobat".to_string(),
+                                description: None,
+                            },
+                            SchemaSelectOption {
+                                value: "artisan".to_string(),
+                                label: "Artisan".to_string(),
+                                description: None,
+                            },
+                            SchemaSelectOption {
+                                value: "barkeep".to_string(),
+                                label: "Barkeep".to_string(),
+                                description: None,
+                            },
+                            SchemaSelectOption {
+                                value: "charlatan".to_string(),
+                                label: "Charlatan".to_string(),
+                                description: None,
+                            },
+                            SchemaSelectOption {
+                                value: "criminal".to_string(),
+                                label: "Criminal".to_string(),
+                                description: None,
+                            },
+                            SchemaSelectOption {
+                                value: "detective".to_string(),
+                                label: "Detective".to_string(),
+                                description: None,
+                            },
+                            SchemaSelectOption {
+                                value: "entertainer".to_string(),
+                                label: "Entertainer".to_string(),
+                                description: None,
+                            },
+                            SchemaSelectOption {
+                                value: "farmhand".to_string(),
+                                label: "Farmhand".to_string(),
+                                description: None,
+                            },
+                            SchemaSelectOption {
+                                value: "gladiator".to_string(),
+                                label: "Gladiator".to_string(),
+                                description: None,
+                            },
+                            SchemaSelectOption {
+                                value: "guard".to_string(),
+                                label: "Guard".to_string(),
+                                description: None,
+                            },
+                            SchemaSelectOption {
+                                value: "herbalist".to_string(),
+                                label: "Herbalist".to_string(),
+                                description: None,
+                            },
+                            SchemaSelectOption {
+                                value: "hunter".to_string(),
+                                label: "Hunter".to_string(),
+                                description: None,
+                            },
+                            SchemaSelectOption {
+                                value: "laborer".to_string(),
+                                label: "Laborer".to_string(),
+                                description: None,
+                            },
+                            SchemaSelectOption {
+                                value: "merchant".to_string(),
+                                label: "Merchant".to_string(),
+                                description: None,
+                            },
+                            SchemaSelectOption {
+                                value: "noble".to_string(),
+                                label: "Noble".to_string(),
+                                description: None,
+                            },
+                            SchemaSelectOption {
+                                value: "nomad".to_string(),
+                                label: "Nomad".to_string(),
+                                description: None,
+                            },
+                            SchemaSelectOption {
+                                value: "scholar".to_string(),
+                                label: "Scholar".to_string(),
+                                description: None,
+                            },
+                            SchemaSelectOption {
+                                value: "scout".to_string(),
+                                label: "Scout".to_string(),
+                                description: None,
+                            },
+                            SchemaSelectOption {
+                                value: "warrior".to_string(),
+                                label: "Warrior".to_string(),
+                                description: None,
+                            },
+                        ],
+                        allow_custom: true,
+                    },
+                    editable: true,
+                    required: false,
+                    derived_from: None,
+                    validation: None,
+                    layout: FieldLayout {
+                        width: Some(4),
+                        ..Default::default()
+                    },
+                    description: None,
+                    placeholder: None,
+                },
+            ],
+            collapsible: false,
+            collapsed_default: false,
+            description: None,
+        }
+    }
+
+    fn ability_scores_section(&self) -> SchemaSection {
+        let abilities = [
+            ("STR", "Strength", "Physical power and Athletics"),
+            ("DEX", "Dexterity", "Agility, reflexes, and finesse"),
+            ("CON", "Constitution", "Health and stamina"),
+            ("INT", "Intelligence", "Reasoning and knowledge"),
+            ("WIS", "Wisdom", "Perception and willpower"),
+            ("CHA", "Charisma", "Force of personality"),
+        ];
+
+        let mut fields: Vec<FieldDefinition> = Vec::new();
+
+        for (id, label, description) in &abilities {
+            fields.push(FieldDefinition {
+                id: id.to_string(),
+                label: label.to_string(),
+                field_type: SchemaFieldType::AbilityScore {
+                    min: Some(1),
+                    max: Some(30),
+                },
+                editable: true,
+                required: true,
+                derived_from: None,
+                validation: Some(FieldValidation {
+                    min: Some(1),
+                    max: Some(30),
+                    pattern: None,
+                    error_message: Some("Ability scores must be 1-30".to_string()),
+                }),
+                layout: FieldLayout {
+                    width: Some(2),
+                    ..Default::default()
+                },
+                description: Some(description.to_string()),
+                placeholder: None,
+            });
+        }
+
+        SchemaSection {
+            id: "ability_scores".to_string(),
+            label: "Ability Scores".to_string(),
+            section_type: SectionType::AbilityScores,
+            fields,
+            collapsible: false,
+            collapsed_default: false,
+            description: Some(
+                "Your six core abilities. In PF2e, 10 is the baseline for an average person."
+                    .to_string(),
+            ),
+        }
+    }
+
+    fn skills_section(&self) -> SchemaSection {
+        let skill_abilities: Vec<(&str, &str)> = vec![
+            ("Acrobatics", "DEX"),
+            ("Arcana", "INT"),
+            ("Athletics", "STR"),
+            ("Crafting", "INT"),
+            ("Deception", "CHA"),
+            ("Diplomacy", "CHA"),
+            ("Intimidation", "CHA"),
+            ("Lore", "INT"),
+            ("Medicine", "WIS"),
+            ("Nature", "WIS"),
+            ("Occultism", "INT"),
+            ("Performance", "CHA"),
+            ("Religion", "WIS"),
+            ("Society", "INT"),
+            ("Stealth", "DEX"),
+            ("Survival", "WIS"),
+            ("Thievery", "DEX"),
+        ];
+
+        let proficiency_options = vec![
+            ProficiencyOption {
+                value: "untrained".to_string(),
+                label: "Untrained (+0)".to_string(),
+                multiplier: 0.0,
+            },
+            ProficiencyOption {
+                value: "trained".to_string(),
+                label: "Trained (+level+2)".to_string(),
+                multiplier: 1.0,
+            },
+            ProficiencyOption {
+                value: "expert".to_string(),
+                label: "Expert (+level+4)".to_string(),
+                multiplier: 1.0,
+            },
+            ProficiencyOption {
+                value: "master".to_string(),
+                label: "Master (+level+6)".to_string(),
+                multiplier: 1.0,
+            },
+            ProficiencyOption {
+                value: "legendary".to_string(),
+                label: "Legendary (+level+8)".to_string(),
+                multiplier: 1.0,
+            },
+        ];
+
+        let fields: Vec<FieldDefinition> = skill_abilities
+            .iter()
+            .map(|(skill, ability)| {
+                let skill_id = skill.to_uppercase().replace(' ', "_");
+                FieldDefinition {
+                    id: format!("{}_RANK", skill_id),
+                    label: skill.to_string(),
+                    field_type: SchemaFieldType::Skill {
+                        ability: ability.to_string(),
+                        proficiency_levels: proficiency_options.clone(),
+                    },
+                    editable: true,
+                    required: false,
+                    derived_from: None,
+                    validation: None,
+                    layout: FieldLayout {
+                        width: Some(6),
+                        ..Default::default()
+                    },
+                    description: Some(format!("Based on {}", ability)),
+                    placeholder: None,
+                }
+            })
+            .collect();
+
+        SchemaSection {
+            id: "skills".to_string(),
+            label: "Skills".to_string(),
+            section_type: SectionType::Skills,
+            fields,
+            collapsible: true,
+            collapsed_default: false,
+            description: Some(
+                "Skills use proficiency ranks: Untrained, Trained, Expert, Master, Legendary"
+                    .to_string(),
+            ),
+        }
+    }
+
+    fn saves_section(&self) -> SchemaSection {
+        let saves = [
+            ("FORTITUDE", "Fortitude", "CON", "Physical resilience"),
+            ("REFLEX", "Reflex", "DEX", "Dodging and agility"),
+            ("WILL", "Will", "WIS", "Mental fortitude"),
+        ];
+
+        let proficiency_options = vec![
+            ProficiencyOption {
+                value: "untrained".to_string(),
+                label: "Untrained (+0)".to_string(),
+                multiplier: 0.0,
+            },
+            ProficiencyOption {
+                value: "trained".to_string(),
+                label: "Trained (+level+2)".to_string(),
+                multiplier: 1.0,
+            },
+            ProficiencyOption {
+                value: "expert".to_string(),
+                label: "Expert (+level+4)".to_string(),
+                multiplier: 1.0,
+            },
+            ProficiencyOption {
+                value: "master".to_string(),
+                label: "Master (+level+6)".to_string(),
+                multiplier: 1.0,
+            },
+            ProficiencyOption {
+                value: "legendary".to_string(),
+                label: "Legendary (+level+8)".to_string(),
+                multiplier: 1.0,
+            },
+        ];
+
+        let fields: Vec<FieldDefinition> = saves
+            .iter()
+            .map(|(id, label, ability, description)| FieldDefinition {
+                id: format!("{}_RANK", id),
+                label: label.to_string(),
+                field_type: SchemaFieldType::Skill {
+                    ability: ability.to_string(),
+                    proficiency_levels: proficiency_options.clone(),
+                },
+                editable: true,
+                required: false,
+                derived_from: None,
+                validation: None,
+                layout: FieldLayout {
+                    width: Some(4),
+                    ..Default::default()
+                },
+                description: Some(description.to_string()),
+                placeholder: None,
+            })
+            .collect();
+
+        SchemaSection {
+            id: "saves".to_string(),
+            label: "Saving Throws".to_string(),
+            section_type: SectionType::Combat,
+            fields,
+            collapsible: true,
+            collapsed_default: false,
+            description: Some("Your three saving throws with proficiency ranks".to_string()),
+        }
+    }
+
+    fn combat_section(&self) -> SchemaSection {
+        let armor_proficiency_options = vec![
+            ProficiencyOption {
+                value: "untrained".to_string(),
+                label: "Untrained (+0)".to_string(),
+                multiplier: 0.0,
+            },
+            ProficiencyOption {
+                value: "trained".to_string(),
+                label: "Trained (+level+2)".to_string(),
+                multiplier: 1.0,
+            },
+            ProficiencyOption {
+                value: "expert".to_string(),
+                label: "Expert (+level+4)".to_string(),
+                multiplier: 1.0,
+            },
+            ProficiencyOption {
+                value: "master".to_string(),
+                label: "Master (+level+6)".to_string(),
+                multiplier: 1.0,
+            },
+            ProficiencyOption {
+                value: "legendary".to_string(),
+                label: "Legendary (+level+8)".to_string(),
+                multiplier: 1.0,
+            },
+        ];
+
+        let perception_proficiency_options = armor_proficiency_options.clone();
+
+        SchemaSection {
+            id: "combat".to_string(),
+            label: "Combat".to_string(),
+            section_type: SectionType::Combat,
+            fields: vec![
+                FieldDefinition {
+                    id: "CURRENT_HP".to_string(),
+                    label: "Current HP".to_string(),
+                    field_type: SchemaFieldType::ResourceBar {
+                        max_field: "MAX_HP".to_string(),
+                        color: ResourceColor::Red,
+                    },
+                    editable: true,
+                    required: false,
+                    derived_from: None,
+                    validation: None,
+                    layout: FieldLayout {
+                        width: Some(4),
+                        ..Default::default()
+                    },
+                    description: None,
+                    placeholder: None,
+                },
+                FieldDefinition {
+                    id: "MAX_HP".to_string(),
+                    label: "Max HP".to_string(),
+                    field_type: SchemaFieldType::Integer {
+                        min: Some(1),
+                        max: None,
+                        show_modifier: false,
+                    },
+                    editable: false,
+                    required: false,
+                    derived_from: Some(DerivedField {
+                        derivation_type: DerivationType::Custom,
+                        dependencies: vec![
+                            "LEVEL".to_string(),
+                            "CON".to_string(),
+                            "ANCESTRY_HP".to_string(),
+                            "CLASS_HP".to_string(),
+                        ],
+                        display_format: None,
+                    }),
+                    validation: None,
+                    layout: FieldLayout {
+                        width: Some(2),
+                        ..Default::default()
+                    },
+                    description: Some("Ancestry HP + (Class HP + CON) per level".to_string()),
+                    placeholder: None,
+                },
+                FieldDefinition {
+                    id: "ANCESTRY_HP".to_string(),
+                    label: "Ancestry HP".to_string(),
+                    field_type: SchemaFieldType::Integer {
+                        min: Some(6),
+                        max: Some(12),
+                        show_modifier: false,
+                    },
+                    editable: true,
+                    required: false,
+                    derived_from: None,
+                    validation: Some(FieldValidation {
+                        min: Some(6),
+                        max: Some(12),
+                        pattern: None,
+                        error_message: Some("Ancestry HP is typically 6-12".to_string()),
+                    }),
+                    layout: FieldLayout {
+                        width: Some(2),
+                        ..Default::default()
+                    },
+                    description: Some("HP from your ancestry".to_string()),
+                    placeholder: Some("8".to_string()),
+                },
+                FieldDefinition {
+                    id: "CLASS_HP".to_string(),
+                    label: "Class HP".to_string(),
+                    field_type: SchemaFieldType::Integer {
+                        min: Some(6),
+                        max: Some(12),
+                        show_modifier: false,
+                    },
+                    editable: true,
+                    required: false,
+                    derived_from: None,
+                    validation: Some(FieldValidation {
+                        min: Some(6),
+                        max: Some(12),
+                        pattern: None,
+                        error_message: Some("Class HP is typically 6-12".to_string()),
+                    }),
+                    layout: FieldLayout {
+                        width: Some(2),
+                        ..Default::default()
+                    },
+                    description: Some("HP per level from your class".to_string()),
+                    placeholder: Some("8".to_string()),
+                },
+                FieldDefinition {
+                    id: "AC".to_string(),
+                    label: "Armor Class".to_string(),
+                    field_type: SchemaFieldType::Integer {
+                        min: Some(1),
+                        max: None,
+                        show_modifier: false,
+                    },
+                    editable: false,
+                    required: false,
+                    derived_from: Some(DerivedField {
+                        derivation_type: DerivationType::Custom,
+                        dependencies: vec![
+                            "DEX".to_string(),
+                            "LEVEL".to_string(),
+                            "ARMOR_RANK".to_string(),
+                            "ARMOR_BONUS".to_string(),
+                        ],
+                        display_format: None,
+                    }),
+                    validation: None,
+                    layout: FieldLayout {
+                        width: Some(2),
+                        new_row: true,
+                        ..Default::default()
+                    },
+                    description: Some("10 + DEX + proficiency + armor".to_string()),
+                    placeholder: None,
+                },
+                FieldDefinition {
+                    id: "ARMOR_RANK".to_string(),
+                    label: "Armor Proficiency".to_string(),
+                    field_type: SchemaFieldType::Skill {
+                        ability: "DEX".to_string(),
+                        proficiency_levels: armor_proficiency_options,
+                    },
+                    editable: true,
+                    required: false,
+                    derived_from: None,
+                    validation: None,
+                    layout: FieldLayout {
+                        width: Some(4),
+                        ..Default::default()
+                    },
+                    description: Some("Your armor proficiency rank".to_string()),
+                    placeholder: None,
+                },
+                FieldDefinition {
+                    id: "ARMOR_BONUS".to_string(),
+                    label: "Armor Item Bonus".to_string(),
+                    field_type: SchemaFieldType::Integer {
+                        min: Some(0),
+                        max: Some(6),
+                        show_modifier: false,
+                    },
+                    editable: true,
+                    required: false,
+                    derived_from: None,
+                    validation: None,
+                    layout: FieldLayout {
+                        width: Some(2),
+                        ..Default::default()
+                    },
+                    description: Some("Item bonus from armor".to_string()),
+                    placeholder: Some("0".to_string()),
+                },
+                FieldDefinition {
+                    id: "DEX_CAP".to_string(),
+                    label: "Dex Cap".to_string(),
+                    field_type: SchemaFieldType::Integer {
+                        min: Some(0),
+                        max: Some(10),
+                        show_modifier: false,
+                    },
+                    editable: true,
+                    required: false,
+                    derived_from: None,
+                    validation: None,
+                    layout: FieldLayout {
+                        width: Some(2),
+                        ..Default::default()
+                    },
+                    description: Some("Max DEX bonus from armor".to_string()),
+                    placeholder: Some("5".to_string()),
+                },
+                FieldDefinition {
+                    id: "SPEED".to_string(),
+                    label: "Speed".to_string(),
+                    field_type: SchemaFieldType::Integer {
+                        min: Some(0),
+                        max: None,
+                        show_modifier: false,
+                    },
+                    editable: true,
+                    required: false,
+                    derived_from: None,
+                    validation: None,
+                    layout: FieldLayout {
+                        width: Some(2),
+                        new_row: true,
+                        ..Default::default()
+                    },
+                    description: Some("Movement speed in feet".to_string()),
+                    placeholder: Some("25".to_string()),
+                },
+                FieldDefinition {
+                    id: "PERCEPTION_RANK".to_string(),
+                    label: "Perception".to_string(),
+                    field_type: SchemaFieldType::Skill {
+                        ability: "WIS".to_string(),
+                        proficiency_levels: perception_proficiency_options,
+                    },
+                    editable: true,
+                    required: false,
+                    derived_from: None,
+                    validation: None,
+                    layout: FieldLayout {
+                        width: Some(4),
+                        ..Default::default()
+                    },
+                    description: Some("Based on WIS with proficiency".to_string()),
+                    placeholder: None,
+                },
+                FieldDefinition {
+                    id: "PERCEPTION_MOD".to_string(),
+                    label: "Perception Modifier".to_string(),
+                    field_type: SchemaFieldType::Integer {
+                        min: None,
+                        max: None,
+                        show_modifier: true,
+                    },
+                    editable: false,
+                    required: false,
+                    derived_from: Some(DerivedField {
+                        derivation_type: DerivationType::Custom,
+                        dependencies: vec![
+                            "WIS".to_string(),
+                            "LEVEL".to_string(),
+                            "PERCEPTION_RANK".to_string(),
+                        ],
+                        display_format: Some("+{}".to_string()),
+                    }),
+                    validation: None,
+                    layout: FieldLayout {
+                        width: Some(2),
+                        ..Default::default()
+                    },
+                    description: Some("WIS mod + proficiency".to_string()),
+                    placeholder: None,
+                },
+            ],
+            collapsible: false,
+            collapsed_default: false,
+            description: None,
+        }
+    }
+
+    fn resources_section(&self) -> SchemaSection {
+        SchemaSection {
+            id: "resources".to_string(),
+            label: "Resources".to_string(),
+            section_type: SectionType::Resources,
+            fields: vec![FieldDefinition {
+                id: "HERO_POINTS".to_string(),
+                label: "Hero Points".to_string(),
+                field_type: SchemaFieldType::Integer {
+                    min: Some(0),
+                    max: Some(3),
+                    show_modifier: false,
+                },
+                editable: true,
+                required: false,
+                derived_from: None,
+                validation: Some(FieldValidation {
+                    min: Some(0),
+                    max: Some(3),
+                    pattern: None,
+                    error_message: Some("Hero Points must be 0-3".to_string()),
+                }),
+                layout: FieldLayout {
+                    width: Some(2),
+                    ..Default::default()
+                },
+                description: Some(
+                    "Spend to reroll or avoid death. Start each session with 1.".to_string(),
+                ),
+                placeholder: None,
+            }],
+            collapsible: true,
+            collapsed_default: false,
+            description: Some("Hero Points and other trackable resources".to_string()),
+        }
+    }
+}
+
+/// Get the ability score associated with a skill in PF2e.
+pub fn skill_ability(skill: &str) -> &'static str {
+    match skill.to_lowercase().as_str() {
+        "acrobatics" | "stealth" | "thievery" => "DEX",
+        "arcana" | "crafting" | "lore" | "occultism" | "society" => "INT",
+        "athletics" => "STR",
+        "deception" | "diplomacy" | "intimidation" | "performance" => "CHA",
+        "medicine" | "nature" | "religion" | "survival" => "WIS",
+        _ => "INT", // Default for unknown Lore skills
+    }
+}
+
+/// Calculate Multiple Attack Penalty for PF2e.
+pub fn multiple_attack_penalty(attack_number: u8, is_agile: bool) -> i32 {
+    match attack_number {
+        0 | 1 => 0,
+        2 => if is_agile { -4 } else { -5 },
+        _ => if is_agile { -8 } else { -10 },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn proficiency_rank_bonuses() {
+        assert_eq!(Pf2eProficiencyRank::Untrained.rank_bonus(), 0);
+        assert_eq!(Pf2eProficiencyRank::Trained.rank_bonus(), 2);
+        assert_eq!(Pf2eProficiencyRank::Expert.rank_bonus(), 4);
+        assert_eq!(Pf2eProficiencyRank::Master.rank_bonus(), 6);
+        assert_eq!(Pf2eProficiencyRank::Legendary.rank_bonus(), 8);
+    }
+
+    #[test]
+    fn proficiency_with_level() {
+        // Level 5 character
+        assert_eq!(Pf2eProficiencyRank::Untrained.proficiency_bonus(5), 0);
+        assert_eq!(Pf2eProficiencyRank::Trained.proficiency_bonus(5), 7); // 2 + 5
+        assert_eq!(Pf2eProficiencyRank::Expert.proficiency_bonus(5), 9); // 4 + 5
+        assert_eq!(Pf2eProficiencyRank::Master.proficiency_bonus(5), 11); // 6 + 5
+        assert_eq!(Pf2eProficiencyRank::Legendary.proficiency_bonus(5), 13); // 8 + 5
+    }
+
+    #[test]
+    fn degree_of_success_determination() {
+        // Simple success (beat DC)
+        assert_eq!(
+            determine_success(15, 5, 18, false, false),
+            DegreeOfSuccess::Success
+        );
+
+        // Simple failure (below DC)
+        assert_eq!(
+            determine_success(10, 5, 18, false, false),
+            DegreeOfSuccess::Failure
+        );
+
+        // Critical success (beat by 10+)
+        assert_eq!(
+            determine_success(18, 10, 15, false, false),
+            DegreeOfSuccess::CriticalSuccess
+        );
+
+        // Critical failure (miss by 10+)
+        assert_eq!(
+            determine_success(5, 0, 20, false, false),
+            DegreeOfSuccess::CriticalFailure
+        );
+
+        // Nat 20 upgrades success to critical
+        assert_eq!(
+            determine_success(20, 0, 18, true, false),
+            DegreeOfSuccess::CriticalSuccess
+        );
+
+        // Nat 1 downgrades
+        assert_eq!(
+            determine_success(1, 15, 10, false, true),
+            DegreeOfSuccess::Failure
+        );
+    }
+
+    #[test]
+    fn ability_modifier_calculation() {
+        let system = Pf2eSystem::new();
+        assert_eq!(system.ability_modifier(10), 0);
+        assert_eq!(system.ability_modifier(18), 4);
+        assert_eq!(system.ability_modifier(8), -1);
+        assert_eq!(system.ability_modifier(1), -5);
+    }
+
+    #[test]
+    fn multiple_attack_penalty_values() {
+        // Non-agile weapon
+        assert_eq!(multiple_attack_penalty(1, false), 0);
+        assert_eq!(multiple_attack_penalty(2, false), -5);
+        assert_eq!(multiple_attack_penalty(3, false), -10);
+
+        // Agile weapon
+        assert_eq!(multiple_attack_penalty(1, true), 0);
+        assert_eq!(multiple_attack_penalty(2, true), -4);
+        assert_eq!(multiple_attack_penalty(3, true), -8);
+    }
+
+    #[test]
+    fn skill_abilities_correct() {
+        assert_eq!(skill_ability("Acrobatics"), "DEX");
+        assert_eq!(skill_ability("Athletics"), "STR");
+        assert_eq!(skill_ability("Arcana"), "INT");
+        assert_eq!(skill_ability("Diplomacy"), "CHA");
+        assert_eq!(skill_ability("Medicine"), "WIS");
+    }
+
+    #[test]
+    fn system_identification() {
+        let system = Pf2eSystem::new();
+        assert_eq!(system.system_id(), "pf2e");
+        assert_eq!(system.display_name(), "Pathfinder 2nd Edition");
+    }
+
+    #[test]
+    fn character_sheet_schema_sections() {
+        let system = Pf2eSystem::new();
+        let schema = system.character_sheet_schema();
+
+        assert_eq!(schema.system_id, "pf2e");
+        assert_eq!(schema.system_name, "Pathfinder 2nd Edition");
+        assert_eq!(schema.sections.len(), 6);
+
+        // Verify section IDs
+        let section_ids: Vec<&str> = schema.sections.iter().map(|s| s.id.as_str()).collect();
+        assert!(section_ids.contains(&"identity"));
+        assert!(section_ids.contains(&"ability_scores"));
+        assert!(section_ids.contains(&"skills"));
+        assert!(section_ids.contains(&"saves"));
+        assert!(section_ids.contains(&"combat"));
+        assert!(section_ids.contains(&"resources"));
+    }
+
+    #[test]
+    fn character_sheet_creation_steps() {
+        let system = Pf2eSystem::new();
+        let schema = system.character_sheet_schema();
+
+        assert_eq!(schema.creation_steps.len(), 4);
+        assert_eq!(schema.creation_steps[0].id, "basic_info");
+        assert_eq!(schema.creation_steps[1].id, "ability_boosts");
+        assert_eq!(schema.creation_steps[2].id, "skills");
+        assert_eq!(schema.creation_steps[3].id, "equipment");
+    }
+
+    #[test]
+    fn calculate_derived_values_ability_modifiers() {
+        let system = Pf2eSystem::new();
+        let mut values = HashMap::new();
+        values.insert("LEVEL".to_string(), serde_json::json!(1));
+        values.insert("STR".to_string(), serde_json::json!(18)); // +4 mod
+        values.insert("DEX".to_string(), serde_json::json!(14)); // +2 mod
+        values.insert("CON".to_string(), serde_json::json!(12)); // +1 mod
+        values.insert("INT".to_string(), serde_json::json!(10)); // +0 mod
+        values.insert("WIS".to_string(), serde_json::json!(16)); // +3 mod
+        values.insert("CHA".to_string(), serde_json::json!(8));  // -1 mod
+
+        let derived = system.calculate_derived_values(&values);
+
+        assert_eq!(derived.get("STR_MOD").unwrap(), &serde_json::json!(4));
+        assert_eq!(derived.get("DEX_MOD").unwrap(), &serde_json::json!(2));
+        assert_eq!(derived.get("CON_MOD").unwrap(), &serde_json::json!(1));
+        assert_eq!(derived.get("INT_MOD").unwrap(), &serde_json::json!(0));
+        assert_eq!(derived.get("WIS_MOD").unwrap(), &serde_json::json!(3));
+        assert_eq!(derived.get("CHA_MOD").unwrap(), &serde_json::json!(-1));
+    }
+
+    #[test]
+    fn calculate_derived_values_skill_modifiers_with_proficiency() {
+        let system = Pf2eSystem::new();
+        let mut values = HashMap::new();
+        values.insert("LEVEL".to_string(), serde_json::json!(5));
+        values.insert("STR".to_string(), serde_json::json!(16)); // +3 mod
+        values.insert("DEX".to_string(), serde_json::json!(14)); // +2 mod
+        values.insert("CON".to_string(), serde_json::json!(10));
+        values.insert("INT".to_string(), serde_json::json!(10));
+        values.insert("WIS".to_string(), serde_json::json!(10));
+        values.insert("CHA".to_string(), serde_json::json!(10));
+        values.insert("ATHLETICS_RANK".to_string(), serde_json::json!("trained"));
+        values.insert("ACROBATICS_RANK".to_string(), serde_json::json!("expert"));
+        values.insert("STEALTH_RANK".to_string(), serde_json::json!("untrained"));
+
+        let derived = system.calculate_derived_values(&values);
+
+        // Athletics: STR (+3) + Trained at level 5 (2 + 5 = 7) = 10
+        assert_eq!(derived.get("ATHLETICS_MOD").unwrap(), &serde_json::json!(10));
+
+        // Acrobatics: DEX (+2) + Expert at level 5 (4 + 5 = 9) = 11
+        assert_eq!(derived.get("ACROBATICS_MOD").unwrap(), &serde_json::json!(11));
+
+        // Stealth: DEX (+2) + Untrained (0) = 2
+        assert_eq!(derived.get("STEALTH_MOD").unwrap(), &serde_json::json!(2));
+    }
+
+    #[test]
+    fn calculate_derived_values_saves() {
+        let system = Pf2eSystem::new();
+        let mut values = HashMap::new();
+        values.insert("LEVEL".to_string(), serde_json::json!(5));
+        values.insert("STR".to_string(), serde_json::json!(10));
+        values.insert("DEX".to_string(), serde_json::json!(14)); // +2 mod
+        values.insert("CON".to_string(), serde_json::json!(16)); // +3 mod
+        values.insert("INT".to_string(), serde_json::json!(10));
+        values.insert("WIS".to_string(), serde_json::json!(12)); // +1 mod
+        values.insert("CHA".to_string(), serde_json::json!(10));
+        values.insert("FORTITUDE_RANK".to_string(), serde_json::json!("expert"));
+        values.insert("REFLEX_RANK".to_string(), serde_json::json!("trained"));
+        values.insert("WILL_RANK".to_string(), serde_json::json!("master"));
+
+        let derived = system.calculate_derived_values(&values);
+
+        // Fortitude: CON (+3) + Expert at level 5 (4 + 5 = 9) = 12
+        assert_eq!(derived.get("FORTITUDE_MOD").unwrap(), &serde_json::json!(12));
+
+        // Reflex: DEX (+2) + Trained at level 5 (2 + 5 = 7) = 9
+        assert_eq!(derived.get("REFLEX_MOD").unwrap(), &serde_json::json!(9));
+
+        // Will: WIS (+1) + Master at level 5 (6 + 5 = 11) = 12
+        assert_eq!(derived.get("WILL_MOD").unwrap(), &serde_json::json!(12));
+    }
+
+    #[test]
+    fn calculate_derived_values_ac() {
+        let system = Pf2eSystem::new();
+        let mut values = HashMap::new();
+        values.insert("LEVEL".to_string(), serde_json::json!(5));
+        values.insert("DEX".to_string(), serde_json::json!(14)); // +2 mod
+        values.insert("STR".to_string(), serde_json::json!(10));
+        values.insert("CON".to_string(), serde_json::json!(10));
+        values.insert("INT".to_string(), serde_json::json!(10));
+        values.insert("WIS".to_string(), serde_json::json!(10));
+        values.insert("CHA".to_string(), serde_json::json!(10));
+        values.insert("ARMOR_RANK".to_string(), serde_json::json!("trained"));
+        values.insert("ARMOR_BONUS".to_string(), serde_json::json!(2)); // Leather
+
+        let derived = system.calculate_derived_values(&values);
+
+        // AC: 10 + DEX (+2) + Trained at level 5 (2 + 5 = 7) + armor bonus (2) = 21
+        assert_eq!(derived.get("AC").unwrap(), &serde_json::json!(21));
+    }
+
+    #[test]
+    fn calculate_derived_values_ac_with_dex_cap() {
+        let system = Pf2eSystem::new();
+        let mut values = HashMap::new();
+        values.insert("LEVEL".to_string(), serde_json::json!(5));
+        values.insert("DEX".to_string(), serde_json::json!(18)); // +4 mod, but capped
+        values.insert("STR".to_string(), serde_json::json!(10));
+        values.insert("CON".to_string(), serde_json::json!(10));
+        values.insert("INT".to_string(), serde_json::json!(10));
+        values.insert("WIS".to_string(), serde_json::json!(10));
+        values.insert("CHA".to_string(), serde_json::json!(10));
+        values.insert("ARMOR_RANK".to_string(), serde_json::json!("trained"));
+        values.insert("ARMOR_BONUS".to_string(), serde_json::json!(4)); // Chain shirt
+        values.insert("DEX_CAP".to_string(), serde_json::json!(2));
+
+        let derived = system.calculate_derived_values(&values);
+
+        // AC: 10 + DEX (capped to +2) + Trained at level 5 (7) + armor bonus (4) = 23
+        assert_eq!(derived.get("AC").unwrap(), &serde_json::json!(23));
+    }
+
+    #[test]
+    fn calculate_derived_values_max_hp() {
+        let system = Pf2eSystem::new();
+        let mut values = HashMap::new();
+        values.insert("LEVEL".to_string(), serde_json::json!(5));
+        values.insert("CON".to_string(), serde_json::json!(14)); // +2 mod
+        values.insert("STR".to_string(), serde_json::json!(10));
+        values.insert("DEX".to_string(), serde_json::json!(10));
+        values.insert("INT".to_string(), serde_json::json!(10));
+        values.insert("WIS".to_string(), serde_json::json!(10));
+        values.insert("CHA".to_string(), serde_json::json!(10));
+        values.insert("ANCESTRY_HP".to_string(), serde_json::json!(8)); // Human
+        values.insert("CLASS_HP".to_string(), serde_json::json!(10)); // Fighter
+
+        let derived = system.calculate_derived_values(&values);
+
+        // HP: Ancestry (8) + (Class (10) + CON (+2)) * Level (5) = 8 + (12 * 5) = 8 + 60 = 68
+        assert_eq!(derived.get("MAX_HP").unwrap(), &serde_json::json!(68));
+    }
+
+    #[test]
+    fn validate_field_ability_scores() {
+        let system = Pf2eSystem::new();
+        let all_values = HashMap::new();
+
+        // Valid ability score
+        assert!(system.validate_field("STR", &serde_json::json!(10), &all_values).is_none());
+        assert!(system.validate_field("DEX", &serde_json::json!(18), &all_values).is_none());
+
+        // Invalid ability scores
+        assert!(system.validate_field("STR", &serde_json::json!(0), &all_values).is_some());
+        assert!(system.validate_field("STR", &serde_json::json!(31), &all_values).is_some());
+    }
+
+    #[test]
+    fn validate_field_hero_points() {
+        let system = Pf2eSystem::new();
+        let all_values = HashMap::new();
+
+        // Valid hero points
+        assert!(system.validate_field("HERO_POINTS", &serde_json::json!(0), &all_values).is_none());
+        assert!(system.validate_field("HERO_POINTS", &serde_json::json!(3), &all_values).is_none());
+
+        // Invalid hero points
+        assert!(system.validate_field("HERO_POINTS", &serde_json::json!(-1), &all_values).is_some());
+        assert!(system.validate_field("HERO_POINTS", &serde_json::json!(4), &all_values).is_some());
+    }
+
+    #[test]
+    fn default_values_correct() {
+        let system = Pf2eSystem::new();
+        let defaults = system.default_values();
+
+        assert_eq!(defaults.get("LEVEL").unwrap(), &serde_json::json!(1));
+        assert_eq!(defaults.get("STR").unwrap(), &serde_json::json!(10));
+        assert_eq!(defaults.get("DEX").unwrap(), &serde_json::json!(10));
+        assert_eq!(defaults.get("CON").unwrap(), &serde_json::json!(10));
+        assert_eq!(defaults.get("INT").unwrap(), &serde_json::json!(10));
+        assert_eq!(defaults.get("WIS").unwrap(), &serde_json::json!(10));
+        assert_eq!(defaults.get("CHA").unwrap(), &serde_json::json!(10));
+        assert_eq!(defaults.get("HERO_POINTS").unwrap(), &serde_json::json!(1));
+        assert_eq!(defaults.get("SPEED").unwrap(), &serde_json::json!(25));
+    }
+}

--- a/crates/domain/src/game_systems/traits.rs
+++ b/crates/domain/src/game_systems/traits.rs
@@ -1,0 +1,256 @@
+//! Game system traits for TTRPG-specific mechanics.
+//!
+//! These traits define the interface for system-specific calculations
+//! and mechanics, allowing different TTRPGs to implement their own rules
+//! while sharing a common API.
+
+use crate::entities::{StatBlock, StatModifier};
+use std::collections::HashMap;
+
+// Re-export character sheet schema types for game system implementations
+pub use crate::character_sheet::{
+    CharacterSheetSchema, ConditionLevel, CreationStep, DerivedField, DerivationType,
+    FieldDefinition, FieldLayout, FieldValidation, LadderLabel, ProficiencyOption, ResourceColor,
+    SchemaFieldType, SchemaSection, SchemaSelectOption, SectionType,
+};
+
+/// Core trait all game systems must implement.
+///
+/// This trait provides system identification and access to the calculation engine.
+pub trait GameSystem: Send + Sync {
+    /// Unique identifier for this game system (e.g., "dnd5e", "pf2e").
+    fn system_id(&self) -> &str;
+
+    /// Human-readable display name (e.g., "D&D 5th Edition").
+    fn display_name(&self) -> &str;
+
+    /// Get the calculation engine for this system.
+    fn calculation_engine(&self) -> &dyn CalculationEngine;
+
+    /// Optional: Get the spellcasting system if this system has spellcasting.
+    fn spellcasting_system(&self) -> Option<&dyn SpellcastingSystem> {
+        None
+    }
+
+    /// List of stat names used by this system.
+    fn stat_names(&self) -> &[&str];
+
+    /// List of skill names used by this system.
+    fn skill_names(&self) -> &[&str];
+}
+
+/// Calculation rules that vary per game system.
+///
+/// Implements the mathematical formulas specific to each TTRPG.
+pub trait CalculationEngine: Send + Sync {
+    /// Calculate ability modifier from score.
+    ///
+    /// For D&D-like systems: floor((score - 10) / 2)
+    /// For percentile systems: might return the score directly
+    fn ability_modifier(&self, score: i32) -> i32;
+
+    /// Calculate proficiency bonus from character level.
+    ///
+    /// For D&D 5e: ((level - 1) / 4) + 2
+    /// For systems without proficiency: returns 0
+    fn proficiency_bonus(&self, level: u8) -> i32;
+
+    /// Calculate spell save DC.
+    ///
+    /// For D&D 5e: 8 + proficiency + casting stat modifier
+    fn spell_save_dc(&self, stats: &StatBlock, casting_stat: &str) -> i32;
+
+    /// Calculate spell attack bonus.
+    ///
+    /// For D&D 5e: proficiency + casting stat modifier
+    fn spell_attack_bonus(&self, stats: &StatBlock, casting_stat: &str) -> i32;
+
+    /// Calculate attack bonus for a weapon attack.
+    fn attack_bonus(&self, stats: &StatBlock, attack_stat: &str, proficient: bool) -> i32;
+
+    /// Stack multiple modifiers according to system rules.
+    ///
+    /// For D&D 5e: Most bonuses don't stack (take highest), untyped stack
+    /// For PF2e: Stack by type
+    fn stack_modifiers(&self, modifiers: &[StatModifier]) -> i32;
+
+    /// Calculate Armor Class from stats and equipment.
+    fn calculate_ac(
+        &self,
+        stats: &StatBlock,
+        armor_ac: Option<i32>,
+        shield_bonus: Option<i32>,
+        allows_dex: bool,
+        max_dex_bonus: Option<i32>,
+    ) -> i32;
+
+    /// Calculate skill check modifier.
+    fn skill_modifier(
+        &self,
+        stats: &StatBlock,
+        ability: &str,
+        proficiency_level: ProficiencyLevel,
+    ) -> i32;
+
+    /// Calculate saving throw modifier.
+    fn saving_throw_modifier(
+        &self,
+        stats: &StatBlock,
+        ability: &str,
+        proficient: bool,
+    ) -> i32;
+
+    /// Calculate passive perception (or equivalent).
+    fn passive_perception(&self, stats: &StatBlock, proficiency_level: ProficiencyLevel) -> i32;
+
+    /// Get the hit die size for a class.
+    fn hit_die(&self, class_name: &str) -> u8;
+
+    /// Calculate max HP for a character.
+    fn calculate_max_hp(
+        &self,
+        level: u8,
+        class_name: &str,
+        constitution_modifier: i32,
+        additional_hp: i32,
+    ) -> i32;
+}
+
+/// Proficiency level for skills and saves.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProficiencyLevel {
+    /// Not proficient
+    None,
+    /// Half proficiency (Jack of All Trades, etc.)
+    Half,
+    /// Standard proficiency
+    Proficient,
+    /// Expertise (double proficiency)
+    Expert,
+}
+
+impl ProficiencyLevel {
+    /// Get the multiplier for this proficiency level.
+    pub fn multiplier(&self) -> f32 {
+        match self {
+            ProficiencyLevel::None => 0.0,
+            ProficiencyLevel::Half => 0.5,
+            ProficiencyLevel::Proficient => 1.0,
+            ProficiencyLevel::Expert => 2.0,
+        }
+    }
+}
+
+/// For systems with spellcasting.
+pub trait SpellcastingSystem: Send + Sync {
+    /// Get the caster type for a class (if it has spellcasting).
+    fn caster_type(&self, class: &str) -> Option<CasterType>;
+
+    /// Get the spellcasting ability for a class.
+    fn spellcasting_stat(&self, class: &str) -> Option<&str>;
+
+    /// Whether this class uses spell preparation.
+    fn uses_spell_preparation(&self, class: &str) -> bool;
+
+    /// Calculate maximum prepared spells for a class.
+    fn max_prepared_spells(&self, class: &str, level: u8, stat_mod: i32) -> u8;
+
+    /// Get spell slots for a class at a given level.
+    fn spell_slots(&self, class: &str, level: u8) -> HashMap<u8, u8>;
+
+    /// Get cantrips known for a class at a given level.
+    fn cantrips_known(&self, class: &str, level: u8) -> u8;
+
+    /// Get spells known for a class at a given level (for known-spell casters).
+    fn spells_known(&self, class: &str, level: u8) -> Option<u8>;
+}
+
+/// Type of spellcaster.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CasterType {
+    /// Full caster (Wizard, Cleric, Druid, Sorcerer, Bard)
+    Full,
+    /// Half caster (Paladin, Ranger)
+    Half,
+    /// Third caster (Eldritch Knight, Arcane Trickster)
+    Third,
+    /// Pact magic (Warlock)
+    Pact,
+    /// Innate spellcasting (racial abilities)
+    Innate,
+}
+
+impl CasterType {
+    /// Get the caster level for multiclassing calculations.
+    pub fn effective_caster_levels(&self, class_level: u8) -> u8 {
+        match self {
+            CasterType::Full => class_level,
+            CasterType::Half => class_level / 2,
+            CasterType::Third => class_level / 3,
+            CasterType::Pact => 0, // Warlock doesn't contribute to multiclass slots
+            CasterType::Innate => 0,
+        }
+    }
+}
+
+/// Rest type for resource recovery.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RestType {
+    /// Short rest (typically 1 hour)
+    Short,
+    /// Long rest (typically 8 hours)
+    Long,
+}
+
+/// Trait for generating character sheet schemas.
+///
+/// Game systems implement this to describe what fields their character
+/// sheets need. The engine uses these schemas to drive client rendering.
+pub trait CharacterSheetProvider: Send + Sync {
+    /// Generate the character sheet schema for this game system.
+    ///
+    /// Returns a complete schema with all sections, fields, and creation steps.
+    fn character_sheet_schema(&self) -> CharacterSheetSchema;
+
+    /// Calculate derived field values.
+    ///
+    /// Given a map of field IDs to values, calculate all derived values.
+    fn calculate_derived_values(
+        &self,
+        values: &HashMap<String, serde_json::Value>,
+    ) -> HashMap<String, serde_json::Value>;
+
+    /// Validate a field value.
+    ///
+    /// Returns None if valid, or an error message if invalid.
+    fn validate_field(
+        &self,
+        field_id: &str,
+        value: &serde_json::Value,
+        all_values: &HashMap<String, serde_json::Value>,
+    ) -> Option<String>;
+
+    /// Get default values for all fields.
+    fn default_values(&self) -> HashMap<String, serde_json::Value>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn proficiency_level_multipliers() {
+        assert_eq!(ProficiencyLevel::None.multiplier(), 0.0);
+        assert_eq!(ProficiencyLevel::Half.multiplier(), 0.5);
+        assert_eq!(ProficiencyLevel::Proficient.multiplier(), 1.0);
+        assert_eq!(ProficiencyLevel::Expert.multiplier(), 2.0);
+    }
+
+    #[test]
+    fn caster_type_effective_levels() {
+        assert_eq!(CasterType::Full.effective_caster_levels(5), 5);
+        assert_eq!(CasterType::Half.effective_caster_levels(6), 3);
+        assert_eq!(CasterType::Third.effective_caster_levels(9), 3);
+        assert_eq!(CasterType::Pact.effective_caster_levels(10), 0);
+    }
+}

--- a/crates/domain/src/lib.rs
+++ b/crates/domain/src/lib.rs
@@ -7,42 +7,62 @@ pub mod types;
 pub mod common;
 
 pub mod aggregates;
+pub mod character_sheet;
 pub mod entities;
 pub mod error;
 pub mod events;
+pub mod game_systems;
 pub mod game_time;
 pub mod ids;
 pub mod value_objects;
 
 // Re-export all entities (explicit list in entities/mod.rs)
 pub use entities::{
-    default_skills_for_variant, AcquisitionMethod, Act, ActantialRole, ActantialView, AssetType,
-    BatchStatus, ChainStatus, ChainedEvent, Challenge, ChallengeEventOutcome,
+    default_skills_for_variant, AbilityUses, AcquiredFeat, AcquisitionMethod, Act, ActantialRole,
+    ActantialView, ActiveFeature, AssetType, BackgroundFeature, BatchStatus, CastingTime,
+    CastingTimeUnit, ChainStatus, ChainedEvent, Challenge, ChallengeEventOutcome,
     ChallengeLocationAvailability, ChallengeOutcomes, ChallengePrerequisite,
-    ChallengeRegionAvailability, ChallengeType, ChallengeUnlock, Character, CharacterSheetData,
-    CharacterSheetTemplate, CharacterWant, CombatEventType, CombatOutcome, Difficulty,
-    DifficultyDescriptor, DmMarkerType, EntityType, EventChain, EventChainMembership, EventEffect,
-    EventOutcome, FeaturedNpc, FieldType, FieldValue, FlagScope, FrequencyLevel, GalleryAsset,
-    GameFlag, GenerationBatch, GenerationMetadata, GenerationRequest, Goal, GridMap, InfoType,
-    InputDefault, InputType, InteractionCondition, InteractionRequirement, InteractionTarget,
-    InteractionTargetType, InteractionTemplate, InteractionType, InventoryItem, InvolvedCharacter,
-    Item, ItemListType, ItemSource, Location, LocationConnection, LocationState,
-    LocationStateSummary, LocationType, Lore, LoreCategory, LoreChunk, LoreDiscoverySource,
-    LoreKnowledge, MapBounds, MarkerImportance, MonomythStage, NarrativeEvent, NarrativeTrigger,
-    NarrativeTriggerType, NpcObservation, ObservationSummary, ObservationType, Outcome,
-    OutcomeCondition, OutcomeTrigger, OutcomeType, PlayerCharacter, PromptMapping,
-    PromptMappingType, Region, RegionConnection, RegionExit, RegionState, RegionStateSummary,
+    ChallengeRegionAvailability, ChallengeType, ChallengeUnlock, Character, CharacterFeats,
+    CharacterFeatures, CharacterIdentity, CharacterSheetData, CharacterSheetTemplate, CharacterSpells,
+    CharacterWant, ClassFeature, ClassLevel, CombatEventType, CombatOutcome, Difficulty,
+    DifficultyDescriptor, DmMarkerType, DurationUnit, EntityType, EventChain, EventChainMembership,
+    EventEffect, EventOutcome, Feat, FeatBenefit, FeaturedNpc, FeatureUses, FieldType, FieldValue,
+    FlagScope, FrequencyLevel, GalleryAsset, GameFlag, GenerationBatch, GenerationMetadata,
+    GenerationRequest, Goal, GridMap, InfoType, InputDefault, InputType, InteractionCondition,
+    InteractionRequirement, InteractionTarget, InteractionTargetType, InteractionTemplate,
+    InteractionType, InventoryItem, InvolvedCharacter, Item, ItemListType, ItemSource, KnownSpell,
+    Location, LocationConnection, LocationState, LocationStateSummary, LocationType, Lore,
+    LoreCategory, LoreChunk, LoreDiscoverySource, LoreKnowledge, MapBounds, MarkerImportance,
+    MaterialComponent, MonomythStage, NarrativeEvent, NarrativeTrigger, NarrativeTriggerType,
+    NpcObservation, ObservationSummary, ObservationType, Outcome, OutcomeCondition, OutcomeTrigger,
+    OutcomeType, PlayerCharacter, Prerequisite, PromptMapping, PromptMappingType, RacialTrait,
+    RechargeType, Region, RegionConnection, RegionExit, RegionState, RegionStateSummary,
     ResolvedStateInfo, ResolvedVisualState, Scene, SceneCharacter, SceneCharacterRole,
     SceneCondition, SectionLayout, SelectOption, SheetField, SheetSection, SheetTemplateId, Skill,
-    SkillCategory, StagedNpc, Staging, StagingSource, StatBlock, StoryEvent,
-    StoryEventInfoImportance, StoryEventType, TimeAdvanceResult, TimeContext, TriggerCondition,
-    TriggerContext, TriggerEvaluation, TriggerLogic, TriggerType, VisualStateSource, Want,
+    SkillCategory, Spell, SpellComponents, SpellDuration, SpellLevel, SpellRange, SpellSlotPool,
+    StagedNpc, Staging, StagingSource, StatBlock, StoryEvent, StoryEventInfoImportance,
+    StoryEventType, TimeAdvanceResult, TimeContext, TriggerCondition, TriggerContext,
+    TriggerEvaluation, TriggerLogic, TriggerType, UsesFormula, VisualStateSource, Want,
     WantTargetType, WantVisibility, WorkflowAnalysis, WorkflowConfiguration, WorkflowInput,
     WorkflowSlot, World,
 };
 
 pub use error::DomainError;
 pub use events::DomainEvent;
+
+// Re-export game system traits and types
+pub use game_systems::{
+    dnd5e_skill_ability, CalculationEngine, CasterType, CharacterSheetProvider, Dnd5eSystem,
+    GameSystem, GameSystemRegistry, ProficiencyLevel, RestType, SpellcastingSystem,
+};
+
+// Re-export character sheet schema types
+pub use character_sheet::{
+    CharacterSheetResponse, CharacterSheetSchema, ConditionLevel, CreationStep, DerivedField,
+    DerivationType, EntityRefType, FieldDefinition, FieldLayout, FieldUpdate,
+    FieldUpdateResponse, FieldValidation, LadderLabel, ProficiencyOption, ResourceColor,
+    SchemaFieldType, SchemaSection, SchemaSelectOption, SectionType, ValidationError,
+};
 
 // Re-export game time types
 pub use game_time::{

--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -56,6 +56,9 @@ dashmap = { workspace = true }
 # Random
 rand = { workspace = true }
 
+# Regex (for content parsing)
+regex-lite = { workspace = true }
+
 [dev-dependencies]
 mockall = { workspace = true }
 tokio-tungstenite = { workspace = true }

--- a/crates/engine/src/api/websocket/mod.rs
+++ b/crates/engine/src/api/websocket/mod.rs
@@ -1377,6 +1377,7 @@ mod ws_integration_tests_inline {
             player_character.clone(),
             scene.clone(),
             flag.clone(),
+            world.clone(),
             clock.clone(),
         ));
         let narrative_events = Arc::new(crate::use_cases::narrative::NarrativeEventOps::new(

--- a/crates/engine/src/api/websocket/mod.rs
+++ b/crates/engine/src/api/websocket/mod.rs
@@ -16,6 +16,7 @@ use tokio::sync::mpsc;
 use uuid::Uuid;
 
 mod ws_challenge;
+mod ws_character_sheet;
 mod ws_core;
 mod ws_creator;
 mod ws_conversation;
@@ -629,6 +630,10 @@ async fn handle_request(
         }
         RequestPayload::Stat(req) => {
             ws_stat::handle_stat_request(state, &request_id, &conn_info, req).await
+        }
+        RequestPayload::CharacterSheet(req) => {
+            ws_character_sheet::handle_character_sheet_request(state, &request_id, &conn_info, req)
+                .await
         }
         RequestPayload::Unknown => Ok(ResponseResult::error(
             ErrorCode::BadRequest,

--- a/crates/engine/src/api/websocket/test_support.rs
+++ b/crates/engine/src/api/websocket/test_support.rs
@@ -708,6 +708,7 @@ pub(crate) fn build_test_app_with_ports(
         player_character.clone(),
         scene.clone(),
         flag.clone(),
+        world.clone(),
         clock.clone(),
     ));
     let narrative_events = Arc::new(crate::use_cases::narrative::NarrativeEventOps::new(

--- a/crates/engine/src/api/websocket/ws_challenge.rs
+++ b/crates/engine/src/api/websocket/ws_challenge.rs
@@ -193,9 +193,35 @@ pub(super) async fn handle_challenge_roll(
         ));
     }
 
-    // TODO: Skill modifiers should be fetched from character sheet when skill system is integrated
-    // For now, using 0 as the modifier
-    let skill_modifier = 0; // Placeholder until skill system
+    // Calculate skill modifier from character stats if check_stat is specified
+    let skill_modifier = if let Some(ref stat_name) = challenge.check_stat {
+        // Get the PC's sheet_data to look up stats
+        match state.app.entities.player_character.get(pc_id).await {
+            Ok(Some(pc)) => {
+                // Look up the stat value from sheet_data
+                if let Some(ref sheet_data) = pc.sheet_data {
+                    match sheet_data.get(stat_name) {
+                        Some(wrldbldr_domain::FieldValue::Number(n)) => *n,
+                        Some(wrldbldr_domain::FieldValue::SkillEntry { bonus, .. }) => *bonus,
+                        _ => 0,
+                    }
+                } else {
+                    0
+                }
+            }
+            _ => 0,
+        }
+    } else {
+        0
+    };
+
+    tracing::debug!(
+        challenge_id = %challenge_id,
+        check_stat = ?challenge.check_stat,
+        skill_modifier = skill_modifier,
+        "Challenge roll with modifier"
+    );
+
     match state
         .app
         .use_cases

--- a/crates/engine/src/api/websocket/ws_character_sheet.rs
+++ b/crates/engine/src/api/websocket/ws_character_sheet.rs
@@ -1,0 +1,900 @@
+//! WebSocket handlers for character sheet schema operations.
+//!
+//! Handles requests for character sheet schemas and character creation flow.
+
+use super::*;
+
+use crate::api::connections::ConnectionInfo;
+use serde_json::json;
+use wrldbldr_domain::{CharacterSheetProvider, CharacterSheetSchema, GameSystemRegistry};
+use wrldbldr_protocol::{CharacterSheetRequest, ErrorCode, ResponseResult};
+
+// Import all game systems that implement CharacterSheetProvider
+use wrldbldr_domain::game_systems::{
+    BladesSystem, Coc7eSystem, Dnd5eSystem, FateCoreSystem, PbtaSystem, Pf2eSystem,
+};
+
+/// Check if a game system has a character sheet schema implementation.
+fn has_schema_for_system(system_id: &str) -> bool {
+    matches!(
+        system_id,
+        "dnd5e" | "pf2e" | "coc7e" | "fate_core" | "blades" | "pbta" | "pbta_aw" | "pbta_dw" | "pbta_motw"
+    )
+}
+
+/// Get the character sheet schema for a game system.
+fn get_schema_for_system(system_id: &str) -> Option<CharacterSheetSchema> {
+    match system_id {
+        "dnd5e" => Some(Dnd5eSystem::new().character_sheet_schema()),
+        "pf2e" => Some(Pf2eSystem::new().character_sheet_schema()),
+        "coc7e" => Some(Coc7eSystem::new().character_sheet_schema()),
+        "fate_core" => Some(FateCoreSystem::new().character_sheet_schema()),
+        "blades" => Some(BladesSystem::new().character_sheet_schema()),
+        "pbta" => Some(PbtaSystem::generic().character_sheet_schema()),
+        "pbta_aw" => Some(PbtaSystem::apocalypse_world().character_sheet_schema()),
+        "pbta_dw" => Some(PbtaSystem::dungeon_world().character_sheet_schema()),
+        "pbta_motw" => Some(PbtaSystem::monster_of_the_week().character_sheet_schema()),
+        _ => None,
+    }
+}
+
+/// Get a CharacterSheetProvider for calculating derived values and validation.
+fn get_provider_for_system(system_id: &str) -> Option<Box<dyn CharacterSheetProvider>> {
+    match system_id {
+        "dnd5e" => Some(Box::new(Dnd5eSystem::new())),
+        "pf2e" => Some(Box::new(Pf2eSystem::new())),
+        "coc7e" => Some(Box::new(Coc7eSystem::new())),
+        "fate_core" => Some(Box::new(FateCoreSystem::new())),
+        "blades" => Some(Box::new(BladesSystem::new())),
+        "pbta" => Some(Box::new(PbtaSystem::generic())),
+        "pbta_aw" => Some(Box::new(PbtaSystem::apocalypse_world())),
+        "pbta_dw" => Some(Box::new(PbtaSystem::dungeon_world())),
+        "pbta_motw" => Some(Box::new(PbtaSystem::monster_of_the_week())),
+        _ => None,
+    }
+}
+
+/// Convert a RuleSystemVariant to the corresponding system ID string.
+fn variant_to_system_id(variant: &wrldbldr_domain::RuleSystemVariant) -> String {
+    use wrldbldr_domain::RuleSystemVariant;
+    match variant {
+        RuleSystemVariant::Dnd5e => "dnd5e".to_string(),
+        RuleSystemVariant::Pathfinder2e => "pf2e".to_string(),
+        RuleSystemVariant::CallOfCthulhu7e => "coc7e".to_string(),
+        RuleSystemVariant::FateCore => "fate_core".to_string(),
+        RuleSystemVariant::BladesInTheDark => "blades".to_string(),
+        RuleSystemVariant::PoweredByApocalypse => "pbta".to_string(),
+        RuleSystemVariant::KidsOnBikes => "pbta".to_string(), // Use generic PbtA
+        RuleSystemVariant::RuneQuest => "coc7e".to_string(),  // Similar to CoC (percentile)
+        RuleSystemVariant::GenericD20 => "dnd5e".to_string(), // Closest to D&D
+        RuleSystemVariant::GenericD100 => "coc7e".to_string(), // Percentile system
+        RuleSystemVariant::Custom(_) => "dnd5e".to_string(),  // Default to D&D for custom systems
+        RuleSystemVariant::Unknown => "dnd5e".to_string(),    // Default to D&D for unknown
+    }
+}
+
+pub(super) async fn handle_character_sheet_request(
+    state: &WsState,
+    request_id: &str,
+    _conn_info: &ConnectionInfo,
+    request: CharacterSheetRequest,
+) -> Result<ResponseResult, ServerMessage> {
+    let registry = GameSystemRegistry::new();
+
+    match request {
+        CharacterSheetRequest::GetSchema { system_id } => {
+            let _system = match registry.get(&system_id) {
+                Some(sys) => sys,
+                None => {
+                    return Ok(ResponseResult::error(
+                        ErrorCode::NotFound,
+                        format!("Unknown game system: {}", system_id),
+                    ));
+                }
+            };
+
+            // Get the schema from the CharacterSheetProvider trait
+            let schema = get_schema_for_system(&system_id);
+
+            match schema {
+                Some(schema) => {
+                    tracing::debug!(
+                        system_id = %system_id,
+                        sections = %schema.sections.len(),
+                        "Retrieved character sheet schema"
+                    );
+
+                    Ok(ResponseResult::success(
+                        serde_json::to_value(&schema).unwrap_or_else(|e| {
+                            json!({"error": format!("Failed to serialize schema: {}", e)})
+                        }),
+                    ))
+                }
+                None => {
+                    Ok(ResponseResult::error(
+                        ErrorCode::BadRequest,
+                        format!(
+                            "Character sheet schema not available for system: {}",
+                            system_id
+                        ),
+                    ))
+                }
+            }
+        }
+
+        CharacterSheetRequest::ListSystems => {
+            let systems: Vec<serde_json::Value> = registry
+                .list_systems_with_names()
+                .iter()
+                .map(|(id, name)| {
+                    let sys = registry.get(id);
+                    json!({
+                        "id": id,
+                        "name": name,
+                        "has_spellcasting": sys
+                            .as_ref()
+                            .map(|s| s.spellcasting_system().is_some())
+                            .unwrap_or(false),
+                        "has_sheet_schema": has_schema_for_system(id),
+                    })
+                })
+                .collect();
+
+            tracing::debug!(
+                systems_count = %systems.len(),
+                "Listed available game systems"
+            );
+
+            Ok(ResponseResult::success(json!({
+                "systems": systems
+            })))
+        }
+
+        CharacterSheetRequest::StartCreation {
+            world_id,
+            system_id,
+            name,
+        } => {
+            // Verify the system exists
+            if registry.get(&system_id).is_none() {
+                return Ok(ResponseResult::error(
+                    ErrorCode::NotFound,
+                    format!("Unknown game system: {}", system_id),
+                ));
+            }
+
+            // Parse world ID
+            let world_id_typed = match Uuid::parse_str(&world_id) {
+                Ok(id) => wrldbldr_domain::WorldId::from(id),
+                Err(_) => {
+                    return Ok(ResponseResult::error(
+                        ErrorCode::BadRequest,
+                        "Invalid world ID format",
+                    ));
+                }
+            };
+
+            // Verify the world exists
+            match state.app.entities.world.get(world_id_typed).await {
+                Ok(Some(_)) => {}
+                Ok(None) => {
+                    return Ok(ResponseResult::error(ErrorCode::NotFound, "World not found"));
+                }
+                Err(e) => {
+                    return Ok(ResponseResult::error(
+                        ErrorCode::InternalError,
+                        e.to_string(),
+                    ));
+                }
+            }
+
+            // Create a draft character
+            let character_name = name.unwrap_or_else(|| "New Character".to_string());
+            let character = wrldbldr_domain::Character::new(
+                world_id_typed,
+                character_name,
+                wrldbldr_domain::CampbellArchetype::Hero,
+            );
+            let character_id = character.id;
+
+            // Save the draft character
+            if let Err(e) = state.app.entities.character.save(&character).await {
+                return Ok(ResponseResult::error(
+                    ErrorCode::InternalError,
+                    format!("Failed to create character: {}", e),
+                ));
+            }
+
+            // Get the schema if available
+            let schema = get_schema_for_system(&system_id);
+
+            // Get default values from the provider
+            let defaults = get_provider_for_system(&system_id)
+                .map(|p| p.default_values())
+                .unwrap_or_default();
+
+            tracing::info!(
+                character_id = %character_id,
+                world_id = %world_id,
+                system_id = %system_id,
+                "Started character creation"
+            );
+
+            Ok(ResponseResult::success(json!({
+                "character_id": character_id.to_string(),
+                "schema": schema,
+                "defaults": defaults,
+            })))
+        }
+
+        CharacterSheetRequest::UpdateCreationField {
+            character_id,
+            field_id,
+            value,
+        } => {
+            let character_id_typed = parse_character_id_for_request(&character_id, request_id)?;
+
+            let mut character = match state
+                .app
+                .entities
+                .character
+                .get(character_id_typed)
+                .await
+            {
+                Ok(Some(c)) => c,
+                Ok(None) => {
+                    return Ok(ResponseResult::error(
+                        ErrorCode::NotFound,
+                        "Character not found",
+                    ));
+                }
+                Err(e) => {
+                    return Ok(ResponseResult::error(
+                        ErrorCode::InternalError,
+                        e.to_string(),
+                    ));
+                }
+            };
+
+            // Get the world to determine the system
+            let world = match state.app.entities.world.get(character.world_id).await {
+                Ok(Some(w)) => w,
+                Ok(None) => {
+                    return Ok(ResponseResult::error(ErrorCode::NotFound, "World not found"));
+                }
+                Err(e) => {
+                    return Ok(ResponseResult::error(
+                        ErrorCode::InternalError,
+                        e.to_string(),
+                    ));
+                }
+            };
+
+            // Get the system ID from the world's rule system
+            let system_id = variant_to_system_id(&world.rule_system.variant);
+            let provider = get_provider_for_system(&system_id);
+
+            // Validate the field if we have a provider
+            let all_values = get_character_values(&character);
+            if let Some(ref p) = provider {
+                if let Some(error_msg) = p.validate_field(&field_id, &value, &all_values) {
+                    return Ok(ResponseResult::error(ErrorCode::ValidationError, error_msg));
+                }
+            }
+
+            // Update the field
+            update_character_field(&mut character, &field_id, &value);
+
+            // Recalculate derived values
+            let updated_values = get_character_values(&character);
+            let calculated = provider
+                .as_ref()
+                .map(|p| p.calculate_derived_values(&updated_values))
+                .unwrap_or_default();
+
+            // Apply calculated values back to the character
+            for (field, val) in &calculated {
+                update_character_field(&mut character, field, val);
+            }
+
+            // Save the character
+            if let Err(e) = state.app.entities.character.save(&character).await {
+                return Ok(ResponseResult::error(
+                    ErrorCode::InternalError,
+                    format!("Failed to save character: {}", e),
+                ));
+            }
+
+            tracing::debug!(
+                character_id = %character_id,
+                field_id = %field_id,
+                system_id = %system_id,
+                "Updated creation field"
+            );
+
+            Ok(ResponseResult::success(json!({
+                "field_id": field_id,
+                "value": value,
+                "calculated": calculated,
+            })))
+        }
+
+        CharacterSheetRequest::CompleteCreation { character_id } => {
+            let character_id_typed = parse_character_id_for_request(&character_id, request_id)?;
+
+            let character = match state
+                .app
+                .entities
+                .character
+                .get(character_id_typed)
+                .await
+            {
+                Ok(Some(c)) => c,
+                Ok(None) => {
+                    return Ok(ResponseResult::error(
+                        ErrorCode::NotFound,
+                        "Character not found",
+                    ));
+                }
+                Err(e) => {
+                    return Ok(ResponseResult::error(
+                        ErrorCode::InternalError,
+                        e.to_string(),
+                    ));
+                }
+            };
+
+            // Get the world to determine the system
+            let world = match state.app.entities.world.get(character.world_id).await {
+                Ok(Some(w)) => w,
+                Ok(None) => {
+                    return Ok(ResponseResult::error(ErrorCode::NotFound, "World not found"));
+                }
+                Err(e) => {
+                    return Ok(ResponseResult::error(
+                        ErrorCode::InternalError,
+                        e.to_string(),
+                    ));
+                }
+            };
+
+            // Get the system ID from the world's rule system
+            let system_id = variant_to_system_id(&world.rule_system.variant);
+            let schema = get_schema_for_system(&system_id);
+
+            // Validate required fields
+            let values = get_character_values(&character);
+
+            let mut missing_required = Vec::new();
+            if let Some(ref schema) = schema {
+                for section in &schema.sections {
+                    for field in &section.fields {
+                        if field.required {
+                            if !values.contains_key(&field.id)
+                                || values.get(&field.id) == Some(&serde_json::Value::Null)
+                            {
+                                missing_required.push(field.id.clone());
+                            }
+                        }
+                    }
+                }
+            }
+
+            if !missing_required.is_empty() {
+                return Ok(ResponseResult::error(
+                    ErrorCode::ValidationError,
+                    format!("Missing required fields: {}", missing_required.join(", ")),
+                ));
+            }
+
+            tracing::info!(
+                character_id = %character_id,
+                name = %character.name,
+                "Completed character creation"
+            );
+
+            Ok(ResponseResult::success(json!({
+                "character_id": character_id,
+                "name": character.name,
+                "status": "created",
+            })))
+        }
+
+        CharacterSheetRequest::CancelCreation { character_id } => {
+            let character_id_typed = parse_character_id_for_request(&character_id, request_id)?;
+
+            // Delete the draft character
+            if let Err(e) = state
+                .app
+                .entities
+                .character
+                .delete(character_id_typed)
+                .await
+            {
+                return Ok(ResponseResult::error(
+                    ErrorCode::InternalError,
+                    format!("Failed to delete character: {}", e),
+                ));
+            }
+
+            tracing::info!(
+                character_id = %character_id,
+                "Cancelled character creation"
+            );
+
+            Ok(ResponseResult::success(json!({
+                "character_id": character_id,
+                "status": "cancelled",
+            })))
+        }
+
+        CharacterSheetRequest::GetSheet { character_id } => {
+            let character_id_typed = parse_character_id_for_request(&character_id, request_id)?;
+
+            let character = match state
+                .app
+                .entities
+                .character
+                .get(character_id_typed)
+                .await
+            {
+                Ok(Some(c)) => c,
+                Ok(None) => {
+                    return Ok(ResponseResult::error(
+                        ErrorCode::NotFound,
+                        "Character not found",
+                    ));
+                }
+                Err(e) => {
+                    return Ok(ResponseResult::error(
+                        ErrorCode::InternalError,
+                        e.to_string(),
+                    ));
+                }
+            };
+
+            // Get the world to determine the system
+            let world = match state.app.entities.world.get(character.world_id).await {
+                Ok(Some(w)) => w,
+                Ok(None) => {
+                    return Ok(ResponseResult::error(ErrorCode::NotFound, "World not found"));
+                }
+                Err(e) => {
+                    return Ok(ResponseResult::error(
+                        ErrorCode::InternalError,
+                        e.to_string(),
+                    ));
+                }
+            };
+
+            let system_id = variant_to_system_id(&world.rule_system.variant);
+
+            // Get schema and calculate derived values
+            let schema = get_schema_for_system(&system_id);
+            let values = get_character_values(&character);
+            let calculated = get_provider_for_system(&system_id)
+                .map(|p| p.calculate_derived_values(&values))
+                .unwrap_or_default();
+
+            tracing::debug!(
+                character_id = %character_id,
+                system_id = %system_id,
+                "Retrieved character sheet"
+            );
+
+            Ok(ResponseResult::success(json!({
+                "character_id": character_id,
+                "name": character.name,
+                "schema": schema,
+                "values": values,
+                "calculated": calculated,
+            })))
+        }
+
+        CharacterSheetRequest::UpdateField {
+            character_id,
+            field_id,
+            value,
+        } => {
+            // Same as UpdateCreationField for now
+            let character_id_typed = parse_character_id_for_request(&character_id, request_id)?;
+
+            let mut character = match state
+                .app
+                .entities
+                .character
+                .get(character_id_typed)
+                .await
+            {
+                Ok(Some(c)) => c,
+                Ok(None) => {
+                    return Ok(ResponseResult::error(
+                        ErrorCode::NotFound,
+                        "Character not found",
+                    ));
+                }
+                Err(e) => {
+                    return Ok(ResponseResult::error(
+                        ErrorCode::InternalError,
+                        e.to_string(),
+                    ));
+                }
+            };
+
+            // Get the world to determine the system
+            let world = match state.app.entities.world.get(character.world_id).await {
+                Ok(Some(w)) => w,
+                Ok(None) => {
+                    return Ok(ResponseResult::error(ErrorCode::NotFound, "World not found"));
+                }
+                Err(e) => {
+                    return Ok(ResponseResult::error(
+                        ErrorCode::InternalError,
+                        e.to_string(),
+                    ));
+                }
+            };
+
+            // Get the system ID from the world's rule system
+            let system_id = variant_to_system_id(&world.rule_system.variant);
+            let provider = get_provider_for_system(&system_id);
+
+            // Validate and update
+            let all_values = get_character_values(&character);
+            if let Some(ref p) = provider {
+                if let Some(error_msg) = p.validate_field(&field_id, &value, &all_values) {
+                    return Ok(ResponseResult::error(ErrorCode::ValidationError, error_msg));
+                }
+            }
+
+            update_character_field(&mut character, &field_id, &value);
+
+            let updated_values = get_character_values(&character);
+            let calculated = provider
+                .as_ref()
+                .map(|p| p.calculate_derived_values(&updated_values))
+                .unwrap_or_default();
+
+            for (field, val) in &calculated {
+                update_character_field(&mut character, field, val);
+            }
+
+            if let Err(e) = state.app.entities.character.save(&character).await {
+                return Ok(ResponseResult::error(
+                    ErrorCode::InternalError,
+                    format!("Failed to save character: {}", e),
+                ));
+            }
+
+            tracing::debug!(
+                character_id = %character_id,
+                field_id = %field_id,
+                "Updated character field"
+            );
+
+            Ok(ResponseResult::success(json!({
+                "field_id": field_id,
+                "value": value,
+                "calculated": calculated,
+            })))
+        }
+
+        CharacterSheetRequest::UpdateFields {
+            character_id,
+            updates,
+        } => {
+            let character_id_typed = parse_character_id_for_request(&character_id, request_id)?;
+
+            let mut character = match state
+                .app
+                .entities
+                .character
+                .get(character_id_typed)
+                .await
+            {
+                Ok(Some(c)) => c,
+                Ok(None) => {
+                    return Ok(ResponseResult::error(
+                        ErrorCode::NotFound,
+                        "Character not found",
+                    ));
+                }
+                Err(e) => {
+                    return Ok(ResponseResult::error(
+                        ErrorCode::InternalError,
+                        e.to_string(),
+                    ));
+                }
+            };
+
+            // Get the world to determine the system
+            let world = match state.app.entities.world.get(character.world_id).await {
+                Ok(Some(w)) => w,
+                Ok(None) => {
+                    return Ok(ResponseResult::error(ErrorCode::NotFound, "World not found"));
+                }
+                Err(e) => {
+                    return Ok(ResponseResult::error(
+                        ErrorCode::InternalError,
+                        e.to_string(),
+                    ));
+                }
+            };
+
+            // Get the system ID from the world's rule system
+            let system_id = variant_to_system_id(&world.rule_system.variant);
+            let provider = get_provider_for_system(&system_id);
+
+            // Validate all fields first
+            let all_values = get_character_values(&character);
+            if let Some(ref p) = provider {
+                for update in &updates {
+                    if let Some(error_msg) =
+                        p.validate_field(&update.field_id, &update.value, &all_values)
+                    {
+                        return Ok(ResponseResult::error(
+                            ErrorCode::ValidationError,
+                            format!("{}: {}", update.field_id, error_msg),
+                        ));
+                    }
+                }
+            }
+
+            // Apply all updates
+            for update in &updates {
+                update_character_field(&mut character, &update.field_id, &update.value);
+            }
+
+            // Recalculate
+            let updated_values = get_character_values(&character);
+            let calculated = provider
+                .as_ref()
+                .map(|p| p.calculate_derived_values(&updated_values))
+                .unwrap_or_default();
+
+            for (field, val) in &calculated {
+                update_character_field(&mut character, field, val);
+            }
+
+            if let Err(e) = state.app.entities.character.save(&character).await {
+                return Ok(ResponseResult::error(
+                    ErrorCode::InternalError,
+                    format!("Failed to save character: {}", e),
+                ));
+            }
+
+            tracing::debug!(
+                character_id = %character_id,
+                fields_updated = %updates.len(),
+                "Updated multiple character fields"
+            );
+
+            Ok(ResponseResult::success(json!({
+                "updated": updates.len(),
+                "calculated": calculated,
+            })))
+        }
+
+        CharacterSheetRequest::GetCalculatedValues { character_id } => {
+            let character_id_typed = parse_character_id_for_request(&character_id, request_id)?;
+
+            let character = match state
+                .app
+                .entities
+                .character
+                .get(character_id_typed)
+                .await
+            {
+                Ok(Some(c)) => c,
+                Ok(None) => {
+                    return Ok(ResponseResult::error(
+                        ErrorCode::NotFound,
+                        "Character not found",
+                    ));
+                }
+                Err(e) => {
+                    return Ok(ResponseResult::error(
+                        ErrorCode::InternalError,
+                        e.to_string(),
+                    ));
+                }
+            };
+
+            // Get the world to determine the system
+            let world = match state.app.entities.world.get(character.world_id).await {
+                Ok(Some(w)) => w,
+                Ok(None) => {
+                    return Ok(ResponseResult::error(ErrorCode::NotFound, "World not found"));
+                }
+                Err(e) => {
+                    return Ok(ResponseResult::error(
+                        ErrorCode::InternalError,
+                        e.to_string(),
+                    ));
+                }
+            };
+
+            // Get the system ID from the world's rule system
+            let system_id = variant_to_system_id(&world.rule_system.variant);
+            let values = get_character_values(&character);
+            let calculated = get_provider_for_system(&system_id)
+                .map(|p| p.calculate_derived_values(&values))
+                .unwrap_or_default();
+
+            Ok(ResponseResult::success(json!({
+                "calculated": calculated,
+            })))
+        }
+
+        CharacterSheetRequest::RecalculateAll { character_id } => {
+            let character_id_typed = parse_character_id_for_request(&character_id, request_id)?;
+
+            let mut character = match state
+                .app
+                .entities
+                .character
+                .get(character_id_typed)
+                .await
+            {
+                Ok(Some(c)) => c,
+                Ok(None) => {
+                    return Ok(ResponseResult::error(
+                        ErrorCode::NotFound,
+                        "Character not found",
+                    ));
+                }
+                Err(e) => {
+                    return Ok(ResponseResult::error(
+                        ErrorCode::InternalError,
+                        e.to_string(),
+                    ));
+                }
+            };
+
+            // Get the world to determine the system
+            let world = match state.app.entities.world.get(character.world_id).await {
+                Ok(Some(w)) => w,
+                Ok(None) => {
+                    return Ok(ResponseResult::error(ErrorCode::NotFound, "World not found"));
+                }
+                Err(e) => {
+                    return Ok(ResponseResult::error(
+                        ErrorCode::InternalError,
+                        e.to_string(),
+                    ));
+                }
+            };
+
+            // Get the system ID from the world's rule system
+            let system_id = variant_to_system_id(&world.rule_system.variant);
+            let values = get_character_values(&character);
+            let calculated = get_provider_for_system(&system_id)
+                .map(|p| p.calculate_derived_values(&values))
+                .unwrap_or_default();
+
+            // Apply calculated values
+            for (field, val) in &calculated {
+                update_character_field(&mut character, field, val);
+            }
+
+            if let Err(e) = state.app.entities.character.save(&character).await {
+                return Ok(ResponseResult::error(
+                    ErrorCode::InternalError,
+                    format!("Failed to save character: {}", e),
+                ));
+            }
+
+            tracing::debug!(
+                character_id = %character_id,
+                system_id = %system_id,
+                "Recalculated all derived values"
+            );
+
+            Ok(ResponseResult::success(json!({
+                "calculated": calculated,
+            })))
+        }
+    }
+}
+
+/// Extract character values into a HashMap for schema operations.
+fn get_character_values(
+    character: &wrldbldr_domain::Character,
+) -> std::collections::HashMap<String, serde_json::Value> {
+    let mut values = std::collections::HashMap::new();
+
+    // Add character name
+    values.insert("NAME".to_string(), json!(character.name));
+
+    // Add stats
+    for (name, stat) in character.stats.get_all_stats() {
+        values.insert(name.clone(), json!(stat.effective));
+    }
+
+    values
+}
+
+/// Update a character field based on field ID.
+fn update_character_field(
+    character: &mut wrldbldr_domain::Character,
+    field_id: &str,
+    value: &serde_json::Value,
+) {
+    match field_id {
+        "NAME" => {
+            if let Some(name) = value.as_str() {
+                character.name = name.to_string();
+            }
+        }
+        // Stats
+        "STR" | "DEX" | "CON" | "INT" | "WIS" | "CHA" | "LEVEL" | "CURRENT_HP" | "MAX_HP"
+        | "TEMP_HP" | "AC" | "SPEED" => {
+            if let Some(val) = value.as_i64() {
+                character.stats.set_stat(field_id, val as i32);
+            }
+        }
+        // Derived/calculated stats
+        "PROF_BONUS" | "INITIATIVE" | "PASSIVE_PERCEPTION" => {
+            if let Some(val) = value.as_i64() {
+                character.stats.set_stat(field_id, val as i32);
+            }
+        }
+        // Skill proficiencies
+        field if field.ends_with("_PROF") => {
+            if let Some(val) = value.as_str() {
+                // Store as a stat for simplicity (could use a separate map)
+                let prof_value = match val {
+                    "expert" => 2,
+                    "proficient" => 1,
+                    "half" => -1, // Use negative as flag for half
+                    _ => 0,
+                };
+                character.stats.set_stat(field_id, prof_value);
+            }
+        }
+        // Saving throw proficiencies
+        field if field.ends_with("_SAVE_PROF") => {
+            if let Some(val) = value.as_bool() {
+                character.stats.set_stat(field_id, if val { 1 } else { 0 });
+            }
+        }
+        // Saving throw modifiers (calculated)
+        field if field.ends_with("_SAVE") => {
+            if let Some(val) = value.as_i64() {
+                character.stats.set_stat(field_id, val as i32);
+            }
+        }
+        // Skill modifiers (calculated)
+        field if field.ends_with("_MOD") => {
+            if let Some(val) = value.as_i64() {
+                character.stats.set_stat(field_id, val as i32);
+            }
+        }
+        // Identity fields (CLASS, RACE, BACKGROUND)
+        "CLASS" | "RACE" | "BACKGROUND" => {
+            // These would go in CharacterIdentity when we implement it fully
+            // For now, store as a stat for simplicity
+            if let Some(val) = value.as_str() {
+                // Can't store strings directly in stats, so we'll need to extend the model
+                // For now, log it
+                tracing::debug!(field_id = %field_id, value = %val, "Identity field set (not yet persisted)");
+            }
+        }
+        // Text fields (store in description for now)
+        "FEATURES" => {
+            if let Some(text) = value.as_str() {
+                // Append to description for now until we have a proper features field
+                if !character.description.is_empty() {
+                    character.description.push_str("\n\nFeatures:\n");
+                }
+                character.description.push_str(text);
+            }
+        }
+        _ => {
+            tracing::debug!(field_id = %field_id, "Unknown field, storing as stat if numeric");
+            if let Some(val) = value.as_i64() {
+                character.stats.set_stat(field_id, val as i32);
+            }
+        }
+    }
+}

--- a/crates/engine/src/app.rs
+++ b/crates/engine/src/app.rs
@@ -334,6 +334,7 @@ impl App {
             player_character.clone(),
             scene.clone(),
             flag.clone(),
+            world.clone(),
             clock.clone(),
         ));
         let narrative_events = Arc::new(use_cases::narrative::NarrativeEventOps::new(

--- a/crates/engine/src/infrastructure/importers/fivetools.rs
+++ b/crates/engine/src/infrastructure/importers/fivetools.rs
@@ -1,0 +1,601 @@
+//! 5etools data importer.
+//!
+//! Imports spell, feat, and class feature data from 5etools JSON files
+//! and converts them to our domain types.
+
+use super::fivetools_types::*;
+use std::path::PathBuf;
+use thiserror::Error;
+use tokio::fs;
+use wrldbldr_domain::{
+    CastingTime, CastingTimeUnit, DurationUnit, Feat, FeatBenefit, MaterialComponent, Prerequisite,
+    Spell, SpellComponents, SpellDuration, SpellLevel, SpellRange,
+};
+
+/// Errors that can occur during import.
+#[derive(Debug, Error)]
+pub enum ImportError {
+    #[error("IO error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("JSON parse error: {0}")]
+    Json(#[from] serde_json::Error),
+    #[error("Index file not found at {0}")]
+    IndexNotFound(PathBuf),
+    #[error("Data file not found: {0}")]
+    DataFileNotFound(PathBuf),
+}
+
+/// Importer for 5etools data.
+pub struct FiveToolsImporter {
+    data_path: PathBuf,
+}
+
+impl FiveToolsImporter {
+    /// Create a new importer pointing to the 5etools data directory.
+    ///
+    /// The path should point to the root of the extracted 5etools folder,
+    /// e.g., `/path/to/5etools-v2.22.0`.
+    pub fn new(data_path: impl Into<PathBuf>) -> Self {
+        Self {
+            data_path: data_path.into(),
+        }
+    }
+
+    /// Import all spells from 5etools data.
+    pub async fn import_spells(&self) -> Result<Vec<Spell>, ImportError> {
+        let spells_dir = self.data_path.join("data/spells");
+        let index_path = spells_dir.join("index.json");
+
+        if !index_path.exists() {
+            return Err(ImportError::IndexNotFound(index_path));
+        }
+
+        let index_content = fs::read_to_string(&index_path).await?;
+        let index: FiveToolsIndex = serde_json::from_str(&index_content)?;
+
+        let mut all_spells = Vec::new();
+
+        for (_source, filename) in index {
+            let file_path = spells_dir.join(&filename);
+            if !file_path.exists() {
+                continue; // Skip missing files
+            }
+
+            let content = fs::read_to_string(&file_path).await?;
+            let spell_file: FiveToolsSpellFile = serde_json::from_str(&content)?;
+
+            for raw_spell in spell_file.spell {
+                if let Some(spell) = self.convert_spell(raw_spell) {
+                    all_spells.push(spell);
+                }
+            }
+        }
+
+        Ok(all_spells)
+    }
+
+    /// Import spells from a single source file.
+    pub async fn import_spells_from_file(&self, filename: &str) -> Result<Vec<Spell>, ImportError> {
+        let file_path = self.data_path.join("data/spells").join(filename);
+
+        if !file_path.exists() {
+            return Err(ImportError::DataFileNotFound(file_path));
+        }
+
+        let content = fs::read_to_string(&file_path).await?;
+        let spell_file: FiveToolsSpellFile = serde_json::from_str(&content)?;
+
+        let spells = spell_file
+            .spell
+            .into_iter()
+            .filter_map(|raw| self.convert_spell(raw))
+            .collect();
+
+        Ok(spells)
+    }
+
+    /// Import all feats from 5etools data.
+    pub async fn import_feats(&self) -> Result<Vec<Feat>, ImportError> {
+        let feats_path = self.data_path.join("data/feats.json");
+
+        if !feats_path.exists() {
+            return Err(ImportError::DataFileNotFound(feats_path));
+        }
+
+        let content = fs::read_to_string(&feats_path).await?;
+        let feat_file: FiveToolsFeatFile = serde_json::from_str(&content)?;
+
+        let feats = feat_file
+            .feat
+            .into_iter()
+            .filter_map(|raw| self.convert_feat(raw))
+            .collect();
+
+        Ok(feats)
+    }
+
+    /// Check if 5etools data exists at the configured path.
+    pub async fn validate_path(&self) -> bool {
+        let data_dir = self.data_path.join("data");
+        data_dir.exists()
+    }
+
+    /// Get the list of available spell source files.
+    pub async fn list_spell_sources(&self) -> Result<Vec<String>, ImportError> {
+        let index_path = self.data_path.join("data/spells/index.json");
+
+        if !index_path.exists() {
+            return Err(ImportError::IndexNotFound(index_path));
+        }
+
+        let content = fs::read_to_string(&index_path).await?;
+        let index: FiveToolsIndex = serde_json::from_str(&content)?;
+
+        Ok(index.into_keys().collect())
+    }
+
+    // === Conversion Methods ===
+
+    fn convert_spell(&self, raw: FiveToolsSpell) -> Option<Spell> {
+        let id = format!(
+            "5e_{}_{}",
+            raw.source.to_lowercase(),
+            raw.name.to_lowercase().replace(' ', "_").replace('\'', "")
+        );
+
+        let level = if raw.level == 0 {
+            SpellLevel::Cantrip
+        } else {
+            SpellLevel::Level(raw.level)
+        };
+
+        let school = Some(self.convert_school(&raw.school));
+        let casting_time = self.convert_casting_time(&raw.time);
+        let range = self.convert_range(&raw.range);
+        let components = self.convert_components(&raw.components);
+        let duration = self.convert_duration(&raw.duration);
+        let description = self.entries_to_string(&raw.entries);
+        let higher_levels = raw
+            .entries_higher_level
+            .map(|e| self.entries_to_string(&e));
+
+        let classes = raw
+            .classes
+            .map(|c| {
+                c.from_class_list
+                    .unwrap_or_default()
+                    .into_iter()
+                    .map(|ce| ce.name.to_lowercase())
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        let source = format!(
+            "{} p.{}",
+            raw.source,
+            raw.page.map(|p| p.to_string()).unwrap_or_default()
+        );
+
+        let concentration = raw
+            .duration
+            .first()
+            .map(|d| d.concentration)
+            .unwrap_or(false);
+        let ritual = raw.meta.map(|m| m.ritual).unwrap_or(false);
+
+        let mut tags = raw.misc_tags.unwrap_or_default();
+        if let Some(damage) = raw.damage_inflict {
+            tags.extend(damage);
+        }
+        if let Some(conditions) = raw.condition_inflict {
+            tags.extend(conditions);
+        }
+
+        Some(Spell {
+            id,
+            system_id: "dnd5e".to_string(),
+            name: raw.name,
+            level,
+            school,
+            casting_time,
+            range,
+            components,
+            duration,
+            description,
+            higher_levels,
+            classes,
+            source,
+            tags,
+            ritual,
+            concentration,
+        })
+    }
+
+    fn convert_school(&self, code: &str) -> String {
+        match code.to_uppercase().as_str() {
+            "A" => "Abjuration",
+            "C" => "Conjuration",
+            "D" => "Divination",
+            "E" => "Enchantment",
+            "V" => "Evocation",
+            "I" => "Illusion",
+            "N" => "Necromancy",
+            "T" => "Transmutation",
+            "P" => "Psionic",
+            _ => code,
+        }
+        .to_string()
+    }
+
+    fn convert_casting_time(&self, times: &[FiveToolsTime]) -> CastingTime {
+        let time = times.first();
+
+        match time {
+            Some(t) => {
+                let unit = match t.unit.to_lowercase().as_str() {
+                    "action" => CastingTimeUnit::Action,
+                    "bonus" => CastingTimeUnit::BonusAction,
+                    "reaction" => CastingTimeUnit::Reaction,
+                    "minute" => CastingTimeUnit::Minute,
+                    "hour" => CastingTimeUnit::Hour,
+                    _ => CastingTimeUnit::Special,
+                };
+
+                CastingTime {
+                    amount: t.number.unwrap_or(1),
+                    unit,
+                    condition: t.condition.clone(),
+                }
+            }
+            None => CastingTime::action(),
+        }
+    }
+
+    fn convert_range(&self, range: &Option<FiveToolsRange>) -> SpellRange {
+        match range {
+            Some(r) => match r.range_type.to_lowercase().as_str() {
+                "point" => {
+                    if let Some(dist) = &r.distance {
+                        match dist.distance_type.to_lowercase().as_str() {
+                            "self" => SpellRange::SelfOnly { area: None },
+                            "touch" => SpellRange::Touch,
+                            "feet" => SpellRange::Feet {
+                                distance: dist.amount.unwrap_or(0),
+                            },
+                            "miles" => SpellRange::Miles {
+                                distance: dist.amount.unwrap_or(0),
+                            },
+                            "sight" => SpellRange::Sight,
+                            "unlimited" => SpellRange::Unlimited,
+                            _ => SpellRange::Special {
+                                description: format!("{:?}", dist),
+                            },
+                        }
+                    } else {
+                        SpellRange::Touch
+                    }
+                }
+                "radius" | "sphere" | "cone" | "line" | "cube" | "hemisphere" => {
+                    let area = r.distance.as_ref().map(|d| {
+                        format!(
+                            "{}-foot {}",
+                            d.amount.unwrap_or(0),
+                            r.range_type.to_lowercase()
+                        )
+                    });
+                    SpellRange::SelfOnly { area }
+                }
+                "special" => SpellRange::Special {
+                    description: "See spell description".to_string(),
+                },
+                _ => SpellRange::Touch,
+            },
+            None => SpellRange::Touch,
+        }
+    }
+
+    fn convert_components(&self, components: &Option<FiveToolsComponents>) -> SpellComponents {
+        match components {
+            Some(c) => {
+                let material = c.m.as_ref().map(|m| match m {
+                    FiveToolsMaterial::Simple(s) => MaterialComponent {
+                        description: s.clone(),
+                        consumed: false,
+                        cost: None,
+                    },
+                    FiveToolsMaterial::Detailed(d) => {
+                        let consumed = match &d.consume {
+                            Some(FiveToolsConsume::Bool(b)) => *b,
+                            Some(FiveToolsConsume::String(_)) => true,
+                            None => false,
+                        };
+                        MaterialComponent {
+                            description: d.text.clone(),
+                            consumed,
+                            cost: d.cost,
+                        }
+                    }
+                });
+
+                SpellComponents {
+                    verbal: c.v,
+                    somatic: c.s,
+                    material,
+                }
+            }
+            None => SpellComponents::default(),
+        }
+    }
+
+    fn convert_duration(&self, durations: &[FiveToolsDuration]) -> SpellDuration {
+        let dur = durations.first();
+
+        match dur {
+            Some(d) => match d.duration_type.to_lowercase().as_str() {
+                "instant" => SpellDuration::Instantaneous,
+                "timed" => {
+                    if let Some(amount) = &d.duration {
+                        let unit = match amount.duration_type.to_lowercase().as_str() {
+                            "round" => DurationUnit::Round,
+                            "minute" => DurationUnit::Minute,
+                            "hour" => DurationUnit::Hour,
+                            "day" => DurationUnit::Day,
+                            _ => DurationUnit::Minute,
+                        };
+
+                        SpellDuration::Timed {
+                            amount: amount.amount.unwrap_or(1),
+                            unit,
+                            concentration: d.concentration,
+                        }
+                    } else {
+                        SpellDuration::Instantaneous
+                    }
+                }
+                "permanent" => SpellDuration::UntilDispelled {
+                    trigger: d.ends.as_ref().map(|e| e.join(", ")),
+                },
+                "special" => SpellDuration::Special {
+                    description: "See spell description".to_string(),
+                },
+                _ => SpellDuration::Instantaneous,
+            },
+            None => SpellDuration::Instantaneous,
+        }
+    }
+
+    fn convert_feat(&self, raw: FiveToolsFeat) -> Option<Feat> {
+        let id = format!(
+            "5e_{}_{}",
+            raw.source.to_lowercase(),
+            raw.name.to_lowercase().replace(' ', "_").replace('\'', "")
+        );
+
+        let description = self.entries_to_string(&raw.entries);
+
+        let prerequisites = raw
+            .prerequisite
+            .map(|prereqs| {
+                prereqs
+                    .into_iter()
+                    .flat_map(|p| self.convert_prerequisites(p))
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        let benefits = raw
+            .ability
+            .map(|abilities| {
+                abilities
+                    .into_iter()
+                    .flat_map(|a| self.convert_ability_bonus(a))
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        let source = format!(
+            "{} p.{}",
+            raw.source,
+            raw.page.map(|p| p.to_string()).unwrap_or_default()
+        );
+
+        Some(Feat {
+            id,
+            system_id: "dnd5e".to_string(),
+            name: raw.name,
+            description,
+            prerequisites,
+            benefits,
+            source,
+            category: raw.category,
+            repeatable: false,
+            tags: Vec::new(),
+        })
+    }
+
+    fn convert_prerequisites(&self, prereq: FiveToolsPrerequisite) -> Vec<Prerequisite> {
+        let mut result = Vec::new();
+
+        // Level prerequisite
+        if let Some(level) = prereq.level {
+            match level {
+                FiveToolsLevelPrereq::Simple(l) => {
+                    result.push(Prerequisite::MinLevel { level: l });
+                }
+                FiveToolsLevelPrereq::ClassLevel { class, level } => {
+                    result.push(Prerequisite::HasClass {
+                        class_id: class.name.to_lowercase(),
+                        class_name: Some(class.name),
+                        min_level: Some(level),
+                    });
+                }
+            }
+        }
+
+        // Race prerequisite
+        if let Some(races) = prereq.race {
+            for race in races {
+                result.push(Prerequisite::Race { race: race.name });
+            }
+        }
+
+        // Ability prerequisite
+        if let Some(abilities) = prereq.ability {
+            for ability_map in abilities {
+                for (stat, value) in ability_map {
+                    result.push(Prerequisite::MinStat { stat, value });
+                }
+            }
+        }
+
+        // Spellcasting prerequisite
+        if prereq.spellcasting.unwrap_or(false) || prereq.spellcasting2020.unwrap_or(false) {
+            result.push(Prerequisite::Spellcaster {
+                min_spell_level: None,
+            });
+        }
+
+        // Other/custom prerequisite
+        if let Some(other) = prereq.other {
+            result.push(Prerequisite::Custom { description: other });
+        }
+
+        result
+    }
+
+    fn convert_ability_bonus(&self, bonus: FiveToolsAbilityBonus) -> Vec<FeatBenefit> {
+        let mut result = Vec::new();
+
+        // Fixed bonuses
+        for (stat, value) in bonus.bonuses {
+            if stat != "choose" {
+                result.push(FeatBenefit::StatIncrease {
+                    stat: stat.to_uppercase(),
+                    value,
+                });
+            }
+        }
+
+        // Choice bonuses
+        if let Some(choice) = bonus.choose {
+            let options: Vec<String> = choice.from.into_iter().map(|s| s.to_uppercase()).collect();
+            let count = choice.count.unwrap_or(1);
+            let value = choice.amount.unwrap_or(1);
+
+            result.push(FeatBenefit::StatChoice {
+                options,
+                value,
+                count,
+            });
+        }
+
+        result
+    }
+
+    fn entries_to_string(&self, entries: &[serde_json::Value]) -> String {
+        entries
+            .iter()
+            .filter_map(|e| self.entry_to_string(e))
+            .collect::<Vec<_>>()
+            .join("\n\n")
+    }
+
+    fn entry_to_string(&self, entry: &serde_json::Value) -> Option<String> {
+        match entry {
+            serde_json::Value::String(s) => Some(self.clean_formatting(s)),
+            serde_json::Value::Object(obj) => {
+                if let Some(entries) = obj.get("entries") {
+                    if let Some(arr) = entries.as_array() {
+                        let name = obj
+                            .get("name")
+                            .and_then(|n| n.as_str())
+                            .map(|n| format!("**{}**\n", n))
+                            .unwrap_or_default();
+                        let content = arr
+                            .iter()
+                            .filter_map(|e| self.entry_to_string(e))
+                            .collect::<Vec<_>>()
+                            .join("\n");
+                        Some(format!("{}{}", name, content))
+                    } else {
+                        None
+                    }
+                } else if let Some(text) = obj.get("text") {
+                    text.as_str().map(|s| self.clean_formatting(s))
+                } else {
+                    None
+                }
+            }
+            _ => None,
+        }
+    }
+
+    fn clean_formatting(&self, text: &str) -> String {
+        // Remove 5etools formatting tags like {@damage 1d6}, {@spell fireball}, etc.
+        let mut result = text.to_string();
+
+        // Pattern: {@tag content} or {@tag content|display}
+        let re = regex_lite::Regex::new(r"\{@\w+\s+([^|}]+)(?:\|[^}]*)?\}").unwrap();
+        result = re.replace_all(&result, "$1").to_string();
+
+        // Pattern: {@tag content|display} - use display
+        let re2 = regex_lite::Regex::new(r"\{@\w+\s+[^|]+\|([^}]+)\}").unwrap();
+        result = re2.replace_all(&result, "$1").to_string();
+
+        result
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn school_conversion() {
+        let importer = FiveToolsImporter::new("/test");
+        assert_eq!(importer.convert_school("A"), "Abjuration");
+        assert_eq!(importer.convert_school("V"), "Evocation");
+        assert_eq!(importer.convert_school("N"), "Necromancy");
+    }
+
+    #[test]
+    fn casting_time_conversion() {
+        let importer = FiveToolsImporter::new("/test");
+
+        let times = vec![FiveToolsTime {
+            number: Some(1),
+            unit: "action".to_string(),
+            condition: None,
+        }];
+        let result = importer.convert_casting_time(&times);
+        assert_eq!(result.unit, CastingTimeUnit::Action);
+        assert_eq!(result.amount, 1);
+
+        let times = vec![FiveToolsTime {
+            number: Some(10),
+            unit: "minute".to_string(),
+            condition: None,
+        }];
+        let result = importer.convert_casting_time(&times);
+        assert_eq!(result.unit, CastingTimeUnit::Minute);
+        assert_eq!(result.amount, 10);
+    }
+
+    #[test]
+    fn clean_formatting_removes_tags() {
+        let importer = FiveToolsImporter::new("/test");
+
+        assert_eq!(
+            importer.clean_formatting("Deal {@damage 2d6} fire damage"),
+            "Deal 2d6 fire damage"
+        );
+        assert_eq!(
+            importer.clean_formatting("Cast {@spell fireball}"),
+            "Cast fireball"
+        );
+        assert_eq!(
+            importer.clean_formatting("See {@creature goblin|mm}"),
+            "See goblin"
+        );
+    }
+}

--- a/crates/engine/src/infrastructure/importers/fivetools_types.rs
+++ b/crates/engine/src/infrastructure/importers/fivetools_types.rs
@@ -1,0 +1,322 @@
+//! Type definitions for 5etools JSON data format.
+//!
+//! These types mirror the 5etools JSON schema for spells, feats, items, etc.
+//! They are used for deserialization and then converted to our domain types.
+
+use serde::Deserialize;
+use std::collections::HashMap;
+
+/// Root structure for a 5etools spell file.
+#[derive(Debug, Deserialize)]
+pub struct FiveToolsSpellFile {
+    #[serde(default)]
+    pub spell: Vec<FiveToolsSpell>,
+}
+
+/// A spell in 5etools format.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FiveToolsSpell {
+    pub name: String,
+    pub source: String,
+    #[serde(default)]
+    pub page: Option<u32>,
+    pub level: u8,
+    pub school: String,
+    #[serde(default)]
+    pub time: Vec<FiveToolsTime>,
+    #[serde(default)]
+    pub range: Option<FiveToolsRange>,
+    #[serde(default)]
+    pub components: Option<FiveToolsComponents>,
+    #[serde(default)]
+    pub duration: Vec<FiveToolsDuration>,
+    #[serde(default)]
+    pub entries: Vec<serde_json::Value>,
+    #[serde(rename = "entriesHigherLevel", default)]
+    pub entries_higher_level: Option<Vec<serde_json::Value>>,
+    #[serde(rename = "miscTags", default)]
+    pub misc_tags: Option<Vec<String>>,
+    #[serde(default)]
+    pub meta: Option<FiveToolsSpellMeta>,
+    #[serde(default)]
+    pub classes: Option<FiveToolsClasses>,
+    #[serde(default, rename = "damageInflict")]
+    pub damage_inflict: Option<Vec<String>>,
+    #[serde(default, rename = "conditionInflict")]
+    pub condition_inflict: Option<Vec<String>>,
+    #[serde(default, rename = "savingThrow")]
+    pub saving_throw: Option<Vec<String>>,
+    #[serde(default, rename = "spellAttack")]
+    pub spell_attack: Option<Vec<String>>,
+}
+
+/// Spell metadata (concentration, ritual).
+#[derive(Debug, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct FiveToolsSpellMeta {
+    #[serde(default)]
+    pub ritual: bool,
+}
+
+/// Classes that can cast a spell.
+#[derive(Debug, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct FiveToolsClasses {
+    #[serde(default)]
+    pub from_class_list: Option<Vec<FiveToolsClassEntry>>,
+    #[serde(default)]
+    pub from_subclass: Option<Vec<FiveToolsSubclassEntry>>,
+}
+
+/// A class entry.
+#[derive(Debug, Deserialize)]
+pub struct FiveToolsClassEntry {
+    pub name: String,
+    pub source: String,
+}
+
+/// A subclass entry.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FiveToolsSubclassEntry {
+    pub class: FiveToolsClassEntry,
+    pub subclass: FiveToolsClassEntry,
+}
+
+/// Casting time for a spell.
+#[derive(Debug, Deserialize)]
+pub struct FiveToolsTime {
+    #[serde(default)]
+    pub number: Option<u32>,
+    pub unit: String,
+    #[serde(default)]
+    pub condition: Option<String>,
+}
+
+/// Range of a spell.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FiveToolsRange {
+    #[serde(rename = "type")]
+    pub range_type: String,
+    #[serde(default)]
+    pub distance: Option<FiveToolsDistance>,
+}
+
+/// Distance specification.
+#[derive(Debug, Deserialize)]
+pub struct FiveToolsDistance {
+    #[serde(rename = "type")]
+    pub distance_type: String,
+    #[serde(default)]
+    pub amount: Option<u32>,
+}
+
+/// Spell components.
+#[derive(Debug, Deserialize)]
+pub struct FiveToolsComponents {
+    #[serde(default)]
+    pub v: bool,
+    #[serde(default)]
+    pub s: bool,
+    #[serde(default)]
+    pub m: Option<FiveToolsMaterial>,
+}
+
+/// Material component - can be a string or object.
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+pub enum FiveToolsMaterial {
+    Simple(String),
+    Detailed(FiveToolsMaterialDetailed),
+}
+
+/// Detailed material component.
+#[derive(Debug, Deserialize)]
+pub struct FiveToolsMaterialDetailed {
+    pub text: String,
+    #[serde(default)]
+    pub cost: Option<u32>,
+    #[serde(default)]
+    pub consume: Option<FiveToolsConsume>,
+}
+
+/// Consume specification for material.
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+pub enum FiveToolsConsume {
+    Bool(bool),
+    String(String),
+}
+
+/// Duration of a spell.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FiveToolsDuration {
+    #[serde(rename = "type")]
+    pub duration_type: String,
+    #[serde(default)]
+    pub duration: Option<FiveToolsDurationAmount>,
+    #[serde(default)]
+    pub concentration: bool,
+    #[serde(default)]
+    pub ends: Option<Vec<String>>,
+}
+
+/// Duration amount.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FiveToolsDurationAmount {
+    #[serde(rename = "type")]
+    pub duration_type: String,
+    #[serde(default)]
+    pub amount: Option<u32>,
+    #[serde(default)]
+    pub up_to: bool,
+}
+
+// === Feat Types ===
+
+/// Root structure for a 5etools feat file.
+#[derive(Debug, Deserialize)]
+pub struct FiveToolsFeatFile {
+    #[serde(default)]
+    pub feat: Vec<FiveToolsFeat>,
+}
+
+/// A feat in 5etools format.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FiveToolsFeat {
+    pub name: String,
+    pub source: String,
+    #[serde(default)]
+    pub page: Option<u32>,
+    #[serde(default)]
+    pub prerequisite: Option<Vec<FiveToolsPrerequisite>>,
+    #[serde(default)]
+    pub entries: Vec<serde_json::Value>,
+    #[serde(default)]
+    pub ability: Option<Vec<FiveToolsAbilityBonus>>,
+    #[serde(default)]
+    pub category: Option<String>,
+    #[serde(default)]
+    pub additional_sources: Option<Vec<FiveToolsAdditionalSource>>,
+}
+
+/// Prerequisite for a feat.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FiveToolsPrerequisite {
+    #[serde(default)]
+    pub level: Option<FiveToolsLevelPrereq>,
+    #[serde(default)]
+    pub race: Option<Vec<FiveToolsRacePrereq>>,
+    #[serde(default)]
+    pub ability: Option<Vec<HashMap<String, i32>>>,
+    #[serde(default)]
+    pub spellcasting: Option<bool>,
+    #[serde(default)]
+    pub spellcasting2020: Option<bool>,
+    #[serde(default)]
+    pub proficiency: Option<Vec<HashMap<String, String>>>,
+    #[serde(default)]
+    pub other: Option<String>,
+}
+
+/// Level prerequisite.
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+pub enum FiveToolsLevelPrereq {
+    Simple(u8),
+    ClassLevel { class: FiveToolsClassEntry, level: u8 },
+}
+
+/// Race prerequisite.
+#[derive(Debug, Deserialize)]
+pub struct FiveToolsRacePrereq {
+    pub name: String,
+    #[serde(default)]
+    pub subrace: Option<String>,
+}
+
+/// Ability bonus from a feat.
+#[derive(Debug, Deserialize)]
+pub struct FiveToolsAbilityBonus {
+    #[serde(flatten)]
+    pub bonuses: HashMap<String, i32>,
+    #[serde(default)]
+    pub choose: Option<FiveToolsAbilityChoice>,
+}
+
+/// Choice of ability increase.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FiveToolsAbilityChoice {
+    #[serde(default)]
+    pub from: Vec<String>,
+    #[serde(default)]
+    pub count: Option<u8>,
+    #[serde(default)]
+    pub amount: Option<i32>,
+}
+
+/// Additional source reference.
+#[derive(Debug, Deserialize)]
+pub struct FiveToolsAdditionalSource {
+    pub source: String,
+    #[serde(default)]
+    pub page: Option<u32>,
+}
+
+// === Class Feature Types ===
+
+/// Root structure for a 5etools class features file.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FiveToolsClassFeaturesFile {
+    #[serde(default)]
+    pub class_feature: Vec<FiveToolsClassFeature>,
+    #[serde(default)]
+    pub subclass_feature: Vec<FiveToolsSubclassFeature>,
+}
+
+/// A class feature in 5etools format.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FiveToolsClassFeature {
+    pub name: String,
+    pub source: String,
+    #[serde(default)]
+    pub page: Option<u32>,
+    pub class_name: String,
+    pub class_source: String,
+    pub level: u8,
+    #[serde(default)]
+    pub entries: Vec<serde_json::Value>,
+    #[serde(default)]
+    pub is_class_feature_variant: bool,
+}
+
+/// A subclass feature in 5etools format.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FiveToolsSubclassFeature {
+    pub name: String,
+    pub source: String,
+    #[serde(default)]
+    pub page: Option<u32>,
+    pub class_name: String,
+    pub class_source: String,
+    pub subclass_short_name: String,
+    pub subclass_source: String,
+    pub level: u8,
+    #[serde(default)]
+    pub entries: Vec<serde_json::Value>,
+}
+
+// === Index Types ===
+
+/// Index file mapping sources to filenames.
+pub type FiveToolsIndex = HashMap<String, String>;

--- a/crates/engine/src/infrastructure/importers/mod.rs
+++ b/crates/engine/src/infrastructure/importers/mod.rs
@@ -1,0 +1,9 @@
+//! Content importers for various data sources.
+//!
+//! This module provides importers for loading game content from external sources
+//! like 5etools, converting the data to our domain types.
+
+mod fivetools;
+mod fivetools_types;
+
+pub use fivetools::{FiveToolsImporter, ImportError};

--- a/crates/engine/src/infrastructure/mod.rs
+++ b/crates/engine/src/infrastructure/mod.rs
@@ -5,6 +5,7 @@
 pub mod circuit_breaker;
 pub mod clock;
 pub mod comfyui;
+pub mod importers;
 pub mod neo4j;
 pub mod ollama;
 pub mod ports;

--- a/crates/engine/src/infrastructure/neo4j/challenge_repo.rs
+++ b/crates/engine/src/infrastructure/neo4j/challenge_repo.rs
@@ -227,6 +227,7 @@ impl Neo4jChallengeRepo {
         let order = node.get_i64_or("challenge_order", 0) as u32;
         let is_favorite = node.get_bool_or("is_favorite", false);
         let tags: Vec<String> = node.get_json_or_default("tags_json");
+        let check_stat: Option<String> = node.get_optional_string("check_stat");
 
         Ok(Challenge {
             id,
@@ -241,6 +242,7 @@ impl Neo4jChallengeRepo {
             order,
             is_favorite,
             tags,
+            check_stat,
         })
     }
 }
@@ -300,7 +302,8 @@ impl ChallengeRepo for Neo4jChallengeRepo {
                 c.active = $active,
                 c.challenge_order = $challenge_order,
                 c.is_favorite = $is_favorite,
-                c.tags_json = $tags_json
+                c.tags_json = $tags_json,
+                c.check_stat = $check_stat
             MERGE (w)-[:CONTAINS_CHALLENGE]->(c)
             RETURN c.id as id",
         )
@@ -315,7 +318,11 @@ impl ChallengeRepo for Neo4jChallengeRepo {
         .param("active", challenge.active)
         .param("challenge_order", challenge.order as i64)
         .param("is_favorite", challenge.is_favorite)
-        .param("tags_json", tags_json);
+        .param("tags_json", tags_json)
+        .param(
+            "check_stat",
+            challenge.check_stat.clone().unwrap_or_default(),
+        );
 
         self.graph
             .run(q)

--- a/crates/engine/src/use_cases/content/content_service.rs
+++ b/crates/engine/src/use_cases/content/content_service.rs
@@ -1,0 +1,491 @@
+//! Content service for managing game content.
+//!
+//! Stores and provides access to spells, feats, class features, and other
+//! game content across different game systems.
+
+use crate::infrastructure::importers::{FiveToolsImporter, ImportError};
+use dashmap::DashMap;
+use std::path::PathBuf;
+use std::sync::Arc;
+use thiserror::Error;
+use wrldbldr_domain::{Feat, Spell, WorldId};
+
+/// Errors that can occur in the content service.
+#[derive(Debug, Error)]
+pub enum ContentError {
+    #[error("Import error: {0}")]
+    Import(#[from] ImportError),
+    #[error("System not found: {0}")]
+    SystemNotFound(String),
+    #[error("Content not found: {0}")]
+    ContentNotFound(String),
+}
+
+/// Configuration for the content service.
+#[derive(Debug, Clone)]
+pub struct ContentServiceConfig {
+    /// Path to 5etools data (optional).
+    pub fivetools_path: Option<PathBuf>,
+    /// Whether to preload content on startup.
+    pub preload: bool,
+}
+
+impl Default for ContentServiceConfig {
+    fn default() -> Self {
+        Self {
+            fivetools_path: None,
+            preload: false,
+        }
+    }
+}
+
+/// Filter criteria for content queries.
+#[derive(Debug, Clone, Default)]
+pub struct ContentFilter {
+    /// Minimum spell level.
+    pub level_min: Option<u8>,
+    /// Maximum spell level.
+    pub level_max: Option<u8>,
+    /// School of magic (for spells).
+    pub school: Option<String>,
+    /// Class that can use this content.
+    pub class: Option<String>,
+    /// Text search in name/description.
+    pub search: Option<String>,
+    /// Source book filter.
+    pub source: Option<String>,
+    /// Maximum results to return.
+    pub limit: Option<usize>,
+}
+
+impl ContentFilter {
+    /// Check if a spell matches this filter.
+    pub fn matches_spell(&self, spell: &Spell) -> bool {
+        // Level filter
+        let level = spell.level.as_number();
+        if let Some(min) = self.level_min {
+            if level < min {
+                return false;
+            }
+        }
+        if let Some(max) = self.level_max {
+            if level > max {
+                return false;
+            }
+        }
+
+        // School filter
+        if let Some(ref school) = self.school {
+            if let Some(ref spell_school) = spell.school {
+                if !spell_school.eq_ignore_ascii_case(school) {
+                    return false;
+                }
+            } else {
+                return false;
+            }
+        }
+
+        // Class filter
+        if let Some(ref class) = self.class {
+            let class_lower = class.to_lowercase();
+            if !spell.classes.iter().any(|c| c.to_lowercase() == class_lower) {
+                return false;
+            }
+        }
+
+        // Search filter
+        if let Some(ref search) = self.search {
+            let search_lower = search.to_lowercase();
+            if !spell.name.to_lowercase().contains(&search_lower)
+                && !spell.description.to_lowercase().contains(&search_lower)
+            {
+                return false;
+            }
+        }
+
+        // Source filter
+        if let Some(ref source) = self.source {
+            if !spell.source.to_lowercase().contains(&source.to_lowercase()) {
+                return false;
+            }
+        }
+
+        true
+    }
+
+    /// Check if a feat matches this filter.
+    pub fn matches_feat(&self, feat: &Feat) -> bool {
+        // Search filter
+        if let Some(ref search) = self.search {
+            let search_lower = search.to_lowercase();
+            if !feat.name.to_lowercase().contains(&search_lower)
+                && !feat.description.to_lowercase().contains(&search_lower)
+            {
+                return false;
+            }
+        }
+
+        // Source filter
+        if let Some(ref source) = self.source {
+            if !feat.source.to_lowercase().contains(&source.to_lowercase()) {
+                return false;
+            }
+        }
+
+        true
+    }
+}
+
+/// Service for managing game content (spells, feats, features).
+pub struct ContentService {
+    /// Spells by system ID.
+    spells: DashMap<String, Vec<Spell>>,
+    /// Feats by system ID.
+    feats: DashMap<String, Vec<Feat>>,
+    /// Custom spells by world ID.
+    custom_spells: DashMap<WorldId, Vec<Spell>>,
+    /// Custom feats by world ID.
+    custom_feats: DashMap<WorldId, Vec<Feat>>,
+    /// Configuration.
+    config: ContentServiceConfig,
+}
+
+impl ContentService {
+    /// Create a new content service.
+    pub fn new(config: ContentServiceConfig) -> Self {
+        Self {
+            spells: DashMap::new(),
+            feats: DashMap::new(),
+            custom_spells: DashMap::new(),
+            custom_feats: DashMap::new(),
+            config,
+        }
+    }
+
+    /// Initialize the service, optionally loading content from configured sources.
+    pub async fn initialize(&self) -> Result<(), ContentError> {
+        if self.config.preload {
+            if let Some(ref path) = self.config.fivetools_path {
+                self.load_from_5etools(path).await?;
+            }
+        }
+        Ok(())
+    }
+
+    /// Load content from 5etools data directory.
+    pub async fn load_from_5etools(&self, path: &PathBuf) -> Result<usize, ContentError> {
+        let importer = FiveToolsImporter::new(path);
+
+        if !importer.validate_path().await {
+            return Err(ContentError::Import(ImportError::IndexNotFound(
+                path.join("data"),
+            )));
+        }
+
+        let mut total = 0;
+
+        // Import spells
+        match importer.import_spells().await {
+            Ok(spells) => {
+                total += spells.len();
+                self.spells.insert("dnd5e".to_string(), spells);
+            }
+            Err(e) => {
+                tracing::warn!("Failed to import spells: {}", e);
+            }
+        }
+
+        // Import feats
+        match importer.import_feats().await {
+            Ok(feats) => {
+                total += feats.len();
+                self.feats.insert("dnd5e".to_string(), feats);
+            }
+            Err(e) => {
+                tracing::warn!("Failed to import feats: {}", e);
+            }
+        }
+
+        tracing::info!("Loaded {} items from 5etools", total);
+        Ok(total)
+    }
+
+    // === Spell Methods ===
+
+    /// Get all spells for a system.
+    pub fn get_spells(&self, system_id: &str) -> Vec<Spell> {
+        self.spells
+            .get(system_id)
+            .map(|r| r.value().clone())
+            .unwrap_or_default()
+    }
+
+    /// Get spells matching a filter.
+    pub fn get_spells_filtered(&self, system_id: &str, filter: &ContentFilter) -> Vec<Spell> {
+        let spells = self.spells.get(system_id);
+        let matching: Vec<Spell> = spells
+            .map(|r| {
+                r.value()
+                    .iter()
+                    .filter(|s| filter.matches_spell(s))
+                    .cloned()
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        match filter.limit {
+            Some(limit) => matching.into_iter().take(limit).collect(),
+            None => matching,
+        }
+    }
+
+    /// Get a spell by ID.
+    pub fn get_spell(&self, system_id: &str, spell_id: &str) -> Option<Spell> {
+        self.spells.get(system_id).and_then(|spells| {
+            spells
+                .value()
+                .iter()
+                .find(|s| s.id == spell_id)
+                .cloned()
+        })
+    }
+
+    /// Search spells by name.
+    pub fn search_spells(&self, system_id: &str, query: &str, limit: usize) -> Vec<Spell> {
+        let filter = ContentFilter {
+            search: Some(query.to_string()),
+            limit: Some(limit),
+            ..Default::default()
+        };
+        self.get_spells_filtered(system_id, &filter)
+    }
+
+    /// Get spell count for a system.
+    pub fn spell_count(&self, system_id: &str) -> usize {
+        self.spells
+            .get(system_id)
+            .map(|r| r.value().len())
+            .unwrap_or(0)
+    }
+
+    // === Feat Methods ===
+
+    /// Get all feats for a system.
+    pub fn get_feats(&self, system_id: &str) -> Vec<Feat> {
+        self.feats
+            .get(system_id)
+            .map(|r| r.value().clone())
+            .unwrap_or_default()
+    }
+
+    /// Get feats matching a filter.
+    pub fn get_feats_filtered(&self, system_id: &str, filter: &ContentFilter) -> Vec<Feat> {
+        let feats = self.feats.get(system_id);
+        let matching: Vec<Feat> = feats
+            .map(|r| {
+                r.value()
+                    .iter()
+                    .filter(|f| filter.matches_feat(f))
+                    .cloned()
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        match filter.limit {
+            Some(limit) => matching.into_iter().take(limit).collect(),
+            None => matching,
+        }
+    }
+
+    /// Get a feat by ID.
+    pub fn get_feat(&self, system_id: &str, feat_id: &str) -> Option<Feat> {
+        self.feats.get(system_id).and_then(|feats| {
+            feats.value().iter().find(|f| f.id == feat_id).cloned()
+        })
+    }
+
+    /// Search feats by name.
+    pub fn search_feats(&self, system_id: &str, query: &str, limit: usize) -> Vec<Feat> {
+        let filter = ContentFilter {
+            search: Some(query.to_string()),
+            limit: Some(limit),
+            ..Default::default()
+        };
+        self.get_feats_filtered(system_id, &filter)
+    }
+
+    /// Get feat count for a system.
+    pub fn feat_count(&self, system_id: &str) -> usize {
+        self.feats
+            .get(system_id)
+            .map(|r| r.value().len())
+            .unwrap_or(0)
+    }
+
+    // === Custom Content Methods ===
+
+    /// Add a custom spell for a world.
+    pub fn add_custom_spell(&self, world_id: WorldId, spell: Spell) {
+        self.custom_spells
+            .entry(world_id)
+            .or_default()
+            .push(spell);
+    }
+
+    /// Get custom spells for a world.
+    pub fn get_custom_spells(&self, world_id: WorldId) -> Vec<Spell> {
+        self.custom_spells
+            .get(&world_id)
+            .map(|r| r.value().clone())
+            .unwrap_or_default()
+    }
+
+    /// Add a custom feat for a world.
+    pub fn add_custom_feat(&self, world_id: WorldId, feat: Feat) {
+        self.custom_feats
+            .entry(world_id)
+            .or_default()
+            .push(feat);
+    }
+
+    /// Get custom feats for a world.
+    pub fn get_custom_feats(&self, world_id: WorldId) -> Vec<Feat> {
+        self.custom_feats
+            .get(&world_id)
+            .map(|r| r.value().clone())
+            .unwrap_or_default()
+    }
+
+    // === Statistics ===
+
+    /// Get statistics about loaded content.
+    pub fn stats(&self) -> ContentStats {
+        ContentStats {
+            systems: self.spells.len(),
+            total_spells: self.spells.iter().map(|r| r.value().len()).sum(),
+            total_feats: self.feats.iter().map(|r| r.value().len()).sum(),
+            worlds_with_custom: self.custom_spells.len() + self.custom_feats.len(),
+        }
+    }
+}
+
+/// Statistics about loaded content.
+#[derive(Debug, Clone)]
+pub struct ContentStats {
+    /// Number of game systems with content.
+    pub systems: usize,
+    /// Total number of spells.
+    pub total_spells: usize,
+    /// Total number of feats.
+    pub total_feats: usize,
+    /// Number of worlds with custom content.
+    pub worlds_with_custom: usize,
+}
+
+/// Create a shared content service.
+pub fn create_content_service(config: ContentServiceConfig) -> Arc<ContentService> {
+    Arc::new(ContentService::new(config))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use wrldbldr_domain::{CastingTime, SpellComponents, SpellDuration, SpellLevel, SpellRange};
+
+    fn create_test_spell(name: &str, level: u8, school: &str, classes: Vec<&str>) -> Spell {
+        Spell {
+            id: format!("test_{}", name.to_lowercase().replace(' ', "_")),
+            system_id: "dnd5e".to_string(),
+            name: name.to_string(),
+            level: if level == 0 {
+                SpellLevel::Cantrip
+            } else {
+                SpellLevel::Level(level)
+            },
+            school: Some(school.to_string()),
+            casting_time: CastingTime::action(),
+            range: SpellRange::feet(60),
+            components: SpellComponents::verbal_somatic(),
+            duration: SpellDuration::instantaneous(),
+            description: format!("Test description for {}", name),
+            higher_levels: None,
+            classes: classes.into_iter().map(String::from).collect(),
+            source: "Test".to_string(),
+            tags: vec![],
+            ritual: false,
+            concentration: false,
+        }
+    }
+
+    #[test]
+    fn filter_by_level() {
+        let filter = ContentFilter {
+            level_min: Some(1),
+            level_max: Some(3),
+            ..Default::default()
+        };
+
+        let cantrip = create_test_spell("Fire Bolt", 0, "Evocation", vec!["wizard"]);
+        let level1 = create_test_spell("Magic Missile", 1, "Evocation", vec!["wizard"]);
+        let level3 = create_test_spell("Fireball", 3, "Evocation", vec!["wizard"]);
+        let level5 = create_test_spell("Cone of Cold", 5, "Evocation", vec!["wizard"]);
+
+        assert!(!filter.matches_spell(&cantrip));
+        assert!(filter.matches_spell(&level1));
+        assert!(filter.matches_spell(&level3));
+        assert!(!filter.matches_spell(&level5));
+    }
+
+    #[test]
+    fn filter_by_school() {
+        let filter = ContentFilter {
+            school: Some("Evocation".to_string()),
+            ..Default::default()
+        };
+
+        let evocation = create_test_spell("Fireball", 3, "Evocation", vec!["wizard"]);
+        let necromancy = create_test_spell("Animate Dead", 3, "Necromancy", vec!["wizard"]);
+
+        assert!(filter.matches_spell(&evocation));
+        assert!(!filter.matches_spell(&necromancy));
+    }
+
+    #[test]
+    fn filter_by_class() {
+        let filter = ContentFilter {
+            class: Some("cleric".to_string()),
+            ..Default::default()
+        };
+
+        let wizard_only = create_test_spell("Fireball", 3, "Evocation", vec!["wizard"]);
+        let cleric = create_test_spell("Cure Wounds", 1, "Evocation", vec!["cleric", "bard"]);
+
+        assert!(!filter.matches_spell(&wizard_only));
+        assert!(filter.matches_spell(&cleric));
+    }
+
+    #[test]
+    fn filter_by_search() {
+        let filter = ContentFilter {
+            search: Some("fire".to_string()),
+            ..Default::default()
+        };
+
+        let fireball = create_test_spell("Fireball", 3, "Evocation", vec!["wizard"]);
+        let magic_missile =
+            create_test_spell("Magic Missile", 1, "Evocation", vec!["wizard"]);
+
+        assert!(filter.matches_spell(&fireball));
+        assert!(!filter.matches_spell(&magic_missile));
+    }
+
+    #[test]
+    fn content_service_stats() {
+        let service = ContentService::new(ContentServiceConfig::default());
+        let stats = service.stats();
+
+        assert_eq!(stats.systems, 0);
+        assert_eq!(stats.total_spells, 0);
+        assert_eq!(stats.total_feats, 0);
+    }
+}

--- a/crates/engine/src/use_cases/content/mod.rs
+++ b/crates/engine/src/use_cases/content/mod.rs
@@ -1,0 +1,8 @@
+//! Content management use cases.
+//!
+//! Provides services for managing game content like spells, feats, and features
+//! across different game systems.
+
+mod content_service;
+
+pub use content_service::{ContentFilter, ContentService, ContentServiceConfig};

--- a/crates/engine/src/use_cases/mod.rs
+++ b/crates/engine/src/use_cases/mod.rs
@@ -8,6 +8,7 @@ pub mod actantial;
 pub mod ai;
 pub mod assets;
 pub mod challenge;
+pub mod content;
 pub mod conversation;
 pub mod custom_condition;
 pub mod location_events;

--- a/crates/engine/src/use_cases/narrative/execute_effects.rs
+++ b/crates/engine/src/use_cases/narrative/execute_effects.rs
@@ -11,7 +11,7 @@ use wrldbldr_domain::{
 };
 
 use crate::entities::{
-    Challenge, Character, Flag, Inventory, Narrative, Observation, PlayerCharacter, Scene,
+    Challenge, Character, Flag, Inventory, Narrative, Observation, PlayerCharacter, Scene, World,
 };
 use crate::infrastructure::ports::ClockPort;
 
@@ -76,6 +76,7 @@ pub struct ExecuteEffects {
     player_character: Arc<PlayerCharacter>,
     scene: Arc<Scene>,
     flag: Arc<Flag>,
+    world: Arc<World>,
     clock: Arc<dyn ClockPort>,
 }
 
@@ -89,6 +90,7 @@ impl ExecuteEffects {
         player_character: Arc<PlayerCharacter>,
         scene: Arc<Scene>,
         flag: Arc<Flag>,
+        world: Arc<World>,
         clock: Arc<dyn ClockPort>,
     ) -> Self {
         Self {
@@ -100,6 +102,7 @@ impl ExecuteEffects {
             player_character,
             scene,
             flag,
+            world,
             clock,
         }
     }
@@ -356,21 +359,43 @@ impl ExecuteEffects {
                     };
                 }
 
-                // Handle XP rewards
+                // Handle XP rewards - use system-aware field mapping
                 let reward_type_lower = reward_type.to_lowercase();
                 if reward_type_lower == "xp"
                     || reward_type_lower == "experience"
                     || reward_type_lower == "exp"
                 {
-                    self.execute_add_xp_reward(context.pc_id, *amount, description)
-                        .await
+                    self.execute_add_xp_reward_system_aware(
+                        context.pc_id,
+                        context.world_id,
+                        *amount,
+                        description,
+                    )
+                    .await
                 } else if reward_type_lower == "gold"
                     || reward_type_lower == "gp"
                     || reward_type_lower == "coins"
                 {
-                    // Gold rewards - update GOLD stat
-                    self.execute_add_stat_reward(context.pc_id, "GOLD", *amount, description)
-                        .await
+                    // Gold rewards - use system-aware gold field
+                    self.execute_add_gold_reward_system_aware(
+                        context.pc_id,
+                        context.world_id,
+                        *amount,
+                        description,
+                    )
+                    .await
+                } else if reward_type_lower == "fate"
+                    || reward_type_lower == "fate_points"
+                    || reward_type_lower == "fp"
+                {
+                    // FATE points - for FATE Core system
+                    self.execute_add_stat_reward(
+                        context.pc_id,
+                        "CURRENT_FATE_POINTS",
+                        *amount,
+                        description,
+                    )
+                    .await
                 } else {
                     // Other reward types - mark for DM handling
                     EffectExecutionResult {
@@ -864,6 +889,174 @@ impl ExecuteEffects {
                 error: Some(e.to_string()),
                 requires_dm_action: false,
             },
+        }
+    }
+
+    /// Add XP reward using system-appropriate field name.
+    /// Different game systems track XP differently:
+    /// - D&D 5e, Pathfinder 2e: XP_CURRENT
+    /// - Powered by the Apocalypse: XP
+    /// - Blades in the Dark: PLAYBOOK_XP
+    /// - FATE Core, Call of Cthulhu: No XP (milestone/skill-based advancement)
+    async fn execute_add_xp_reward_system_aware(
+        &self,
+        pc_id: PlayerCharacterId,
+        world_id: WorldId,
+        amount: i32,
+        description: &str,
+    ) -> EffectExecutionResult {
+        use wrldbldr_domain::RuleSystemVariant;
+
+        // Get the world to determine the rule system
+        let world = match self.world.get(world_id).await {
+            Ok(Some(w)) => w,
+            Ok(None) => {
+                // Fall back to generic XP_CURRENT if world not found
+                tracing::warn!(world_id = %world_id, "World not found, using default XP_CURRENT field");
+                return self
+                    .execute_add_stat_reward(pc_id, "XP_CURRENT", amount, description)
+                    .await;
+            }
+            Err(e) => {
+                return EffectExecutionResult {
+                    description: format!("Failed to get world for XP reward: {}", e),
+                    success: false,
+                    error: Some(e.to_string()),
+                    requires_dm_action: false,
+                };
+            }
+        };
+
+        // Map system variant to XP field name
+        let xp_field = match world.rule_system.variant {
+            RuleSystemVariant::Dnd5e
+            | RuleSystemVariant::Pathfinder2e
+            | RuleSystemVariant::GenericD20 => "XP_CURRENT",
+
+            RuleSystemVariant::PoweredByApocalypse => "XP",
+
+            RuleSystemVariant::BladesInTheDark => "PLAYBOOK_XP",
+
+            // Systems without XP-based advancement
+            RuleSystemVariant::FateCore => {
+                return EffectExecutionResult {
+                    description: format!(
+                        "FATE Core uses milestone advancement, not XP. {} XP reward noted for DM.",
+                        amount
+                    ),
+                    success: true,
+                    error: None,
+                    requires_dm_action: true,
+                };
+            }
+            RuleSystemVariant::CallOfCthulhu7e => {
+                return EffectExecutionResult {
+                    description: format!(
+                        "Call of Cthulhu uses skill improvement checks, not XP. {} XP reward noted for DM.",
+                        amount
+                    ),
+                    success: true,
+                    error: None,
+                    requires_dm_action: true,
+                };
+            }
+
+            // Other systems - use generic XP field
+            RuleSystemVariant::KidsOnBikes
+            | RuleSystemVariant::RuneQuest
+            | RuleSystemVariant::GenericD100
+            | RuleSystemVariant::Custom(_)
+            | RuleSystemVariant::Unknown => "XP_CURRENT",
+        };
+
+        self.execute_add_stat_reward(pc_id, xp_field, amount, description)
+            .await
+    }
+
+    /// Add gold/currency reward using system-appropriate field name.
+    /// Different game systems track currency differently:
+    /// - D&D 5e, Pathfinder 2e: GP (gold pieces)
+    /// - Blades in the Dark: COIN
+    /// - Call of Cthulhu: SPENDING_LEVEL or specific currency
+    /// - FATE Core, PbtA: Usually narrative-based (no currency tracking)
+    async fn execute_add_gold_reward_system_aware(
+        &self,
+        pc_id: PlayerCharacterId,
+        world_id: WorldId,
+        amount: i32,
+        description: &str,
+    ) -> EffectExecutionResult {
+        use wrldbldr_domain::RuleSystemVariant;
+
+        // Get the world to determine the rule system
+        let world = match self.world.get(world_id).await {
+            Ok(Some(w)) => w,
+            Ok(None) => {
+                // Fall back to generic GP if world not found
+                tracing::warn!(world_id = %world_id, "World not found, using default GP field");
+                return self
+                    .execute_add_stat_reward(pc_id, "GP", amount, description)
+                    .await;
+            }
+            Err(e) => {
+                return EffectExecutionResult {
+                    description: format!("Failed to get world for gold reward: {}", e),
+                    success: false,
+                    error: Some(e.to_string()),
+                    requires_dm_action: false,
+                };
+            }
+        };
+
+        // Map system variant to currency field name
+        match world.rule_system.variant {
+            RuleSystemVariant::Dnd5e
+            | RuleSystemVariant::Pathfinder2e
+            | RuleSystemVariant::GenericD20 => {
+                self.execute_add_stat_reward(pc_id, "GP", amount, description)
+                    .await
+            }
+
+            RuleSystemVariant::BladesInTheDark => {
+                self.execute_add_stat_reward(pc_id, "COIN", amount, description)
+                    .await
+            }
+
+            RuleSystemVariant::CallOfCthulhu7e => {
+                // CoC uses Credit Rating and spending, not direct gold
+                EffectExecutionResult {
+                    description: format!(
+                        "Call of Cthulhu uses Credit Rating for wealth. {} coins noted for DM.",
+                        amount
+                    ),
+                    success: true,
+                    error: None,
+                    requires_dm_action: true,
+                }
+            }
+
+            // Narrative systems typically don't track currency
+            RuleSystemVariant::FateCore | RuleSystemVariant::PoweredByApocalypse => {
+                EffectExecutionResult {
+                    description: format!(
+                        "Narrative system typically doesn't track currency. {} gold/coins noted for DM.",
+                        amount
+                    ),
+                    success: true,
+                    error: None,
+                    requires_dm_action: true,
+                }
+            }
+
+            // Other systems - use generic GP field
+            RuleSystemVariant::KidsOnBikes
+            | RuleSystemVariant::RuneQuest
+            | RuleSystemVariant::GenericD100
+            | RuleSystemVariant::Custom(_)
+            | RuleSystemVariant::Unknown => {
+                self.execute_add_stat_reward(pc_id, "GP", amount, description)
+                    .await
+            }
         }
     }
 }

--- a/crates/protocol/src/lib.rs
+++ b/crates/protocol/src/lib.rs
@@ -222,6 +222,7 @@ pub use requests::{
     ai::AiRequest,
     challenge::ChallengeRequest,
     character::CharacterRequest,
+    character_sheet::{CharacterSheetRequest, FieldUpdateData, GameSystemInfo},
     event_chain::EventChainRequest,
     expression::ExpressionRequest,
     generation::GenerationRequest,
@@ -300,4 +301,31 @@ pub use responses::{
     ResponseResult,
     // World connection types
     WorldRole,
+};
+
+// =============================================================================
+// Character Sheet Schema Types (re-exported from domain)
+// =============================================================================
+pub use wrldbldr_domain::{
+    // Schema types
+    CharacterSheetResponse,
+    CharacterSheetSchema,
+    ConditionLevel,
+    CreationStep,
+    DerivedField,
+    DerivationType,
+    EntityRefType,
+    FieldDefinition,
+    FieldLayout,
+    FieldUpdate,
+    FieldUpdateResponse,
+    FieldValidation,
+    LadderLabel,
+    ProficiencyOption,
+    ResourceColor,
+    SchemaFieldType,
+    SchemaSection,
+    SchemaSelectOption,
+    SectionType,
+    ValidationError,
 };

--- a/crates/protocol/src/requests.rs
+++ b/crates/protocol/src/requests.rs
@@ -15,6 +15,7 @@ pub mod actantial;
 pub mod ai;
 pub mod challenge;
 pub mod character;
+pub mod character_sheet;
 pub mod event_chain;
 pub mod expression;
 pub mod generation;
@@ -74,6 +75,7 @@ pub enum RequestPayload {
     Items(items::ItemsRequest),
     Lore(lore::LoreRequest),
     Stat(stat::StatRequest),
+    CharacterSheet(character_sheet::CharacterSheetRequest),
 
     #[serde(other)]
     Unknown,

--- a/crates/protocol/src/requests/character_sheet.rs
+++ b/crates/protocol/src/requests/character_sheet.rs
@@ -1,0 +1,145 @@
+//! Character Sheet Request Types
+//!
+//! Requests for character creation, sheet retrieval, and field updates.
+
+use serde::{Deserialize, Serialize};
+
+/// Character sheet operations
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum CharacterSheetRequest {
+    // =========================================================================
+    // Schema Operations
+    // =========================================================================
+    /// Get the character sheet schema for a game system.
+    ///
+    /// Returns the schema describing all fields, sections, and creation steps.
+    GetSchema {
+        /// Game system ID (e.g., "dnd5e", "pf2e", "blades")
+        system_id: String,
+    },
+
+    /// List all available game systems.
+    ///
+    /// Returns a list of system IDs and display names.
+    ListSystems,
+
+    // =========================================================================
+    // Character Creation
+    // =========================================================================
+    /// Start a new character creation session.
+    ///
+    /// Returns a character ID and the creation schema.
+    StartCreation {
+        /// World the character will belong to
+        world_id: String,
+        /// Game system ID
+        system_id: String,
+        /// Optional character name (can be set later)
+        #[serde(default)]
+        name: Option<String>,
+    },
+
+    /// Update a field during character creation.
+    ///
+    /// Validates the value and returns any calculated field updates.
+    UpdateCreationField {
+        /// Character being created
+        character_id: String,
+        /// Field to update
+        field_id: String,
+        /// New value
+        value: serde_json::Value,
+    },
+
+    /// Complete character creation.
+    ///
+    /// Validates all required fields are set and finalizes the character.
+    CompleteCreation {
+        /// Character being created
+        character_id: String,
+    },
+
+    /// Cancel character creation.
+    ///
+    /// Removes the draft character.
+    CancelCreation {
+        /// Character being created
+        character_id: String,
+    },
+
+    // =========================================================================
+    // Character Sheet Operations
+    // =========================================================================
+    /// Get the full character sheet with schema and values.
+    ///
+    /// Returns the schema, current values, and calculated values.
+    GetSheet {
+        /// Character ID
+        character_id: String,
+    },
+
+    /// Update a field on an existing character.
+    ///
+    /// Validates and persists the change, returns calculated field updates.
+    UpdateField {
+        /// Character ID
+        character_id: String,
+        /// Field to update
+        field_id: String,
+        /// New value
+        value: serde_json::Value,
+    },
+
+    /// Update multiple fields atomically.
+    ///
+    /// All fields are validated and updated together.
+    UpdateFields {
+        /// Character ID
+        character_id: String,
+        /// Fields to update
+        updates: Vec<FieldUpdateData>,
+    },
+
+    /// Get only calculated values for a character.
+    ///
+    /// Useful after a batch update to refresh all derived values.
+    GetCalculatedValues {
+        /// Character ID
+        character_id: String,
+    },
+
+    /// Recalculate all derived fields for a character.
+    ///
+    /// Forces recalculation of all derived values.
+    RecalculateAll {
+        /// Character ID
+        character_id: String,
+    },
+}
+
+/// Data for a single field update.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FieldUpdateData {
+    /// Field ID
+    pub field_id: String,
+    /// New value
+    pub value: serde_json::Value,
+}
+
+/// Response for system list.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GameSystemInfo {
+    /// System ID
+    pub id: String,
+    /// Display name
+    pub name: String,
+    /// Short description
+    #[serde(default)]
+    pub description: Option<String>,
+    /// Whether this system supports spellcasting
+    #[serde(default)]
+    pub has_spellcasting: bool,
+}

--- a/docs/game-systems/ARCHITECTURE.md
+++ b/docs/game-systems/ARCHITECTURE.md
@@ -1,0 +1,308 @@
+# Game Systems Architecture
+
+## Overview
+
+WrldBldr supports multiple tabletop roleplaying game (TTRPG) systems through a modular, trait-based architecture. This document describes how different game systems are integrated while maintaining clean separation of concerns.
+
+## System Categories
+
+Game systems are organized by their fundamental mechanics:
+
+### Category 1: D20-Based Systems
+- **D&D 5th Edition** - d20 + modifier vs DC
+- **Pathfinder 2e** - d20 + modifier with four degrees of success
+
+### Category 2: Percentile Systems
+- **Call of Cthulhu 7e** - d100 roll-under with Hard/Extreme success tiers
+
+### Category 3: Narrative Dice Pool Systems
+- **Blades in the Dark** - d6 dice pool, take highest
+- **FATE Core** - 4dF + skill on a ladder
+
+### Category 4: Powered by the Apocalypse
+- **PbtA Games** - 2d6 + stat with move-based resolution
+
+## Core Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────────────────┐
+│                            Application Layer                                 │
+│  ┌────────────────┐  ┌────────────────┐  ┌────────────────┐                │
+│  │ Character UI   │  │  Combat UI     │  │  Content UI    │                │
+│  │ (per-system)   │  │  (per-system)  │  │  (universal)   │                │
+│  └───────┬────────┘  └───────┬────────┘  └───────┬────────┘                │
+└──────────┼───────────────────┼───────────────────┼──────────────────────────┘
+           │                   │                   │
+┌──────────▼───────────────────▼───────────────────▼──────────────────────────┐
+│                            Service Layer                                     │
+│  ┌─────────────────────────────────────────────────────────────────────┐   │
+│  │                      ContentService                                  │   │
+│  │  • Spell/Feat/Feature management                                    │   │
+│  │  • Import adapters (5etools, etc.)                                  │   │
+│  │  • Custom content per world                                         │   │
+│  └─────────────────────────────────────────────────────────────────────┘   │
+│  ┌─────────────────────────────────────────────────────────────────────┐   │
+│  │                    GameSystemRegistry                                │   │
+│  │  • System lookup by ID                                              │   │
+│  │  • Calculation engine access                                        │   │
+│  │  • System metadata                                                  │   │
+│  └─────────────────────────────────────────────────────────────────────┘   │
+└─────────────────────────────────────────────────────────────────────────────┘
+           │
+┌──────────▼──────────────────────────────────────────────────────────────────┐
+│                            Domain Layer                                      │
+│                                                                              │
+│  ┌─────────────────────────────────────────────────────────────────────┐   │
+│  │                     Game System Traits                               │   │
+│  │                                                                      │   │
+│  │  trait GameSystem {                                                 │   │
+│  │      fn system_id() -> &str;                                        │   │
+│  │      fn calculation_engine() -> &dyn CalculationEngine;             │   │
+│  │      fn dice_system() -> DiceSystem;                                │   │
+│  │  }                                                                  │   │
+│  │                                                                      │   │
+│  │  trait CalculationEngine {                                          │   │
+│  │      fn ability_modifier(score: i32) -> i32;                        │   │
+│  │      fn roll_interpretation(roll: &RollResult) -> RollOutcome;      │   │
+│  │      fn calculate_derived_stat(stat: &str, block: &StatBlock) -> i32;│   │
+│  │  }                                                                  │   │
+│  │                                                                      │   │
+│  │  trait ProgressionSystem {                                          │   │
+│  │      fn xp_for_level(level: u32) -> u32;                            │   │
+│  │      fn features_at_level(class: &str, level: u32) -> Vec<Feature>;  │   │
+│  │  }                                                                  │   │
+│  └─────────────────────────────────────────────────────────────────────┘   │
+│                                                                              │
+│  ┌──────────────┐ ┌──────────────┐ ┌──────────────┐ ┌──────────────┐       │
+│  │   Dnd5e      │ │   Pf2e       │ │   Coc7e      │ │   FateCore   │       │
+│  │   System     │ │   System     │ │   System     │ │   System     │       │
+│  └──────────────┘ └──────────────┘ └──────────────┘ └──────────────┘       │
+│  ┌──────────────┐ ┌──────────────┐                                          │
+│  │   Blades     │ │   PbtA       │                                          │
+│  │   System     │ │   System     │                                          │
+│  └──────────────┘ └──────────────┘                                          │
+└─────────────────────────────────────────────────────────────────────────────┘
+```
+
+## Data Flow
+
+### Character Creation Flow
+
+```
+┌─────────────┐     ┌─────────────┐     ┌─────────────────┐     ┌─────────────┐
+│   UI Form   │────▶│  Protocol   │────▶│  GameSystem     │────▶│  Character  │
+│  (System-   │     │  Request    │     │  Validation     │     │  Entity     │
+│   specific) │     │             │     │  & Defaults     │     │             │
+└─────────────┘     └─────────────┘     └─────────────────┘     └─────────────┘
+                                               │
+                                               ▼
+                                        ┌─────────────────┐
+                                        │  StatBlock      │
+                                        │  (Universal)    │
+                                        │  + Modifiers    │
+                                        └─────────────────┘
+```
+
+### Dice Roll Resolution Flow
+
+```
+┌─────────────┐     ┌─────────────────┐     ┌─────────────────┐     ┌─────────────┐
+│  Roll       │────▶│  DiceFormula    │────▶│  GameSystem     │────▶│  UI Display │
+│  Request    │     │  Execute        │     │  Interpret      │     │  + Effects  │
+│             │     │  (d20, d100,    │     │  Result         │     │             │
+│             │     │   4dF, d6 pool) │     │                 │     │             │
+└─────────────┘     └─────────────────┘     └─────────────────┘     └─────────────┘
+                           │                        │
+                           ▼                        ▼
+                    ┌─────────────┐          ┌─────────────────┐
+                    │ Raw Result  │          │  RollOutcome    │
+                    │ (numbers)   │          │  (success type, │
+                    │             │          │   degree, etc.) │
+                    └─────────────┘          └─────────────────┘
+```
+
+### Stat Calculation Flow
+
+```
+┌─────────────┐     ┌─────────────────┐     ┌─────────────────┐
+│  StatBlock  │────▶│  Calculation    │────▶│  Derived Stats  │
+│  Base Stats │     │  Engine         │     │  (AC, HP, etc.) │
+│             │     │  (System-       │     │                 │
+│             │     │   specific)     │     │                 │
+└─────────────┘     └─────────────────┘     └─────────────────┘
+       │                   │
+       ▼                   ▼
+┌─────────────┐     ┌─────────────────┐
+│  Modifiers  │     │  Stacking Rules │
+│  (buffs,    │────▶│  (system-       │
+│   items)    │     │   specific)     │
+└─────────────┘     └─────────────────┘
+```
+
+## Stat Block Flexibility
+
+The `StatBlock` struct is designed to be flexible across all systems:
+
+```rust
+pub struct StatBlock {
+    // Base values - named arbitrarily per system
+    pub stats: HashMap<String, StatValue>,
+
+    // Active modifiers with stacking rules
+    pub modifiers: Vec<StatModifier>,
+
+    // System-specific metadata
+    pub metadata: HashMap<String, serde_json::Value>,
+}
+```
+
+### Stat Naming Conventions by System
+
+| System | Primary Stats | Derived Stats |
+|--------|--------------|---------------|
+| D&D 5e | STR, DEX, CON, INT, WIS, CHA | AC, HP, PROF_BONUS |
+| PF2e | STR, DEX, CON, INT, WIS, CHA | AC, HP, PERCEPTION |
+| CoC 7e | STR, CON, SIZ, DEX, APP, INT, POW, EDU | HP, SAN, MP, LUCK |
+| FATE | APPROACHES or custom | REFRESH, STRESS_PHYS, STRESS_MENT |
+| Blades | INSIGHT, PROWESS, RESOLVE | STRESS, TRAUMA |
+| PbtA | Varies by game (COOL, HARD, etc.) | HP/HARM varies |
+
+## Modifier Stacking Rules
+
+Different systems have different stacking rules:
+
+```rust
+trait StackingRules {
+    fn stack_modifiers(&self, modifiers: &[StatModifier]) -> i32;
+}
+
+// D&D 5e: Same-named bonuses don't stack (take highest)
+// PF2e: Bonuses stack by type (circumstance, item, status)
+// CoC 7e: Flat bonuses/penalties stack
+// FATE: Aspects provide +2 each, can stack
+// Blades: Dice added to pool, not bonuses
+```
+
+## UI Components per System
+
+Each system may require specialized UI components:
+
+### D&D 5e / PF2e
+- Six-stat display with modifiers
+- Spell slot tracker
+- Feat/ability list
+- Equipment with AC calculation
+
+### Call of Cthulhu
+- Eight-characteristic display
+- Sanity meter with threshold markers
+- Skill percentages with Hard/Extreme values
+- Luck track
+
+### FATE Core
+- Aspect cards (draggable, invoke/compel buttons)
+- Skill pyramid visualization
+- Stress boxes with consequence slots
+- Fate point tracker
+
+### Blades in the Dark
+- Action dot display (12 actions)
+- Stress/trauma track
+- Load selector
+- Clock widgets
+
+### PbtA
+- Move cards with triggers
+- Stat modifiers (-2 to +3)
+- Harm/condition boxes
+- Hold counters
+
+## File Structure
+
+```
+crates/domain/src/game_systems/
+├── mod.rs                 # Module exports, registry
+├── traits.rs              # Core traits
+├── dnd5e.rs               # D&D 5e implementation
+├── pf2e.rs                # Pathfinder 2e implementation
+├── coc7e.rs               # Call of Cthulhu 7e implementation
+├── fate_core.rs           # FATE Core implementation
+├── blades.rs              # Blades in the Dark implementation
+├── pbta/
+│   ├── mod.rs             # PbtA common code
+│   ├── apocalypse_world.rs
+│   ├── dungeon_world.rs
+│   └── monster_of_week.rs
+└── generic.rs             # Fallback generic system
+
+docs/game-systems/
+├── ARCHITECTURE.md        # This file
+├── dnd5e.md               # D&D 5e rules reference
+├── pf2e.md                # Pathfinder 2e rules reference
+├── coc7e.md               # Call of Cthulhu 7e rules reference
+├── fate_core.md           # FATE Core rules reference
+├── blades.md              # Blades in the Dark rules reference
+├── pbta.md                # PbtA rules reference
+└── UI_MOCKUPS.md          # UI component designs
+```
+
+## Extension Points
+
+### Adding a New System
+
+1. Create `new_system.rs` in `game_systems/`
+2. Implement `GameSystem` trait
+3. Implement `CalculationEngine` trait
+4. Add to `GameSystemRegistry::new()`
+5. Create documentation in `docs/game-systems/`
+6. Create UI components if needed
+
+### System-Specific Content
+
+Systems can define their own content types:
+
+```rust
+// In the system module
+pub struct Pf2eAncestry { ... }
+pub struct BladesPlaybook { ... }
+pub struct PbtAMove { ... }
+```
+
+These are stored in the `ContentService` with system-specific keys.
+
+## Integration with Existing Code
+
+### StatBlock Usage
+
+The existing `StatBlock` from `character.rs` works with all systems:
+
+```rust
+// D&D 5e usage
+stats.set_stat("STR", 16);
+let modifier = dnd5e.ability_modifier(stats.get_stat("STR").unwrap_or(10));
+
+// CoC 7e usage
+stats.set_stat("POW", 65);  // Percentile value
+let san = stats.get_stat("POW").unwrap_or(50);  // Starting sanity = POW
+
+// FATE usage
+stats.set_stat("FIGHT", 3);  // +3 on the ladder
+```
+
+### RuleSystemConfig Integration
+
+The existing `RuleSystemConfig` is extended:
+
+```rust
+pub enum RuleSystemVariant {
+    Dnd5E,
+    Pathfinder2E,
+    CallOfCthulhu7E,
+    FateCore,
+    BladesInTheDark,
+    PoweredByApocalypse,
+    Custom,
+}
+```
+
+Each variant maps to its corresponding `GameSystem` implementation.

--- a/docs/game-systems/UI_MOCKUPS.md
+++ b/docs/game-systems/UI_MOCKUPS.md
@@ -1,0 +1,545 @@
+# UI Mockups for Game System Character Sheets
+
+## Overview
+
+Each game system requires specialized UI components to properly display and interact with its unique mechanics. This document provides wireframe specifications for each supported system.
+
+---
+
+## D&D 5th Edition
+
+### Character Sheet Layout
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  CHARACTER NAME                              Level X [Class]    │
+│  Race | Background | Alignment                                  │
+├─────────────────────────────────────────────────────────────────┤
+│                                                                 │
+│  ┌─────────────────────────┐  ┌─────────────────────────────┐  │
+│  │  ABILITY SCORES         │  │  COMBAT STATS               │  │
+│  │  ┌─────┐ ┌─────┐        │  │                             │  │
+│  │  │ STR │ │ DEX │        │  │  AC: [__]  Initiative: [__] │  │
+│  │  │ 16  │ │ 14  │        │  │  Speed: 30ft                │  │
+│  │  │ +3  │ │ +2  │        │  │                             │  │
+│  │  └─────┘ └─────┘        │  │  HP: [__] / [__]            │  │
+│  │  ┌─────┐ ┌─────┐        │  │  ████████░░░░               │  │
+│  │  │ CON │ │ INT │        │  │  Temp HP: [__]              │  │
+│  │  │ 15  │ │ 10  │        │  │                             │  │
+│  │  │ +2  │ │ +0  │        │  │  Hit Dice: d10 [5/5]        │  │
+│  │  └─────┘ └─────┘        │  │  Death Saves: ○○○ / ●●●     │  │
+│  │  ┌─────┐ ┌─────┐        │  └─────────────────────────────┘  │
+│  │  │ WIS │ │ CHA │        │                                   │
+│  │  │ 12  │ │ 8   │        │  ┌─────────────────────────────┐  │
+│  │  │ +1  │ │ -1  │        │  │  PROFICIENCIES              │  │
+│  │  └─────┘ └─────┘        │  │  Prof Bonus: +3             │  │
+│  └─────────────────────────┘  │  Passive Perception: 14     │  │
+│                               └─────────────────────────────┘  │
+├─────────────────────────────────────────────────────────────────┤
+│  SAVING THROWS          │  SKILLS                              │
+│  ○ STR +3               │  ● Acrobatics (DEX)     +5          │
+│  ● DEX +5               │  ○ Animal Handling (WIS) +1          │
+│  ● CON +5               │  ○ Arcana (INT)          +0          │
+│  ○ INT +0               │  ● Athletics (STR)       +6          │
+│  ○ WIS +1               │  ...                                 │
+│  ○ CHA -1               │                                      │
+├─────────────────────────────────────────────────────────────────┤
+│  ATTACKS & SPELLCASTING                                         │
+│  ┌──────────────┬────────┬────────────┐                        │
+│  │ Longsword    │ +6     │ 1d8+3 slsh │                        │
+│  │ Shortbow     │ +5     │ 1d6+2 prc  │                        │
+│  └──────────────┴────────┴────────────┘                        │
+├─────────────────────────────────────────────────────────────────┤
+│  SPELL SLOTS          SPELLS KNOWN/PREPARED                     │
+│  1st: ●●●●○           [Cure Wounds] [Bless] [Shield of Faith]  │
+│  2nd: ●●●○○           [Aid] [Lesser Restoration]               │
+│  3rd: ●●○○○           [Revivify] [Spirit Guardians]            │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+### Key Components
+- **Ability Score Boxes**: Score + modifier, clickable for rolls
+- **HP Bar**: Visual with current/max, temp HP field
+- **Saving Throws**: Checkboxes for proficiency
+- **Skills**: Proficiency indicators, calculated modifiers
+- **Spell Slots**: Fillable circles, track used/available
+
+---
+
+## Pathfinder 2e
+
+### Character Sheet Layout
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  CHARACTER NAME                              Level X [Class]    │
+│  Ancestry | Heritage | Background                               │
+├─────────────────────────────────────────────────────────────────┤
+│  ┌─────────────────────────┐  ┌─────────────────────────────┐  │
+│  │  ABILITY SCORES         │  │  DEFENSES                   │  │
+│  │  STR: 18 (+4)           │  │                             │  │
+│  │  DEX: 14 (+2)           │  │  AC: 22 (10+2+4+6)          │  │
+│  │  CON: 16 (+3)           │  │     [T] [E] [M] [L]         │  │
+│  │  INT: 10 (+0)           │  │                             │  │
+│  │  WIS: 12 (+1)           │  │  Fortitude: +12 [E]         │  │
+│  │  CHA: 8  (-1)           │  │  Reflex:    +8  [T]         │  │
+│  └─────────────────────────┘  │  Will:      +10 [E]         │  │
+│                               │                             │  │
+│  ┌─────────────────────────┐  │  Speed: 25 ft               │  │
+│  │  PERCEPTION             │  │  Perception: +10 [E]        │  │
+│  │  +10 [Expert]           │  └─────────────────────────────┘  │
+│  │  DC: 20                 │                                   │
+│  └─────────────────────────┘  ┌─────────────────────────────┐  │
+│                               │  HIT POINTS                 │  │
+│  ┌─────────────────────────┐  │  [78] / [78]                │  │
+│  │  CLASS DC               │  │  ████████████████████       │  │
+│  │  21 [Expert]            │  │  Dying: ○○○○                │  │
+│  └─────────────────────────┘  │  Wounded: 0                 │  │
+│                               │  Doomed: 0                  │  │
+│                               └─────────────────────────────┘  │
+├─────────────────────────────────────────────────────────────────┤
+│  PROFICIENCY LEGEND: [U]ntrained [T]rained [E]xpert [M]aster [L]egendary │
+├─────────────────────────────────────────────────────────────────┤
+│  SKILLS (Proficiency + Level + Ability Mod)                     │
+│  ┌────────────────────┬─────┬────────┬─────────────────────┐   │
+│  │ Acrobatics (DEX)   │ [T] │ +10    │ 2 + 5 + 2 + 1 item  │   │
+│  │ Arcana (INT)       │ [U] │ +0     │ 0 + 0 + 0           │   │
+│  │ Athletics (STR)    │ [E] │ +15    │ 4 + 5 + 4 + 2 item  │   │
+│  │ Crafting (INT)     │ [T] │ +7     │ 2 + 5 + 0           │   │
+│  │ Deception (CHA)    │ [U] │ -1     │ 0 + 0 - 1           │   │
+│  └────────────────────┴─────┴────────┴─────────────────────┘   │
+├─────────────────────────────────────────────────────────────────┤
+│  ACTIONS (3 per turn)  ◆ ◆ ◆                                   │
+│  ┌──────────────────────────────────────────────────────────┐  │
+│  │  STRIKES                                                  │  │
+│  │  ┌────────────┬───────┬───────┬─────────────┬─────────┐  │  │
+│  │  │ Weapon     │ Prof  │ Atk   │ Damage      │ Traits  │  │  │
+│  │  ├────────────┼───────┼───────┼─────────────┼─────────┤  │  │
+│  │  │ Longsword  │ [M]   │ +17   │ 2d8+4 S     │ Versatile│  │  │
+│  │  │ -1st: +17  -2nd: +12  -3rd: +7 (MAP)                 │  │  │
+│  │  └────────────┴───────┴───────┴─────────────┴─────────┘  │  │
+│  └──────────────────────────────────────────────────────────┘  │
+├─────────────────────────────────────────────────────────────────┤
+│  HERO POINTS: ●●○                                               │
+├─────────────────────────────────────────────────────────────────┤
+│  CONDITIONS                                                      │
+│  ┌──────────┬───┐  ┌──────────┬───┐  ┌──────────┬───┐         │
+│  │Frightened│ 2 │  │Clumsy    │ 0 │  │Drained   │ 0 │         │
+│  └──────────┴───┘  └──────────┴───┘  └──────────┴───┘         │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+### Key Components
+- **Proficiency Badges**: [U] [T] [E] [M] [L] visual indicators
+- **Four Degrees Display**: Roll results show Critical/Success/Failure/Critical Failure
+- **Three Actions**: Visual action economy tracker
+- **MAP Display**: Multiple Attack Penalty calculator
+- **Conditions with Values**: Numeric severity for each condition
+- **Hero Points**: Visual tracker (max 3)
+
+---
+
+## Call of Cthulhu 7e
+
+### Character Sheet Layout
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  INVESTIGATOR NAME                              Occupation       │
+│  Age: __  Birthplace: __________  Residence: __________         │
+├─────────────────────────────────────────────────────────────────┤
+│  CHARACTERISTICS                                                 │
+│  ┌─────────────────────────────────────────────────────────┐   │
+│  │   STR     CON     SIZ     DEX     APP     INT     POW     EDU│
+│  │   [55]    [60]    [65]    [50]    [45]    [70]    [55]   [80]│
+│  │    27      30      32      25      22      35      27     40 │
+│  │    11      12      13      10       9      14      11     16 │
+│  │   (Half)  (Half)  (Half)  (Half)  (Half)  (Half)  (Half) (1/5)│
+│  └─────────────────────────────────────────────────────────┘   │
+├─────────────────────────────────────────────────────────────────┤
+│  DERIVED ATTRIBUTES                                              │
+│  ┌───────────────────────────────────────────────────────────┐ │
+│  │  HP: [12] / [12]        Sanity: [55] / [99]               │ │
+│  │  ████████████████       SAN: ████████████░░░░░░░░░░░░░░   │ │
+│  │                         Max SAN: 99 - Mythos (0) = 99     │ │
+│  │  Magic Points: [11]     Luck: [55]                        │ │
+│  │  ███████████░░░         ███████████░░░░░░░░░              │ │
+│  │                                                           │ │
+│  │  Damage Bonus: None     Build: 0     Move: 8              │ │
+│  └───────────────────────────────────────────────────────────┘ │
+├─────────────────────────────────────────────────────────────────┤
+│  SKILLS                    Regular | Hard  | Extreme           │
+│  ┌──────────────────────────────────────────────────────────┐  │
+│  │  ○ Accounting           05%      02%     01%             │  │
+│  │  ○ Anthropology         01%      00%     00%             │  │
+│  │  ● Art/Craft (Photo)    45%      22%     09%             │  │
+│  │  ○ Climb                20%      10%     04%             │  │
+│  │  ● Credit Rating        35%      17%     07%             │  │
+│  │  ○ Cthulhu Mythos       00%      --      --    [LOCKED]  │  │
+│  │  ● Dodge                30%      15%     06%             │  │
+│  │  ● Fast Talk            55%      27%     11%   ☑ CHECK   │  │
+│  │  ● Library Use          65%      32%     13%             │  │
+│  │  ● Listen               45%      22%     09%             │  │
+│  │  ...                                                      │  │
+│  └──────────────────────────────────────────────────────────┘  │
+│  ● = Occupation skill   ☑ = Marked for improvement             │
+├─────────────────────────────────────────────────────────────────┤
+│  COMBAT                                                         │
+│  ┌─────────────────────────────────────────────────────────┐   │
+│  │  Weapon          Skill   Damage     Range    Attacks      │   │
+│  │  .38 Revolver    35%     1d10       15 yds   1            │   │
+│  │  Fist/Punch      50%     1d3+DB     Touch    1            │   │
+│  └─────────────────────────────────────────────────────────┘   │
+├─────────────────────────────────────────────────────────────────┤
+│  SANITY CHECK RESULT                                            │
+│  ┌─────────────────────────────────────────────────────────┐   │
+│  │  Roll: [__]  vs Sanity: [55]                             │   │
+│  │  ○ Success (lose min)  ○ Failure (lose max)              │   │
+│  │  Bout of Madness: ○ Yes ○ No  (lost 5+ in one incident)  │   │
+│  └─────────────────────────────────────────────────────────┘   │
+├─────────────────────────────────────────────────────────────────┤
+│  BACKSTORY                                                       │
+│  Ideology: _________________________________________________    │
+│  Significant People: ________________________________________    │
+│  Meaningful Locations: ______________________________________    │
+│  Treasured Possessions: _____________________________________    │
+│  Phobias & Manias: __________________________________________    │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+### Key Components
+- **Percentile Display**: Each stat shows Full / Half / Fifth values
+- **Sanity Meter**: Visual with max SAN affected by Mythos
+- **Skill Improvement Checks**: Checkboxes for session-end rolls
+- **Luck Track**: Spendable and depletable
+- **Sanity Check Dialog**: Quick reference for SAN rolls
+- **Cthulhu Mythos**: Special locked skill that reduces max SAN
+
+---
+
+## FATE Core
+
+### Character Sheet Layout
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  CHARACTER NAME                                                  │
+├─────────────────────────────────────────────────────────────────┤
+│  ASPECTS                                                         │
+│  ┌─────────────────────────────────────────────────────────┐   │
+│  │  High Concept: "Wizard Private Investigator"             │   │
+│  │  ┌──────┐                                                │   │
+│  │  │INVOKE│  +2 or Reroll when investigating magic        │   │
+│  │  └──────┘                                                │   │
+│  ├─────────────────────────────────────────────────────────┤   │
+│  │  Trouble: "Owes Favors to the Faerie Court"              │   │
+│  │  ┌───────┐                                               │   │
+│  │  │COMPEL │  The Fae call in a favor at bad time         │   │
+│  │  └───────┘                                               │   │
+│  ├─────────────────────────────────────────────────────────┤   │
+│  │  Aspect: "My Partner Has My Back"                        │   │
+│  │  Aspect: "Books Contain All Answers"                     │   │
+│  │  Aspect: "Former Police Detective"                       │   │
+│  └─────────────────────────────────────────────────────────┘   │
+├─────────────────────────────────────────────────────────────────┤
+│  SKILLS (Pyramid)                                                │
+│  ┌─────────────────────────────────────────────────────────┐   │
+│  │  +4 Great      [Investigate]                             │   │
+│  │  +3 Good       [Lore] [Will]                             │   │
+│  │  +2 Fair       [Contacts] [Notice] [Rapport]             │   │
+│  │  +1 Average    [Athletics] [Empathy] [Shoot] [Stealth]   │   │
+│  │  +0 Mediocre   [All Others]                              │   │
+│  └─────────────────────────────────────────────────────────┘   │
+├─────────────────────────────────────────────────────────────────┤
+│  FATE POINTS                              REFRESH: 3             │
+│  ┌─────────────────────────────────────────────────────────┐   │
+│  │  Current: ●●●○○                                          │   │
+│  │  [Spend]  [Gain]                                         │   │
+│  └─────────────────────────────────────────────────────────┘   │
+├─────────────────────────────────────────────────────────────────┤
+│  STUNTS                                                          │
+│  ┌─────────────────────────────────────────────────────────┐   │
+│  │  1. "The Truth Is Out There"                             │   │
+│  │     +2 to Investigate when searching for occult clues    │   │
+│  │                                                          │   │
+│  │  2. "Scholarly Network"                                  │   │
+│  │     Use Lore instead of Contacts for academic circles    │   │
+│  │                                                          │   │
+│  │  3. "Wards and Protections"                              │   │
+│  │     Once per session, ignore supernatural attack         │   │
+│  └─────────────────────────────────────────────────────────┘   │
+├─────────────────────────────────────────────────────────────────┤
+│  STRESS                                                          │
+│  ┌─────────────────────────────────────────────────────────┐   │
+│  │  Physical: □ □ □ □    (4 boxes from Physique +2)        │   │
+│  │  Mental:   □ □ □      (3 boxes from Will +3)            │   │
+│  └─────────────────────────────────────────────────────────┘   │
+├─────────────────────────────────────────────────────────────────┤
+│  CONSEQUENCES                                                    │
+│  ┌─────────────────────────────────────────────────────────┐   │
+│  │  Mild (-2):     [____________________________]          │   │
+│  │  Moderate (-4): [____________________________]          │   │
+│  │  Severe (-6):   [____________________________]          │   │
+│  │                                                          │   │
+│  │  Each consequence is an aspect that can be invoked!      │   │
+│  └─────────────────────────────────────────────────────────┘   │
+├─────────────────────────────────────────────────────────────────┤
+│  SITUATION ASPECTS (Scene)                                       │
+│  ┌─────────────────────────────────────────────────────────┐   │
+│  │  "Dark Alley" [●●] free invokes                          │   │
+│  │  "On Fire" [●] free invoke                               │   │
+│  └─────────────────────────────────────────────────────────┘   │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+### Key Components
+- **Aspect Cards**: Draggable cards with Invoke/Compel buttons
+- **Skill Pyramid**: Visual pyramid showing skill distribution
+- **Fate Point Tracker**: Spend/Gain buttons with refresh display
+- **Stress Checkboxes**: Click to mark/unmark
+- **Consequence Slots**: Text fields that become aspects
+- **Situation Aspects Panel**: Scene-specific aspects with free invokes
+
+---
+
+## Blades in the Dark
+
+### Character Sheet Layout
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  CHARACTER NAME                    Playbook: LURK               │
+│  Alias: ____________              Crew: THE SHADOWS              │
+├─────────────────────────────────────────────────────────────────┤
+│  ACTIONS                                                         │
+│  ┌─────────────────────────────────────────────────────────┐   │
+│  │  INSIGHT [3]           PROWESS [4]        RESOLVE [2]    │   │
+│  │  ─────────────         ─────────────      ─────────────  │   │
+│  │  Hunt    ●○○○          Finesse  ●●○○      Attune  ●○○○   │   │
+│  │  Study   ●○○○          Prowl    ●●●○      Command ○○○○   │   │
+│  │  Survey  ●○○○          Skirmish ●○○○      Consort ●○○○   │   │
+│  │  Tinker  ○○○○          Wreck    ○○○○      Sway    ○○○○   │   │
+│  └─────────────────────────────────────────────────────────┘   │
+├─────────────────────────────────────────────────────────────────┤
+│  STRESS          ○○○○○○○○○                   TRAUMA  ○○○○       │
+│                  [_________|]                 Conditions:       │
+│                  Current: 3/9                 ○ Cold  ○ Haunted │
+│                                               ○ Obsessed ○ etc │
+├─────────────────────────────────────────────────────────────────┤
+│  HARM                                                            │
+│  ┌─────────────────────────────────────────────────────────┐   │
+│  │  3 [SEVERE]     [________________________]               │   │
+│  │  2 [MODERATE]   [____________] [____________]            │   │
+│  │  1 [LESSER]     [____________] [____________]            │   │
+│  │                                                          │   │
+│  │  Healing Clock: ○○○○○○                                   │   │
+│  └─────────────────────────────────────────────────────────┘   │
+├─────────────────────────────────────────────────────────────────┤
+│  ARMOR  □ □  Standard        LOAD: [Normal - 5]                 │
+│         □    Heavy           Items: ●●●○○                       │
+│         □    Special (vs supernatural)                          │
+├─────────────────────────────────────────────────────────────────┤
+│  SPECIAL ABILITIES                                               │
+│  ┌─────────────────────────────────────────────────────────┐   │
+│  │  ● INFILTRATOR                                           │   │
+│  │    You are not affected by quality/tier when sneaking    │   │
+│  │                                                          │   │
+│  │  ● SHADOW                                                │   │
+│  │    You blend in anywhere you can see a shadow            │   │
+│  │                                                          │   │
+│  │  ○ [Available ability slot]                              │   │
+│  └─────────────────────────────────────────────────────────┘   │
+├─────────────────────────────────────────────────────────────────┤
+│  ACTION ROLL                                                     │
+│  ┌─────────────────────────────────────────────────────────┐   │
+│  │  Position: [Controlled] [Risky] [Desperate]              │   │
+│  │  Effect:   [Zero] [Limited] [Standard] [Great]           │   │
+│  │                                                          │   │
+│  │  Dice Pool: 3d6                                          │   │
+│  │  [+1d Push] [+1d Devil's Bargain] [+1d Assist]           │   │
+│  │                                                          │   │
+│  │  Results: [4] [6] [2]  →  SUCCESS                        │   │
+│  └─────────────────────────────────────────────────────────┘   │
+├─────────────────────────────────────────────────────────────────┤
+│  CLOCKS                                                          │
+│  ┌─────────────────────────────────────────────────────────┐   │
+│  │   "Pick Lock"        "Guards Coming"      "Project X"    │   │
+│  │      ◐                   ◑                    ◔          │   │
+│  │     3/6                 2/4                  1/8         │   │
+│  └─────────────────────────────────────────────────────────┘   │
+├─────────────────────────────────────────────────────────────────┤
+│  FLASHBACK                                                       │
+│  ┌─────────────────────────────────────────────────────────┐   │
+│  │  [Trigger Flashback]                                     │   │
+│  │  Stress Cost: ○ Simple (0)  ○ Complex (1)  ○ Elaborate (2)│   │
+│  └─────────────────────────────────────────────────────────┘   │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+### Key Components
+- **Action Dots**: Visual representation of 0-4 rating
+- **Attribute Totals**: Auto-calculated from action sums
+- **Stress Bar**: Visual track with trauma threshold
+- **Harm Boxes**: Text fields at each severity level
+- **Position/Effect Selector**: Radio buttons for roll context
+- **Load Tracker**: Dynamic item declaration during play
+- **Clock Widgets**: Visual pie-chart progress trackers
+- **Flashback Button**: Quick access with stress cost selector
+
+---
+
+## Powered by the Apocalypse
+
+### Character Sheet Layout
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  CHARACTER NAME                    Playbook: THE BATTLEBABE     │
+│  Look: ambiguous, scrounged wear, scarred face                  │
+├─────────────────────────────────────────────────────────────────┤
+│  STATS                                                           │
+│  ┌─────────────────────────────────────────────────────────┐   │
+│  │    COOL      HARD      HOT       SHARP     WEIRD        │   │
+│  │    +3        +1        +1        +1        -1           │   │
+│  │   ┌───┐     ┌───┐     ┌───┐     ┌───┐     ┌───┐        │   │
+│  │   │ ● │     │ ● │     │ ● │     │ ● │     │ ○ │        │   │
+│  │   │ ● │     │ ● │     │ ● │     │ ● │     │ ○ │        │   │
+│  │   │ ● │     │ ○ │     │ ○ │     │ ○ │     │ ○ │        │   │
+│  │   │ ○ │     │ ○ │     │ ○ │     │ ○ │     │ ● │        │   │
+│  │   └───┘     └───┘     └───┘     └───┘     └───┘        │   │
+│  │ Highlighted: COOL, WEIRD                                 │   │
+│  └─────────────────────────────────────────────────────────┘   │
+├─────────────────────────────────────────────────────────────────┤
+│  HARM                                                            │
+│  ┌─────────────────────────────────────────────────────────┐   │
+│  │   □ □ □ □ □ □   Countdown      ○ Stabilized             │   │
+│  │   3 6 9 9 1 1   to midnight    ○ Shattered (-1 hard)    │   │
+│  │                 2                                        │   │
+│  └─────────────────────────────────────────────────────────┘   │
+├─────────────────────────────────────────────────────────────────┤
+│  MOVES                                                           │
+│  ┌─────────────────────────────────────────────────────────┐   │
+│  │  BASIC MOVES                                             │   │
+│  │  ┌───────────────────────────────────────────────────┐  │   │
+│  │  │ ACT UNDER FIRE                          [+Cool]   │  │   │
+│  │  │ When you do something under fire, roll+cool.      │  │   │
+│  │  │ • 10+: You do it                                  │  │   │
+│  │  │ • 7-9: You stumble, hesitate, or flinch           │  │   │
+│  │  │ [ROLL]                                            │  │   │
+│  │  └───────────────────────────────────────────────────┘  │   │
+│  │  ┌───────────────────────────────────────────────────┐  │   │
+│  │  │ GO AGGRO                                [+Hard]   │  │   │
+│  │  │ When you go aggro on someone, roll+hard...        │  │   │
+│  │  │ [ROLL]                                            │  │   │
+│  │  └───────────────────────────────────────────────────┘  │   │
+│  │                                                          │   │
+│  │  PLAYBOOK MOVES                                          │   │
+│  │  ┌───────────────────────────────────────────────────┐  │   │
+│  │  │ ● DANGEROUS & SEXY                      [+Hot]    │  │   │
+│  │  │   When you enter a charged situation...           │  │   │
+│  │  │ [ROLL]                                            │  │   │
+│  │  └───────────────────────────────────────────────────┘  │   │
+│  │  ┌───────────────────────────────────────────────────┐  │   │
+│  │  │ ● ICE COLD                              [+Cool]   │  │   │
+│  │  │   When you act under fire, on 10+ you can...      │  │   │
+│  │  └───────────────────────────────────────────────────┘  │   │
+│  └─────────────────────────────────────────────────────────┘   │
+├─────────────────────────────────────────────────────────────────┤
+│  HOLD                                                            │
+│  ┌─────────────────────────────────────────────────────────┐   │
+│  │  Read a Person: ●●○  (2 hold remaining)                  │   │
+│  │  Seduce/Manipulate: ●○○ (1 hold remaining)               │   │
+│  └─────────────────────────────────────────────────────────┘   │
+├─────────────────────────────────────────────────────────────────┤
+│  MODIFIERS                                                       │
+│  ┌─────────────────────────────────────────────────────────┐   │
+│  │  Forward: +1 (from Read a Person)                        │   │
+│  │  Ongoing: +1 (while in my territory)                     │   │
+│  └─────────────────────────────────────────────────────────┘   │
+├─────────────────────────────────────────────────────────────────┤
+│  EXPERIENCE                     ○○○○○ → [ADVANCE]              │
+│                                 (3/5)                           │
+├─────────────────────────────────────────────────────────────────┤
+│  HX (History with other PCs)                                     │
+│  ┌─────────────────────────────────────────────────────────┐   │
+│  │  Rico the Gunlugger:   +2                                │   │
+│  │  Frost the Skinner:    +1                                │   │
+│  │  Doc the Angel:        -1                                │   │
+│  └─────────────────────────────────────────────────────────┘   │
+├─────────────────────────────────────────────────────────────────┤
+│  GEAR                                                            │
+│  ┌─────────────────────────────────────────────────────────┐   │
+│  │  • Custom firearms (2-harm close reload loud)            │   │
+│  │  • Leather wear (1-armor)                                │   │
+│  │  • Oddments worth 2-barter                               │   │
+│  └─────────────────────────────────────────────────────────┘   │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+### Key Components
+- **Stat Display**: Visual (-2 to +3) with highlighting
+- **Move Cards**: Expandable cards with trigger text and roll button
+- **Three-Tier Results**: Clear 6-/7-9/10+ outcome display
+- **Hold Tracker**: Per-move hold counters
+- **Forward/Ongoing Panel**: Active modifiers
+- **XP Track**: 5-segment advancement tracker
+- **History (Hx)**: Relationship values with other PCs
+- **Highlighted Stats**: Mark for session XP
+
+---
+
+## Cross-System Components
+
+### Universal Roll Dialog
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  ROLL: [Action/Skill Name]                                      │
+├─────────────────────────────────────────────────────────────────┤
+│  System: [Auto-detected from character]                         │
+│                                                                 │
+│  Base:     +5 (Skill modifier)                                  │
+│  Bonuses:  +2 (Aspect invoke)                                   │
+│  Penalties: -1 (Wounded)                                        │
+│  ─────────────────                                              │
+│  Total:    +6                                                   │
+│                                                                 │
+│  [Roll Dice]                                                    │
+│                                                                 │
+│  Result: 14                                                     │
+│  Outcome: SUCCESS                                               │
+│                                                                 │
+│  [Apply Result] [Cancel]                                        │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+### System Indicator Badge
+Each character sheet should have a clear system indicator:
+```
+┌───────────────────┐
+│ D&D 5e           │  ← Blue badge
+│ PF2e             │  ← Red badge
+│ CoC 7e           │  ← Green badge
+│ FATE Core        │  ← Orange badge
+│ Blades           │  ← Purple badge
+│ PbtA             │  ← Yellow badge
+└───────────────────┘
+```
+
+---
+
+## Implementation Notes
+
+### Component Library Requirements
+1. **Checkbox/Pip Components**: For proficiency, stress, XP
+2. **Progress Bars**: For HP, SAN, stress tracks
+3. **Clock Widgets**: For Blades progress clocks
+4. **Card Components**: For aspects, moves, features
+5. **Dice Display**: Animated roll results
+6. **Modal Dialogs**: For rolls, invocations, flashbacks
+7. **Drag-and-Drop**: For rearranging aspects, inventory
+8. **Collapsible Sections**: For large character sheets
+
+### Accessibility
+- High contrast modes for all systems
+- Screen reader support for all components
+- Keyboard navigation for all interactive elements
+- Color-blind friendly indicators (icons + colors)
+
+### Responsive Design
+- Desktop: Full sheet layout
+- Tablet: Collapsible sections
+- Mobile: Tab-based navigation between sections

--- a/docs/game-systems/blades.md
+++ b/docs/game-systems/blades.md
@@ -1,0 +1,501 @@
+# Blades in the Dark System Reference
+
+## Overview
+
+Blades in the Dark is a heist-focused RPG using a d6 dice pool system with position/effect mechanics. Set in a haunted industrial city, it emphasizes flashbacks, crew dynamics, and fiction-first play. Characters are scoundrels pulling dangerous scores.
+
+## Core Mechanics
+
+### Dice System
+- **Primary Roll**: Dice pool of d6s (based on action rating)
+- **Take Highest**: Roll pool, keep single highest die
+- **No Modifiers**: Position/Effect change outcomes, not dice
+
+### Zero Dice Rule
+If you have 0 dice in your pool:
+- Roll 2d6 and take the **lowest** result
+
+### Result Interpretation
+| Highest Die | Outcome |
+|-------------|---------|
+| 1-3 | **Failure** - Things go badly, face full consequence |
+| 4-5 | **Partial Success** - You do it, but there's a complication |
+| 6 | **Full Success** - You achieve your goal cleanly |
+| Multiple 6s | **Critical** - Success with increased effect |
+
+```rust
+fn resolve_blades_roll(dice_results: &[u8]) -> BladesOutcome {
+    let highest = *dice_results.iter().max().unwrap_or(&0);
+    let sixes = dice_results.iter().filter(|&&d| d == 6).count();
+
+    if sixes >= 2 {
+        BladesOutcome::Critical
+    } else if highest == 6 {
+        BladesOutcome::Success
+    } else if highest >= 4 {
+        BladesOutcome::PartialSuccess
+    } else {
+        BladesOutcome::Failure
+    }
+}
+```
+
+### Position (Risk Level)
+Determines consequence severity:
+
+| Position | Description | Typical Consequences |
+|----------|-------------|---------------------|
+| **Controlled** | You act on your terms | Minor: reduced effect, complication, worse position |
+| **Risky** | Standard danger | Moderate: harm, serious complication, worse position |
+| **Desperate** | Serious trouble | Severe: severe harm, lost opportunity, major complication |
+
+### Effect Level (Impact)
+Determines success magnitude:
+
+| Effect | Clock Ticks | Description |
+|--------|-------------|-------------|
+| Zero | 0 | No meaningful progress |
+| Limited | 1 | Partial/weak effect |
+| Standard | 2 | Normal expected outcome |
+| Great | 3 | More than usual |
+| Extreme | 4 | Extraordinary (from critical) |
+
+## Character Attributes
+
+### Three Attributes
+Characters have 12 actions grouped into 3 attributes:
+
+**Insight** (Mental/Perceptive):
+| Action | Description |
+|--------|-------------|
+| Hunt | Track, chase, notice details |
+| Study | Scrutinize, research, interpret |
+| Survey | Observe, anticipate, case |
+| Tinker | Fiddle, create, repair, disable |
+
+**Prowess** (Physical/Athletic):
+| Action | Description |
+|--------|-------------|
+| Finesse | Dexterity, misdirection, precision |
+| Prowl | Stealth, climbing, quiet movement |
+| Skirmish | Close combat, melee fighting |
+| Wreck | Smash, demolish, brute force |
+
+**Resolve** (Social/Supernatural):
+| Action | Description |
+|--------|-------------|
+| Attune | Supernatural, spirits, arcane |
+| Command | Order, intimidate, lead |
+| Consort | Socialize, network, blend in |
+| Sway | Persuade, deceive, charm |
+
+### Action Ratings (0-4)
+| Rating | Dice Rolled |
+|--------|-------------|
+| 0 | Roll 2d6, take lowest |
+| 1 | 1d6 |
+| 2 | 2d6 |
+| 3 | 3d6 |
+| 4 | 4d6 (maximum) |
+
+### Attribute Ratings (for Resistance)
+Sum of action dots in that attribute:
+```rust
+fn insight_rating(char: &Character) -> u8 {
+    char.hunt + char.study + char.survey + char.tinker
+}
+
+fn prowess_rating(char: &Character) -> u8 {
+    char.finesse + char.prowl + char.skirmish + char.wreck
+}
+
+fn resolve_rating(char: &Character) -> u8 {
+    char.attune + char.command + char.consort + char.sway
+}
+```
+
+## Playbooks (Character Types)
+
+### Seven Core Playbooks
+| Playbook | Role | Starting Action | XP Trigger |
+|----------|------|-----------------|------------|
+| **Cutter** | Fighter | Skirmish 2 | Violence or coercion |
+| **Hound** | Sharpshooter | Hunt 2 | Tracking or violence |
+| **Leech** | Technician | Wreck 2 | Technical skill or mayhem |
+| **Lurk** | Infiltrator | Prowl 2 | Stealth or evasion |
+| **Slide** | Manipulator | Sway 2 | Deception or influence |
+| **Spider** | Mastermind | Study 2 | Calculation or conspiracy |
+| **Whisper** | Channeler | Attune 2 | Knowledge or arcane power |
+
+### Special Abilities
+- Each playbook has **8 unique abilities**
+- Start with **1 ability**
+- Gain more via XP advancement
+- Can take from other playbooks at +1 XP cost
+
+## Stress and Trauma
+
+### Stress Track (0-9)
+**Gaining Stress**:
+| Action | Stress Cost |
+|--------|-------------|
+| Push Yourself | 2 stress (+1d or +1 effect) |
+| Assist Another | 1 stress |
+| Protect Teammate | Consequence + 1 stress |
+| Resistance Roll | 6 - successes (minimum 0) |
+
+### Resistance Rolls
+When facing a consequence:
+1. Choose relevant attribute (Insight, Prowess, Resolve)
+2. Roll dice = attribute rating
+3. Count 6s rolled
+4. Stress cost = 6 - (number of 6s)
+5. Consequence is reduced/avoided
+
+```rust
+fn resistance_roll(attribute_rating: u8, dice_results: &[u8]) -> ResistanceResult {
+    let sixes = dice_results.iter().filter(|&&d| d == 6).count();
+    let stress_cost = (6 - sixes as i32).max(0) as u8;
+
+    ResistanceResult {
+        stress_cost,
+        consequence_reduced: true,
+    }
+}
+```
+
+### Trauma
+**When Triggered**: Stress reaches 9, then increases
+- Reset stress to 0
+- Mark one trauma condition
+
+**Trauma Conditions**:
+- **Cold**: Unmoved by emotion
+- **Haunted**: Lost in past
+- **Obsessed**: Single focus
+- **Paranoid**: Trust no one
+- **Reckless**: Disregard safety
+- **Soft**: Lost your edge
+- **Unstable**: Volatile emotions
+- **Vicious**: Seeks to hurt
+
+**At 4 Trauma**: Character retires
+
+## Harm System
+
+### Harm Levels
+| Level | Slots | Effect | Examples |
+|-------|-------|--------|----------|
+| 1 (Lesser) | 2 | Narrative only | Battered, Drained |
+| 2 (Moderate) | 2 | -1d to related actions | Exhausted, Deep Cut |
+| 3 (Severe) | 1 | -1d (stacks) | Broken Leg, Shot |
+| 4 (Fatal) | 1 | Dying/Dead | Needs immediate help |
+
+### Overflow
+If a harm level is full, next harm "rolls up":
+- Level 1 full → becomes Level 2
+- Level 2 full → becomes Level 3
+- Level 3 full → becomes Level 4 (fatal)
+
+### Armor
+- Standard Armor: Reduce harm by 1 level (mark armor box)
+- Heavy Armor: Reduce harm by 2 levels (mark 2 boxes)
+- Special Armor: From abilities, vs specific threats
+
+### Recovery
+| Harm Level | Natural Healing |
+|------------|-----------------|
+| Level 1 | 1-2 days |
+| Level 2 | 1 week |
+| Level 3 | 1 month (with care) |
+| Level 4 | Immediate treatment or death |
+
+## Load System
+
+### Load Levels
+| Level | Items | Penalty |
+|-------|-------|---------|
+| Light | 3 | None |
+| Normal | 5 | None |
+| Heavy | 6 | -1d to Prowess actions |
+
+### Key Rule: Declare Items During Play
+You don't pre-select specific items:
+1. Choose load level before score
+2. During score, declare "I have a..." when needed
+3. Mark load equal to item cost
+4. Cannot exceed chosen load level
+
+```rust
+pub struct CharacterLoad {
+    load_level: LoadLevel,
+    items_declared: Vec<LoadItem>,
+    current_load: u8,
+}
+
+impl CharacterLoad {
+    pub fn declare_item(&mut self, item: LoadItem) -> Result<()> {
+        let new_total = self.current_load + item.cost;
+        if new_total > self.load_level.max() {
+            return Err(Error::ExceedsLoadLevel);
+        }
+        self.items_declared.push(item);
+        self.current_load = new_total;
+        Ok(())
+    }
+}
+```
+
+### Common Items
+| Item | Load |
+|------|------|
+| Blade, Pistol | 1 |
+| Large Weapon | 2 |
+| Armor | 1 |
+| Heavy Armor | 3 |
+| Burglary Gear | 1 |
+| Climbing Gear | 2 |
+| Arcane Implements | 1 |
+| Demolitions | 2 |
+
+## Crew Mechanics
+
+### Crew Types
+| Type | Focus | Hunting Grounds |
+|------|-------|-----------------|
+| **Assassins** | Murder for hire | Killings |
+| **Bravos** | Thugs | Extortion, sabotage |
+| **Cult** | Occultists | Occult operations |
+| **Hawkers** | Dealers | Product sales |
+| **Shadows** | Thieves | Burglary, espionage |
+| **Smugglers** | Transporters | Smuggling routes |
+
+### Crew Stats
+- **Reputation** (0-12): Power/influence tier
+- **Heat** (0-9): Attention from authorities
+- **Wanted Level** (0-4): How hunted you are
+- **Coin**: Shared treasury
+- **Turf**: Controlled territory (+2 coin per score each)
+- **Claims**: Special locations with benefits
+
+### Heat and Wanted
+**Gaining Heat** (after each score):
+| Situation | Heat |
+|-----------|------|
+| Smooth & quiet | 0 |
+| Contained incident | 2 |
+| Loud & messy | 4 |
+| Spectacular disaster | 6 |
+
+**When Heat fills (9→10)**:
+- Roll to potentially raise Wanted Level
+- Clear heat track
+
+**At Wanted Level 4**: Hunted by special forces
+
+### Entanglements
+After each score, roll for entanglement based on wanted level:
+- Gang Trouble, Rivals, Unquiet Dead
+- Bluecoat Raids, Interrogations
+- Opportunities mixed with complications
+
+## Unique Mechanics
+
+### Flashbacks
+**Purpose**: Avoid lengthy planning, keep action moving
+
+**How It Works**:
+1. During score, declare "Earlier, I prepared for this..."
+2. Pay stress based on complexity:
+   - 0 stress: Simple, obvious prep
+   - 1 stress: Complex or unlikely
+   - 2 stress: Elaborate or improbable
+3. Might require action roll in flashback
+4. Return to present with advantage
+
+**Limits**:
+- Can't contradict established facts
+- Can't undo suffered consequences
+
+### Devil's Bargains
+**Offered by GM during action rolls**:
+- Accept: +1d to roll, complication happens regardless
+- Refuse: No extra die
+
+**Examples**:
+- "+1d, but leave evidence behind"
+- "+1d, but owe dangerous favor"
+- "+1d, but rival crew notices"
+
+### Clocks (Progress Tracking)
+**Progress Clocks**: Circles with 4, 6, or 8 segments
+
+**Uses**:
+- Obstacle Clocks: "Pick the Lock" (6 segments)
+- Project Clocks: "Craft Device" (8 segments)
+- Danger Clocks: "Guards Arrive" (4 segments)
+- Racing Clocks: Competing progress
+
+**Filling Clocks**:
+- Success fills segments = effect level
+- Limited: 1 tick, Standard: 2 ticks, Great: 3 ticks
+- Critical: +1 extra tick
+
+```rust
+pub struct ProgressClock {
+    pub name: String,
+    pub segments: u8,     // 4, 6, or 8
+    pub filled: u8,
+    pub clock_type: ClockType,
+}
+
+pub enum ClockType {
+    Progress,   // Player filling
+    Danger,     // GM filling
+    Racing,     // Both competing
+}
+```
+
+## Downtime
+
+### Downtime Actions (2 per character)
+
+**Acquire Asset**: Get item/resource/information
+- Roll tier or contact quality
+- Each 6 = 1 use of asset
+
+**Long-Term Project**: Progress on extended goal
+- Roll appropriate action
+- Each 6 = 1 tick on project clock
+
+**Recover**: Heal harm
+- Roll Tinker (or friend helps)
+- Each 6 = clear 1 harm level
+
+**Reduce Heat**: Lay low
+- Automatic -2 heat (no roll)
+
+**Train**: Mark XP
+- +1 XP in chosen track
+- Can spend coin for more XP
+
+**Indulge Vice**: Clear stress
+- Roll lowest attribute rating
+- Clear stress = highest die result
+- Risk: Overindulge on 1-3
+
+### Vice and Overindulgence
+**Vice Types**: Luxury, Stupor, Obligation, Pleasure, Gambling, Faith, Weird
+
+**Overindulgence Results** (when highest die is 1-3):
+- Attract unwanted attention
+- Brag about crimes
+- Lost for days
+- Tapped (out of cash)
+
+## Engagement Roll
+
+Before each score:
+1. Crew chooses approach
+2. Detail plan in one sentence
+3. Roll 1d6 + crew tier ± modifiers
+
+| Result | Starting Position |
+|--------|-------------------|
+| Critical | Controlled with opportunity |
+| 6 | Controlled |
+| 4-5 | Risky |
+| 1-3 | Desperate |
+
+## XP and Advancement
+
+### XP Triggers
+**Per Attribute** (when used desperately):
+- 1 XP for Insight, Prowess, or Resolve actions in desperate position
+
+**Playbook XP**:
+- Up to 3 XP per session for playbook-specific trigger
+- Express beliefs, drives, heritage, background
+- Struggle with vice or trauma
+
+### Spending XP
+| Advancement | Cost |
+|-------------|------|
+| New action dot | 1 XP (first), 2 XP (second), etc. |
+| New special ability | Varies (1-8 XP) |
+| Other playbook ability | +1 XP extra |
+
+## Integration Considerations
+
+### StatBlock Mapping
+```rust
+pub struct BladesStatBlock {
+    // 12 Actions (0-4 each)
+    pub hunt: u8,
+    pub study: u8,
+    pub survey: u8,
+    pub tinker: u8,
+    pub finesse: u8,
+    pub prowl: u8,
+    pub skirmish: u8,
+    pub wreck: u8,
+    pub attune: u8,
+    pub command: u8,
+    pub consort: u8,
+    pub sway: u8,
+
+    // Derived attribute ratings
+    pub insight: u8,   // Sum of insight actions
+    pub prowess: u8,   // Sum of prowess actions
+    pub resolve: u8,   // Sum of resolve actions
+
+    // Stress/Trauma
+    pub stress: u8,    // 0-9
+    pub trauma: u8,    // 0-4
+    pub trauma_conditions: Vec<TraumaCondition>,
+
+    // Harm
+    pub harm_1: [Option<String>; 2],
+    pub harm_2: [Option<String>; 2],
+    pub harm_3: Option<String>,
+
+    // Armor
+    pub armor_used: u8,
+    pub armor_max: u8,
+}
+```
+
+### Position/Effect System
+```rust
+pub enum Position {
+    Controlled,
+    Risky,
+    Desperate,
+}
+
+pub enum EffectLevel {
+    Zero,
+    Limited,
+    Standard,
+    Great,
+    Extreme,
+}
+
+pub struct ActionContext {
+    pub position: Position,
+    pub effect: EffectLevel,
+    pub action: String,
+    pub dice_pool: u8,
+}
+```
+
+### Key Differences from D20 Systems
+1. **Dice Pool**: Multiple d6s, take highest (not d20 + modifier)
+2. **No Target Numbers**: Outcomes based on die faces, not DC
+3. **Position/Effect**: Separate from dice pool
+4. **Stress as Resource**: Spend to boost, not just damage
+5. **Flashbacks**: Retroactive preparation during play
+6. **Load Declaration**: Equipment decided during play
+7. **Crew Mechanics**: Shared group character
+8. **Clocks**: Visual progress tracking
+9. **Fiction-First**: Narrative determines mechanics

--- a/docs/game-systems/coc7e.md
+++ b/docs/game-systems/coc7e.md
@@ -1,0 +1,442 @@
+# Call of Cthulhu 7th Edition (CoC 7e) System Reference
+
+## Overview
+
+Call of Cthulhu is a horror investigation RPG using a percentile (d100) roll-under system. Unlike heroic fantasy games, investigators are ordinary people facing cosmic horrors, with fragile sanity and no progression through "leveling up."
+
+## Core Mechanics
+
+### Dice System
+- **Primary Roll**: d100 (percentile dice) roll-under
+- **Roll Formula**: Roll d100, compare to skill value
+- **Lower is better**: Must roll equal to or under skill value
+
+### Success Levels
+Three tiers of success based on skill value:
+
+| Level | Target | Description |
+|-------|--------|-------------|
+| Regular Success | ≤ skill value | Standard success |
+| Hard Success | ≤ skill ÷ 2 | Difficult success |
+| Extreme Success | ≤ skill ÷ 5 | Exceptional success |
+
+**Implementation**:
+```rust
+fn check_success(roll: u8, skill: u8) -> SuccessLevel {
+    let hard = skill / 2;
+    let extreme = skill / 5;
+
+    if roll <= extreme {
+        SuccessLevel::Extreme
+    } else if roll <= hard {
+        SuccessLevel::Hard
+    } else if roll <= skill {
+        SuccessLevel::Regular
+    } else {
+        SuccessLevel::Failure
+    }
+}
+```
+
+### Critical and Fumble
+- **Critical (01)**: Always succeeds, exceptional outcome
+- **Fumble**: 96-100 if skill < 50, or 100 if skill ≥ 50
+
+```rust
+fn is_fumble(roll: u8, skill: u8) -> bool {
+    if skill < 50 {
+        roll >= 96
+    } else {
+        roll == 100
+    }
+}
+
+fn is_critical(roll: u8) -> bool {
+    roll == 1
+}
+```
+
+### Pushed Rolls
+- **One chance** to re-roll a failed check
+- Must describe additional effort/risk
+- If pushed roll fails, **consequences are worse**
+- Cannot push: Combat, Sanity, Luck rolls
+
+## Character Characteristics
+
+### Eight Characteristics
+Unlike D&D's six attributes, CoC has eight:
+
+| Characteristic | Abbreviation | Generation | Description |
+|---------------|--------------|------------|-------------|
+| Strength | STR | 3d6 × 5 | Physical power |
+| Constitution | CON | 3d6 × 5 | Health, vitality |
+| Size | SIZ | (2d6+6) × 5 | Physical bulk |
+| Dexterity | DEX | 3d6 × 5 | Agility, speed |
+| Appearance | APP | 3d6 × 5 | Charisma, looks |
+| Intelligence | INT | (2d6+6) × 5 | Reasoning ability |
+| Power | POW | 3d6 × 5 | Willpower, magical aptitude |
+| Education | EDU | (2d6+6) × 5 | Formal knowledge |
+
+**Typical Range**: 15-90 (average human ~50)
+
+### Derived Attributes
+
+| Attribute | Formula | Description |
+|-----------|---------|-------------|
+| Hit Points | (CON + SIZ) ÷ 10 | Physical health |
+| Sanity | POW | Starting mental stability |
+| Magic Points | POW ÷ 5 | Magical energy |
+| Luck | 3d6 × 5 | Fortune (spendable) |
+| Move Rate | Based on STR, DEX, SIZ | Movement speed |
+
+```rust
+fn calculate_hp(con: u8, siz: u8) -> u8 {
+    (con + siz) / 10
+}
+
+fn calculate_starting_sanity(pow: u8) -> u8 {
+    pow  // Starting Sanity = POW
+}
+
+fn calculate_magic_points(pow: u8) -> u8 {
+    pow / 5
+}
+
+fn calculate_move_rate(str: u8, dex: u8, siz: u8) -> u8 {
+    if dex < siz && str < siz {
+        7
+    } else if str >= siz || dex >= siz {
+        8
+    } else if str > siz && dex > siz {
+        9
+    } else {
+        8
+    }
+}
+```
+
+### Damage Bonus & Build
+
+| STR + SIZ | Damage Bonus | Build |
+|-----------|--------------|-------|
+| 2-64 | -2 | -2 |
+| 65-84 | -1 | -1 |
+| 85-124 | None | 0 |
+| 125-164 | +1d4 | +1 |
+| 165-204 | +1d6 | +2 |
+| 205-284 | +2d6 | +3 |
+| 285-364 | +3d6 | +4 |
+| 365+ | +4d6 | +5 |
+
+## Skills
+
+### Complete Skill List (with Base Values)
+
+**Combat Skills**:
+| Skill | Base % |
+|-------|--------|
+| Dodge | DEX/2 |
+| Fighting (Brawl) | 25% |
+| Fighting (specify) | 01% |
+| Firearms (Handgun) | 20% |
+| Firearms (Rifle/Shotgun) | 25% |
+| Firearms (specify) | 01% |
+| Throw | 20% |
+
+**Investigation Skills**:
+| Skill | Base % |
+|-------|--------|
+| Appraise | 05% |
+| Library Use | 20% |
+| Listen | 20% |
+| Spot Hidden | 25% |
+| Track | 10% |
+
+**Social Skills**:
+| Skill | Base % |
+|-------|--------|
+| Charm | 15% |
+| Fast Talk | 05% |
+| Intimidate | 15% |
+| Persuade | 10% |
+| Psychology | 10% |
+
+**Knowledge Skills**:
+| Skill | Base % |
+|-------|--------|
+| Accounting | 05% |
+| Anthropology | 01% |
+| Archaeology | 01% |
+| Art/Craft (specify) | 05% |
+| Cthulhu Mythos | 00% |
+| History | 05% |
+| Language (Other) | 01% |
+| Language (Own) | EDU |
+| Law | 05% |
+| Medicine | 01% |
+| Natural World | 10% |
+| Navigate | 10% |
+| Occult | 05% |
+| Science (specify) | 01% |
+
+**Practical Skills**:
+| Skill | Base % |
+|-------|--------|
+| Climb | 20% |
+| Drive Auto | 20% |
+| Electrical Repair | 10% |
+| First Aid | 30% |
+| Jump | 20% |
+| Locksmith | 01% |
+| Mechanical Repair | 10% |
+| Operate Heavy Machinery | 01% |
+| Pilot (specify) | 01% |
+| Ride | 05% |
+| Sleight of Hand | 10% |
+| Stealth | 20% |
+| Survival (specify) | 10% |
+| Swim | 20% |
+
+### Occupation Skills
+- Characters choose an **occupation** (e.g., Professor, Private Eye, Doctor)
+- Occupation provides **skill points** = EDU × 4 (or EDU × 2 + other stat × 2)
+- Points distributed among **8 occupation skills**
+
+### Personal Interest Skills
+- **INT × 2** points for any non-occupation skills
+- Represents hobbies and personal knowledge
+
+### Credit Rating
+Special skill representing wealth and social status:
+
+| Credit Rating | Lifestyle | Assets |
+|--------------|-----------|--------|
+| 0 | Penniless | None |
+| 1-9 | Poor | ~$500 |
+| 10-49 | Average | ~$10,000 |
+| 50-89 | Affluent | ~$50,000 |
+| 90-98 | Wealthy | ~$500,000 |
+| 99 | Super Rich | Millions |
+
+## Combat Mechanics
+
+### Combat Flow
+1. **Determine DEX order** (highest acts first)
+2. **Declare actions**
+3. **Resolve attacks** (skill roll vs Dodge/Fighting Back)
+4. **Apply damage**
+
+### Attack Resolution
+- **Attacker rolls** Fighting or Firearms skill
+- **Defender chooses**: Dodge or Fight Back
+- **Compare success levels**: Higher level wins
+- **Ties**: Defender wins (if dodging) or compare skill values
+
+### Damage
+```
+Damage = Weapon Base + Damage Bonus (if melee)
+```
+
+**Common Weapons**:
+| Weapon | Damage | Range | Attacks |
+|--------|--------|-------|---------|
+| Fist/Punch | 1d3 + DB | Touch | 1 |
+| Knife | 1d4 + DB | Touch | 1 |
+| .38 Revolver | 1d10 | 15 yards | 1 |
+| Shotgun | 4d6/2d6/1d6 | 10/20/50 | 1 |
+
+### Major Wound
+If damage ≥ half max HP in one hit:
+- Make a **CON roll** or fall unconscious
+- Roll on major wound table for lasting effects
+
+### Dying
+- At 0 HP: Dying
+- Make CON roll each round or lose 1 HP
+- At negative HP equal to max HP: Dead
+
+## Sanity System
+
+### Starting Sanity
+- **Initial**: Equal to POW
+- **Maximum**: 99 - Cthulhu Mythos skill
+
+### Sanity Rolls
+When facing horror, roll d100:
+- **Success** (≤ Sanity): Lose minimum Sanity
+- **Failure** (> Sanity): Lose maximum Sanity
+
+Example: "0/1d6" means lose 0 on success, 1d6 on failure
+
+### Common Sanity Losses
+
+| Encounter | Loss (Pass/Fail) |
+|-----------|-----------------|
+| Dead body | 0/1d3 |
+| Grisly murder scene | 0/1d4 |
+| Zombie | 0/1d8 |
+| Deep One | 0/1d6 |
+| Shoggoth | 1d6/1d20 |
+| Great Old One | 1d10/1d100 |
+
+### Temporary Insanity
+If lose 5+ Sanity in one incident:
+- Roll **INT**: Success = repress, Failure = bout of madness
+- **Bout of Madness**: 1d10 rounds of temporary insanity
+
+### Indefinite Insanity
+If lose 20% of current Sanity in game hour:
+- Develop **underlying insanity** (phobia, mania, etc.)
+- Requires extended treatment to cure
+
+### Cthulhu Mythos
+- **Cannot be reduced** once gained
+- **Reduces maximum Sanity** (Max SAN = 99 - Mythos)
+- Gained from: reading tomes, casting spells, witnessing entities
+
+## Magic System
+
+### Magic Points
+- **Equal to POW ÷ 5**
+- Regenerate 1 MP per hour of rest
+- Fully regenerate after 8 hours sleep
+
+### Spells
+- **Learning**: Requires time, Sanity, sometimes ritual
+- **Casting**: Costs MP, sometimes Sanity, sometimes POW
+- **Opposed**: Attacker's MP vs target's MP on resistance table
+
+### Resistance Table
+When opposing forces clash:
+```
+Base Chance = 50% + (Active - Passive) × 5
+```
+Example: Caster MP 12 vs Target MP 8:
+- Chance = 50% + (12-8) × 5 = 70%
+
+## Character Progression
+
+### No Traditional Leveling
+Characters don't gain XP and level up. Instead:
+
+### Skill Improvement
+During investigation:
+1. GM tells player to **check** a successfully used skill
+2. Between sessions, roll d100 for each checked skill
+3. If roll > current skill: Add 1d10 to skill
+4. If roll ≤ current skill: No improvement
+
+```rust
+fn improve_skill(current: u8) -> u8 {
+    let roll = rand::random::<u8>() % 100 + 1;
+    if roll > current {
+        let gain = rand::random::<u8>() % 10 + 1;
+        (current + gain).min(99)
+    } else {
+        current
+    }
+}
+```
+
+### Characteristic Improvement
+- Rarely improves
+- Sanity can be restored through therapy
+- POW can increase through successful magic resistance
+
+## Unique Features
+
+### Luck Points
+- **Spendable resource**: Spend Luck to modify rolls
+- **1:1 ratio**: Spend 1 Luck to add 1 to roll (or subtract 1)
+- **Reduces permanently** when spent
+- Recovered between sessions (optional rule)
+
+### Backstory Elements
+Character creation includes:
+
+| Element | Purpose |
+|---------|---------|
+| Ideology/Beliefs | Core values and worldview |
+| Significant People | Important relationships |
+| Meaningful Locations | Places of importance |
+| Treasured Possessions | Valued items |
+| Traits | Personality descriptors |
+| Injuries & Scars | Physical marks |
+| Phobias & Manias | Mental conditions |
+
+### Pulp Cthulhu
+Heroic variant with:
+- **Higher HP**: (CON + SIZ) ÷ 5
+- **Talents**: Special abilities
+- **Hero points**: Luck-like mechanic
+- More combat-capable characters
+
+## Integration Considerations
+
+### StatBlock Mapping
+```rust
+pub struct CocStatBlock {
+    // Eight characteristics (percentile values)
+    characteristics: HashMap<String, u8>,  // STR, CON, SIZ, DEX, APP, INT, POW, EDU
+
+    // Skills (percentile values)
+    skills: HashMap<String, u8>,
+
+    // Current values (can change)
+    current_hp: u8,
+    max_hp: u8,
+    current_sanity: u8,
+    max_sanity: u8,
+    current_mp: u8,
+    current_luck: u8,
+
+    // Cthulhu Mythos (special, reduces max sanity)
+    mythos_skill: u8,
+
+    // Backstory elements
+    backstory: CocBackstory,
+
+    // Skill improvement checks
+    checked_skills: HashSet<String>,
+}
+
+pub struct CocBackstory {
+    ideology: String,
+    significant_people: Vec<String>,
+    meaningful_locations: Vec<String>,
+    treasured_possessions: Vec<String>,
+    traits: Vec<String>,
+    injuries: Vec<String>,
+    phobias: Vec<String>,
+    manias: Vec<String>,
+}
+```
+
+### New Types Needed
+```rust
+pub enum CocSuccessLevel {
+    CriticalSuccess,  // Roll of 01
+    ExtremeSuccess,   // ≤ skill/5
+    HardSuccess,      // ≤ skill/2
+    RegularSuccess,   // ≤ skill
+    Failure,          // > skill
+    Fumble,           // 96-100 or 100
+}
+
+pub struct SanityCheck {
+    pass_loss: DiceFormula,  // e.g., "0" or "1d3"
+    fail_loss: DiceFormula,  // e.g., "1d6" or "1d20"
+}
+```
+
+### Key Differences from D&D-style Games
+1. **Roll-under vs Roll-over**: Lower is better
+2. **Percentile skills**: 1-100 scale, not modifiers
+3. **No HP scaling**: Characters remain fragile
+4. **Sanity resource**: Unique mental health system
+5. **No leveling**: Skill-based improvement only
+6. **Investigation focus**: Combat is dangerous, not heroic
+7. **Luck spending**: Permanent resource consumption
+8. **Eight characteristics**: Different from D&D's six
+9. **Opposed roll table**: Different from contested checks

--- a/docs/game-systems/fate_core.md
+++ b/docs/game-systems/fate_core.md
@@ -1,0 +1,456 @@
+# FATE Core System Reference
+
+## Overview
+
+FATE Core is a narrative-focused RPG using Fudge dice (4dF) with a ladder-based result system. It emphasizes player agency, collaborative storytelling, and aspects as the central mechanic. Characters are defined more by descriptive phrases than numerical stats.
+
+## Core Mechanics
+
+### Dice System
+- **Primary Roll**: 4dF (four Fudge dice)
+- **Each Die**: Three faces: +1, 0, -1
+- **Result Range**: -4 to +4 (bell curve centered on 0)
+- **Roll Formula**: `4dF + Skill Rating vs Difficulty`
+
+### Probability Distribution
+| Result | Probability |
+|--------|-------------|
+| 0 | 23.46% |
+| ±1 | 19.75% each |
+| ±2 | 12.35% each |
+| ±3 | 4.94% each |
+| ±4 | 1.23% each |
+
+### The Ladder
+All values in FATE use a descriptive ladder:
+
+| Rating | Descriptor |
+|--------|------------|
+| +8 | Legendary |
+| +7 | Epic |
+| +6 | Fantastic |
+| +5 | Superb |
+| +4 | Great |
+| +3 | Good |
+| +2 | Fair |
+| +1 | Average |
+| 0 | Mediocre |
+| -1 | Poor |
+| -2 | Terrible |
+
+### Shifts and Outcomes
+**Shifts** = Your Roll - Opposition (Difficulty or opposing roll)
+
+| Shifts | Outcome | Effect |
+|--------|---------|--------|
+| < 0 | Failure | Don't achieve goal, may face consequence |
+| 0 | Tie | Success at minor cost, or boost |
+| 1-2 | Success | Achieve your goal |
+| 3+ | Success with Style | Achieve goal + bonus (boost or extra effect) |
+
+**Implementation**:
+```rust
+fn resolve_fate_roll(
+    skill_rating: i32,
+    dice_result: i32,  // Sum of 4dF
+    difficulty: i32,
+) -> FateOutcome {
+    let total = skill_rating + dice_result;
+    let shifts = total - difficulty;
+
+    if shifts >= 3 {
+        FateOutcome::SuccessWithStyle { shifts }
+    } else if shifts >= 1 {
+        FateOutcome::Success { shifts }
+    } else if shifts == 0 {
+        FateOutcome::Tie
+    } else {
+        FateOutcome::Failure { shifts }
+    }
+}
+```
+
+## Character Aspects
+
+### Five Aspects
+Every character has five aspects - descriptive phrases that define who they are:
+
+| Aspect Type | Purpose | Example |
+|-------------|---------|---------|
+| High Concept | Core identity | "Wizard Private Investigator" |
+| Trouble | Major complication | "Owes Favors to the Faerie Court" |
+| Aspect 1-3 | Relationships, beliefs, possessions | "My Partner Has My Back" |
+
+### Invoking Aspects
+- **Cost**: 1 Fate Point
+- **Benefit**: +2 to roll OR reroll all 4dF
+- **When**: After rolling, when aspect is relevant
+
+```rust
+pub enum InvokeType {
+    AddTwo,   // +2 to roll
+    Reroll,   // Reroll all 4dF
+}
+
+fn invoke_aspect(fate_points: &mut u8, invoke_type: InvokeType) -> Result<InvokeType> {
+    if *fate_points < 1 {
+        return Err(Error::InsufficientFatePoints);
+    }
+    *fate_points -= 1;
+    Ok(invoke_type)
+}
+```
+
+### Compelling Aspects
+- **Trigger**: GM or player offers a complication based on aspect
+- **If Accepted**: Gain 1 Fate Point, complication happens
+- **If Refused**: Pay 1 Fate Point to avoid
+
+### Situation Aspects
+- Created during play via Create Advantage action
+- Temporary (scene-specific)
+- Come with free invocations
+
+## Skills
+
+### Standard Skill List (18 Skills)
+| Skill | Description |
+|-------|-------------|
+| Athletics | Running, jumping, climbing, dodging |
+| Burglary | Breaking and entering, lockpicking |
+| Contacts | Knowing people, gathering info via network |
+| Crafts | Building and fixing things |
+| Deceive | Lying, misdirection, false impressions |
+| Drive | Operating vehicles |
+| Empathy | Reading emotions, detecting lies |
+| Fight | Close-quarters combat |
+| Investigate | Finding clues, piecing together info |
+| Lore | Academic knowledge, esoteric facts |
+| Notice | Passive awareness, spotting details |
+| Physique | Strength, endurance, toughness |
+| Provoke | Intimidation, scaring, angering |
+| Rapport | Building relationships, making friends |
+| Resources | Wealth and material resources |
+| Shoot | Ranged weapons and attacks |
+| Stealth | Staying hidden, moving unseen |
+| Will | Mental fortitude, resisting mental attacks |
+
+### Skill Pyramid
+Characters distribute skills in a pyramid structure:
+- 1 skill at +4 (Great)
+- 2 skills at +3 (Good)
+- 3 skills at +2 (Fair)
+- 4 skills at +1 (Average)
+- All others at +0 (Mediocre)
+
+```rust
+pub struct SkillPyramid {
+    pub skills: HashMap<SkillId, i32>,
+    pub max_rating: i32,  // typically 4
+}
+
+impl SkillPyramid {
+    pub fn validate(&self) -> Result<(), PyramidError> {
+        let mut counts: HashMap<i32, u32> = HashMap::new();
+        for rating in self.skills.values() {
+            *counts.entry(*rating).or_insert(0) += 1;
+        }
+
+        // Pyramid: Each level N needs at least N skills at level (N-1)
+        for level in 1..=self.max_rating {
+            let count_at_level = counts.get(&level).copied().unwrap_or(0);
+            let count_below = counts.get(&(level - 1)).copied().unwrap_or(0);
+
+            if count_below < count_at_level {
+                return Err(PyramidError::InvalidShape { level });
+            }
+        }
+        Ok(())
+    }
+}
+```
+
+### FATE Accelerated (Variant)
+Uses 6 **Approaches** instead of 18 skills:
+- **Careful**: Cautious, methodical actions
+- **Clever**: Thinking fast, solving puzzles
+- **Flashy**: Dramatic, attention-grabbing
+- **Forceful**: Brute strength, willpower
+- **Quick**: Speed, reaction time
+- **Sneaky**: Misdirection, stealth
+
+Rated +0 to +3, distributed as: one +3, two +2, two +1, one +0
+
+## Four Actions
+
+### Overcome
+**Purpose**: Get past obstacles, solve problems
+**Outcomes**:
+- Fail: Don't overcome, or succeed at serious cost
+- Tie: Succeed at minor cost
+- Success: Overcome the obstacle
+- Style: Overcome + create a boost
+
+### Create Advantage
+**Purpose**: Create or discover aspects, get free invocations
+**Outcomes**:
+- Fail: Don't create aspect, or opponent gets free invocation
+- Tie: Create aspect with 1 free invocation (or boost existing)
+- Success: Create aspect with 1 free invocation
+- Style: Create aspect with 2 free invocations
+
+### Attack
+**Purpose**: Harm opponent (vs. Defend)
+**Outcomes**:
+- Fail/Tie: No effect
+- Success: Deal shifts as stress
+- Style: Deal shifts + create a boost
+
+### Defend
+**Purpose**: Counter Attack or Create Advantage
+**Roll**: Opposes attacker's roll
+
+```rust
+pub enum FateAction {
+    Overcome {
+        skill: SkillId,
+        difficulty: i32,
+    },
+    CreateAdvantage {
+        skill: SkillId,
+        target: AdvantageTarget,
+    },
+    Attack {
+        skill: SkillId,
+        target: CharacterId,
+    },
+    Defend {
+        skill: SkillId,
+    },
+}
+
+pub enum AdvantageTarget {
+    NewAspect { name: String },
+    ExistingAspect { aspect_id: String },
+    DiscoverAspect,
+}
+```
+
+## Stunts
+
+### What Stunts Do
+Three types of effects:
+
+1. **Add Bonus**: +2 to skill in specific situation
+   - "Because I'm a Combat Veteran, I get +2 to Fight when outnumbered"
+
+2. **Add Action**: Do something normally impossible
+   - "Because I Read People, I can use Empathy to defend against Deceive"
+
+3. **Rule Exception**: Break a game rule in specific way
+   - "Once per session, I can clear a mild consequence immediately"
+
+### Stunts and Refresh
+- **Starting Stunts**: 3
+- **Maximum Stunts**: 5
+- **Refresh Trade-off**: Extra stunts reduce Refresh
+
+```
+Refresh = 3 - (Stunts - 3)  // if Stunts > 3
+
+Examples:
+- 3 stunts = 3 Refresh
+- 4 stunts = 2 Refresh
+- 5 stunts = 1 Refresh (minimum)
+```
+
+## Fate Points
+
+### Refresh
+- Starting Fate Points each session
+- Default: 3
+- Reduced by extra stunts
+- Minimum: 1
+
+### Uses
+1. **Invoke Aspect**: +2 or reroll (costs 1 FP)
+2. **Accept Compel**: Gain 1 FP
+3. **Refuse Compel**: Pay 1 FP
+4. **Declare Story Detail**: Add minor fact to scene (costs 1 FP, GM approval)
+5. **Power a Stunt**: Some stunts cost FP
+
+```rust
+pub struct FatePointTracker {
+    pub current: u8,
+    pub refresh: u8,
+}
+
+impl FatePointTracker {
+    pub fn start_session(&mut self) {
+        if self.current < self.refresh {
+            self.current = self.refresh;
+        }
+        // Note: If current > refresh, you keep the excess
+    }
+
+    pub fn spend(&mut self) -> Result<()> {
+        if self.current < 1 {
+            return Err(Error::InsufficientFatePoints);
+        }
+        self.current -= 1;
+        Ok(())
+    }
+
+    pub fn gain(&mut self) {
+        self.current += 1;
+    }
+}
+```
+
+## Stress and Consequences
+
+### Stress Tracks
+- **Physical Stress**: 2 boxes (+ more from Physique)
+- **Mental Stress**: 2 boxes (+ more from Will)
+
+**Extra Boxes from Skills**:
+| Skill Rating | Stress Boxes |
+|--------------|--------------|
+| Mediocre (+0) | 2 boxes |
+| Average/Fair (+1/+2) | 3 boxes |
+| Good/Great (+3/+4) | 4 boxes |
+
+### Taking Hits
+When you take stress (shifts of damage):
+1. Check a stress box equal to or greater than shifts
+2. OR take a consequence
+3. OR be Taken Out
+
+**Stress clears at end of scene**
+
+### Consequences
+| Severity | Shifts Absorbed | Recovery Time |
+|----------|-----------------|---------------|
+| Mild (-2) | 2 | End of scene |
+| Moderate (-4) | 4 | End of session |
+| Severe (-6) | 6 | End of scenario |
+
+- Each character has: 1 Mild, 1 Moderate, 1 Severe slot
+- Consequence is an aspect (can be invoked/compelled)
+- Opponent names the consequence
+- First invocation against you is free
+
+```rust
+pub struct Consequence {
+    pub severity: ConsequenceSeverity,
+    pub aspect_text: String,
+    pub free_invoke_used: bool,
+}
+
+pub enum ConsequenceSeverity {
+    Mild,     // -2, heals end of scene
+    Moderate, // -4, heals end of session
+    Severe,   // -6, heals end of scenario
+}
+
+impl Consequence {
+    pub fn shifts_absorbed(&self) -> i32 {
+        match self.severity {
+            ConsequenceSeverity::Mild => 2,
+            ConsequenceSeverity::Moderate => 4,
+            ConsequenceSeverity::Severe => 6,
+        }
+    }
+}
+```
+
+### Being Taken Out
+- Occurs when you can't absorb stress
+- Opponent narrates your defeat
+- Alternative: **Concede** before being Taken Out (you narrate your exit, gain FP)
+
+## Character Creation
+
+### Summary Steps
+1. **High Concept**: Core identity aspect
+2. **Trouble**: Major complication aspect
+3. **Phase One**: First adventure (creates 1 aspect)
+4. **Phase Two**: Crossing paths with another PC (creates 1 aspect)
+5. **Phase Three**: Another crossing (creates 1 aspect)
+6. **Skills**: Distribute in pyramid
+7. **Stunts**: Choose 1-3 stunts
+8. **Refresh**: Calculate (3 minus extra stunts)
+9. **Stress & Consequences**: Mark boxes based on Physique/Will
+
+### Advancement (Milestones)
+
+**Minor Milestone** (every session):
+- Switch two skill ratings
+- Rename one aspect
+- Purchase stunt (if refresh available)
+
+**Significant Milestone** (end of scenario):
+- All minor milestone options
+- +1 skill (obeying pyramid)
+- OR take new stunt and reduce refresh
+
+**Major Milestone** (campaign conclusion):
+- All significant milestone options
+- +1 refresh
+- Rename high concept (if appropriate)
+- Increase skill cap (if relevant)
+
+## Integration Considerations
+
+### StatBlock Mapping
+```rust
+pub struct FateStatBlock {
+    // Skills (ladder values)
+    skills: HashMap<String, i32>,
+
+    // Approaches (for FAE variant)
+    approaches: Option<HashMap<String, i32>>,
+
+    // Stress tracks
+    physical_stress: Vec<bool>,  // Checkboxes
+    mental_stress: Vec<bool>,
+
+    // Consequences
+    mild_consequence: Option<Consequence>,
+    moderate_consequence: Option<Consequence>,
+    severe_consequence: Option<Consequence>,
+
+    // Fate Points
+    current_fate_points: u8,
+    refresh: u8,
+}
+```
+
+### Aspect System
+```rust
+pub struct FateAspect {
+    pub id: String,
+    pub aspect_type: AspectType,
+    pub text: String,
+    pub free_invokes: u8,
+}
+
+pub enum AspectType {
+    HighConcept,
+    Trouble,
+    Character,
+    Situation,
+    Consequence(ConsequenceSeverity),
+    Boost,  // One-time, disappears after use
+}
+```
+
+### Key Differences from D20 Systems
+1. **Narrative First**: Fiction determines mechanics, not vice versa
+2. **No HP/Damage**: Stress + Consequences instead
+3. **Aspects, Not Stats**: Descriptive phrases define capabilities
+4. **Player Narrative Control**: Fate Points buy story influence
+5. **Collaborative**: Players contribute to world-building
+6. **Bounded Values**: Ladder -2 to +8, not scaling numbers
+7. **Pyramid Structure**: Skill distribution is constrained
+8. **Double-Edged Aspects**: Can help or hinder equally

--- a/docs/game-systems/pbta.md
+++ b/docs/game-systems/pbta.md
@@ -1,0 +1,533 @@
+# Powered by the Apocalypse (PbtA) System Reference
+
+## Overview
+
+Powered by the Apocalypse (PbtA) is a family of narrative RPGs derived from Apocalypse World. The system uses 2d6 + stat with move-based resolution. Each game in the family (Apocalypse World, Dungeon World, Monster of the Week, etc.) adapts the core engine to its genre.
+
+## Core Mechanics
+
+### Dice System
+- **Primary Roll**: 2d6 + stat modifier
+- **Result Ranges**: 6-, 7-9, 10+
+- **No Modifiers Stack**: Just stat + roll
+
+### Three-Tier Outcomes
+| Roll | Outcome | Description |
+|------|---------|-------------|
+| 10+ | **Full Success** | You do it without complications |
+| 7-9 | **Partial Success** | You do it with a cost, complication, or reduced effect |
+| 6- | **Miss** | GM makes a move (usually bad for you) |
+
+```rust
+fn resolve_pbta_roll(dice_sum: u8, stat_modifier: i32) -> PbtaOutcome {
+    let total = dice_sum as i32 + stat_modifier;
+
+    if total >= 10 {
+        PbtaOutcome::FullSuccess
+    } else if total >= 7 {
+        PbtaOutcome::PartialSuccess
+    } else {
+        PbtaOutcome::Miss
+    }
+}
+```
+
+### The Fiction First
+- Describe what you're doing in fiction
+- GM determines if it triggers a move
+- Roll only when a move triggers
+- Results interpreted through fiction
+
+## Stats (Vary by Game)
+
+### Apocalypse World Stats
+| Stat | Description |
+|------|-------------|
+| **Cool** | Calmness under pressure |
+| **Hard** | Violence and intimidation |
+| **Hot** | Seduction and manipulation |
+| **Sharp** | Perception and cunning |
+| **Weird** | Psychic and unnatural |
+
+### Dungeon World Stats
+| Stat | Description |
+|------|-------------|
+| **STR** | Physical power |
+| **DEX** | Agility and reflexes |
+| **CON** | Endurance and health |
+| **INT** | Knowledge and reason |
+| **WIS** | Perception and willpower |
+| **CHA** | Force of personality |
+
+### Monster of the Week Stats
+| Stat | Description |
+|------|-------------|
+| **Charm** | Manipulation and social |
+| **Cool** | Calm, collected, sneaky |
+| **Sharp** | Thinking and noticing |
+| **Tough** | Fighting and strength |
+| **Weird** | Supernatural abilities |
+
+### Stat Ranges
+Most PbtA games use: **-1 to +3** (occasionally -2 or +4)
+
+```rust
+pub struct PbtaStats {
+    pub stats: HashMap<String, i8>,  // Typically -2 to +4
+}
+
+impl PbtaStats {
+    pub fn get_modifier(&self, stat: &str) -> i8 {
+        self.stats.get(stat).copied().unwrap_or(0)
+    }
+}
+```
+
+## Moves
+
+### What Are Moves?
+Moves are the core mechanic - specific actions that trigger dice rolls:
+- Have a **trigger** (fiction that activates them)
+- Require a **roll** (usually 2d6 + stat)
+- Have **outcomes** for 10+, 7-9, and sometimes 6-
+
+### Basic Moves (Core to Most PbtA)
+
+**Act Under Pressure** (Apocalypse World) / **Defy Danger** (Dungeon World):
+```
+When you act under fire/defy danger, roll +Cool/+relevant stat.
+• 10+: You do it
+• 7-9: You stumble, hesitate, or flinch - GM offers worse outcome, hard bargain, or ugly choice
+• 6-: GM makes a move
+```
+
+**Go Aggro** / **Hack and Slash**:
+```
+When you attack an enemy in melee, roll +Hard/+STR.
+• 10+: You deal your damage and avoid their attack
+• 7-9: You deal damage but expose yourself to their attack
+• 6-: GM makes a move
+```
+
+**Read a Situation** / **Discern Realities**:
+```
+When you assess a situation, roll +Sharp/+WIS.
+• 10+: Ask 3 questions from the list
+• 7-9: Ask 1 question
+Questions: What happened here? What is about to happen?
+What should I be on the lookout for? etc.
+```
+
+**Read a Person**:
+```
+When you read a person, roll +Sharp.
+• 10+: Ask 3 questions, take +1 forward when acting on answers
+• 7-9: Ask 1 question
+Questions: Is your character telling the truth?
+What does your character intend to do?
+What does your character wish I'd do? etc.
+```
+
+**Manipulate/Seduce**:
+```
+When you try to manipulate someone, roll +Hot/+CHA.
+• 10+: They do what you want if you give them what they want
+• 7-9: They'll do it, but need concrete assurance, a bribe, or a promise
+• 6-: GM makes a move
+```
+
+### Move Structure
+```rust
+pub struct PbtaMove {
+    pub id: String,
+    pub name: String,
+    pub trigger: String,           // "When you..."
+    pub stat: String,              // Stat to roll with
+    pub full_success: String,      // 10+ outcome
+    pub partial_success: String,   // 7-9 outcome
+    pub miss: Option<String>,      // 6- (often "GM makes a move")
+    pub options: Vec<MoveOption>,  // For moves with choices
+}
+
+pub struct MoveOption {
+    pub text: String,
+    pub available_at: Vec<Outcome>, // Which results can pick this
+}
+```
+
+### Playbook Moves
+Each character type (playbook) has unique moves:
+- Start with 2-3 playbook moves
+- Gain more through advancement
+- Define what makes each playbook special
+
+## Playbooks (Character Types)
+
+### What's a Playbook?
+A playbook is a character archetype that defines:
+- **Stats Array**: How stats are distributed
+- **Moves**: Special abilities unique to this type
+- **Look**: Appearance options
+- **Gear**: Starting equipment
+- **Advancement**: How they grow
+
+### Example: Dungeon World Playbooks
+| Playbook | Role | Key Moves |
+|----------|------|-----------|
+| Fighter | Warrior | Bend Bars Lift Gates, Signature Weapon |
+| Wizard | Spellcaster | Spellbook, Cast a Spell, Ritual |
+| Cleric | Divine agent | Deity, Cast a Spell, Turn Undead |
+| Thief | Stealth expert | Backstab, Tricks of the Trade |
+| Ranger | Wilderness expert | Animal Companion, Hunt and Track |
+| Bard | Social expert | Arcane Art, Charming and Open |
+| Druid | Shapeshifter | Shapeshifter, Born of the Soil |
+| Paladin | Holy warrior | Lay on Hands, Quest |
+
+### Example: Monster of the Week Playbooks
+| Playbook | Concept |
+|----------|---------|
+| The Chosen | Destined hero |
+| The Crooked | Criminal with a heart |
+| The Divine | Angelic warrior |
+| The Expert | Knowledgeable mentor |
+| The Flake | Conspiracy theorist |
+| The Mundane | Normal person |
+| The Professional | Agency operative |
+| The Spell-Slinger | Practicing wizard |
+| The Spooky | Dark-powered |
+| The Wronged | Vengeance seeker |
+
+## Harm System
+
+### Harm Tracks (Vary by Game)
+
+**Apocalypse World** (Harm Clock):
+- 6-segment clock
+- At 6:00: Rolling +Harm
+- Past 6:00: Dying
+- At 12:00: Dead
+
+**Dungeon World** (HP-based):
+- HP = Constitution + Class Base
+- Damage reduces HP
+- At 0 HP: Last Breath move
+
+**Monster of the Week** (Harm Track):
+- 7 boxes (0-7 harm)
+- 4+ harm: Unstable (need help)
+- 7 harm: Dying
+- 8+ harm: Dead
+
+```rust
+pub enum HarmSystem {
+    Clock {
+        segments: u8,
+        current: u8,
+    },
+    HitPoints {
+        max: u8,
+        current: u8,
+    },
+    HarmTrack {
+        boxes: u8,
+        filled: u8,
+        unstable_at: u8,
+    },
+}
+```
+
+### Healing
+Varies by game but usually:
+- Rest heals some harm
+- Moves like "Heal" or "First Aid"
+- Conditions may need specific treatment
+
+## Forward and Ongoing
+
+### +1 Forward
+- Bonus to your **next** roll (one time)
+- Then it's gone
+- "Take +1 forward to Act Under Fire"
+
+### +1 Ongoing
+- Bonus to **all** rolls for a condition
+- Until condition ends
+- "Take +1 ongoing while in your sanctuary"
+
+### -1 Forward/Ongoing
+- Penalty works the same way
+- "Take -1 forward from your wound"
+
+```rust
+pub struct RollModifiers {
+    pub forward: i8,        // Consumed after next roll
+    pub ongoing: Vec<OngoingModifier>,
+}
+
+pub struct OngoingModifier {
+    pub value: i8,
+    pub condition: String,
+    pub applicable_to: Vec<String>,  // Stats or moves
+}
+```
+
+## Hold
+
+### What is Hold?
+Some moves grant "hold" - currency to spend on options:
+- "On a 10+, hold 3. On a 7-9, hold 1."
+- "Spend hold 1-for-1 to ask questions"
+- Hold persists until spent or situation changes
+
+```rust
+pub struct MoveHold {
+    pub move_id: String,
+    pub amount: u8,
+    pub options: Vec<HoldOption>,
+}
+
+pub struct HoldOption {
+    pub cost: u8,
+    pub effect: String,
+}
+```
+
+## GM Principles and Moves
+
+### MC/GM Principles
+Core guidelines for running PbtA:
+- Make the world seem real
+- Make the characters' lives not boring
+- Play to find out what happens
+- Address yourself to the characters, not players
+- Make your move, but never speak its name
+- Be a fan of the players' characters
+
+### GM Moves (Hard Moves on 6-)
+When players miss, GM makes a move:
+- Separate them
+- Put someone in a spot
+- Announce future badness
+- Deal damage
+- Take away their stuff
+- Make them buy with cost
+- Turn their move back on them
+- Offer opportunity with or without cost
+- Tell consequences and ask
+- Make a threat real
+
+### Soft vs Hard Moves
+- **Soft Move**: Sets up future danger, gives warning
+- **Hard Move**: Immediate consequence, no warning
+- On 6-: GM can make a hard move
+- On 7-9: Usually soft move as complication
+
+## Advancement
+
+### Experience (XP)
+Different games track XP differently:
+
+**Apocalypse World**:
+- Mark XP when you roll highlighted stats
+- Mark XP from session-end questions
+- At 5 XP: Advance
+
+**Dungeon World**:
+- Mark XP on miss (6-)
+- Session-end XP from bonds and questions
+- XP to level = current level + 7
+
+**Monster of the Week**:
+- Mark XP from experience moves
+- At 5 XP: Advance
+
+### Advancement Options (Typical)
+- Get +1 to a stat (max +3)
+- Get a new move from your playbook
+- Get a move from another playbook
+- Get an ally or special equipment
+- Change to a new playbook (advanced option)
+
+```rust
+pub struct PbtaAdvancement {
+    pub xp_current: u8,
+    pub xp_to_advance: u8,
+    pub advancements_taken: Vec<Advancement>,
+}
+
+pub enum Advancement {
+    StatIncrease { stat: String },
+    NewMove { move_id: String },
+    CrossPlaybookMove { playbook: String, move_id: String },
+    Special { description: String },
+}
+```
+
+## Bonds/Relationships
+
+### What Are Bonds?
+Connections between PCs that:
+- Define starting relationships
+- Provide mechanical benefits
+- Can be resolved for XP
+
+### Bond Examples (Dungeon World)
+- "_____ has my back when things go wrong."
+- "I worry about ___'s ability to survive."
+- "_____ knows incriminating details about me."
+
+### Bond Mechanics
+- Start with 2-4 bonds with other PCs
+- When you resolve a bond: Mark XP, write new bond
+- Bonds affect Aid/Interfere moves
+
+## Conditions (Some Games)
+
+### Alternative to Harm
+Some PbtA games use conditions instead of harm:
+
+**Masks** (Teen Superhero) Conditions:
+- Afraid, Angry, Guilty, Hopeless, Insecure
+- Each gives -2 to specific actions
+- Cleared through roleplay
+
+**Monsterhearts** Conditions:
+- Each string gives someone else power over you
+- Traded and spent for various effects
+
+## Common Moves Across PbtA
+
+### Aid/Interfere
+```
+When you help or hinder another PC, roll +Bond/Relationship.
+• 10+: They take +1 or -2 to their roll (your choice)
+• 7-9: They take +1 or -2, but you expose yourself to danger
+```
+
+### End of Session
+```
+At session end, consider:
+• Did we learn something new and important about the world?
+• Did we overcome a notable monster or enemy?
+• Did we loot memorable treasure?
+Mark XP for each "yes"
+```
+
+### Last Breath (Dungeon World)
+```
+When you're dying, you glimpse what lies beyond.
+Roll +nothing.
+• 10+: You stabilize, barely alive
+• 7-9: Death offers a bargain - take it or pass on
+• 6-: Your fate is sealed, the end is near
+```
+
+## Integration Considerations
+
+### StatBlock Mapping
+```rust
+pub struct PbtaStatBlock {
+    // Stats (vary by game, typically -2 to +3)
+    pub stats: HashMap<String, i8>,
+
+    // Harm/HP system
+    pub harm: HarmSystem,
+
+    // Modifiers
+    pub forward: i8,
+    pub ongoing: Vec<OngoingModifier>,
+
+    // Hold from various moves
+    pub hold: HashMap<String, u8>,
+
+    // XP and advancement
+    pub xp: u8,
+    pub xp_threshold: u8,
+
+    // Bonds/Relationships
+    pub bonds: Vec<Bond>,
+}
+
+pub struct Bond {
+    pub target_character: String,
+    pub description: String,
+    pub resolved: bool,
+}
+```
+
+### Move Registry
+```rust
+pub struct MoveRegistry {
+    pub basic_moves: Vec<PbtaMove>,      // Available to all
+    pub playbook_moves: HashMap<String, Vec<PbtaMove>>,  // By playbook
+    pub advanced_moves: Vec<PbtaMove>,   // Unlocked at higher levels
+}
+
+impl MoveRegistry {
+    pub fn get_available_moves(&self, character: &Character) -> Vec<&PbtaMove> {
+        let mut moves: Vec<&PbtaMove> = self.basic_moves.iter().collect();
+
+        if let Some(playbook_moves) = self.playbook_moves.get(&character.playbook) {
+            moves.extend(playbook_moves.iter());
+        }
+
+        moves
+    }
+}
+```
+
+### Game Variant Configuration
+```rust
+pub struct PbtaVariant {
+    pub name: String,                    // "Dungeon World", "Monster of the Week"
+    pub stat_names: Vec<String>,         // ["STR", "DEX", "CON", "INT", "WIS", "CHA"]
+    pub stat_range: (i8, i8),            // (-1, 3) typically
+    pub harm_system: HarmSystemType,
+    pub basic_moves: Vec<PbtaMove>,
+    pub playbooks: Vec<PlaybookDefinition>,
+    pub advancement_type: AdvancementType,
+}
+
+pub enum HarmSystemType {
+    Clock { segments: u8 },
+    HitPoints { formula: String },
+    HarmTrack { boxes: u8, unstable: u8 },
+    Conditions { list: Vec<String> },
+}
+
+pub enum AdvancementType {
+    FiveXP,           // Most PbtA
+    LevelBased,       // Dungeon World
+    MilestoneMarks,   // Some variants
+}
+```
+
+## Key Differences from D20 Systems
+
+| Aspect | D20 Systems | PbtA |
+|--------|-------------|------|
+| Dice | d20 + modifiers | 2d6 + stat |
+| Target | Variable DC | Fixed (6-/7-9/10+) |
+| GM Roll | Yes | Never |
+| Actions | Defined list | Triggered by fiction |
+| Outcomes | Binary (pass/fail) | Three tiers |
+| Damage | HP pools | Harm/Conditions |
+| Initiative | Roll for order | Fiction determines |
+| Skills | Extensive list | Moves replace skills |
+| Advancement | XP and leveling | Varies by game |
+
+## Popular PbtA Games
+
+| Game | Genre | Notable Mechanics |
+|------|-------|-------------------|
+| **Apocalypse World** | Post-apocalyptic | Original PbtA, Harm clocks |
+| **Dungeon World** | Fantasy adventure | D&D-like classes, HP |
+| **Monster of the Week** | Monster hunting | Hunter playbooks, Use Magic |
+| **Masks** | Teen superheroes | Conditions, Labels |
+| **Monsterhearts** | Supernatural teen drama | Strings, darkest self |
+| **Urban Shadows** | Urban fantasy | Debts, factions |
+| **The Sprawl** | Cyberpunk | Countdown clocks, Corps |
+| **Bluebeard's Bride** | Horror | Shared character, rooms |
+| **Fellowship** | Epic fantasy | Overlord mechanics |
+
+Each adapts the core 2d6+stat, three-tier outcome engine to its specific genre and themes.

--- a/docs/game-systems/pf2e.md
+++ b/docs/game-systems/pf2e.md
@@ -1,0 +1,342 @@
+# Pathfinder 2nd Edition (PF2e) System Reference
+
+## Overview
+
+Pathfinder 2e is a d20-based fantasy RPG with four degrees of success, a three-action economy, and a granular proficiency system. It builds on D&D traditions but with significant mechanical innovations.
+
+## Core Mechanics
+
+### Dice System
+- **Primary Roll**: d20 + modifiers vs DC (Difficulty Class)
+- **Check Formula**: `d20 + ability modifier + proficiency bonus + item bonus + circumstance bonus + status bonus`
+
+### Degrees of Success
+Unlike D&D 5e's binary success/failure, PF2e has four outcomes:
+
+| Outcome | Condition |
+|---------|-----------|
+| Critical Success | Beat DC by 10+ OR natural 20 that succeeds |
+| Success | Meet or beat DC |
+| Failure | Below DC |
+| Critical Failure | Miss DC by 10+ OR natural 1 that fails |
+
+**Implementation Formula**:
+```rust
+fn determine_success(roll: i32, modifier: i32, dc: i32) -> DegreeOfSuccess {
+    let total = roll + modifier;
+    let diff = total - dc;
+
+    let base_success = if diff >= 0 { DegreeOfSuccess::Success }
+                       else { DegreeOfSuccess::Failure };
+
+    // Apply +/- 10 rule
+    let adjusted = if diff >= 10 { base_success.upgrade() }
+                   else if diff <= -10 { base_success.downgrade() }
+                   else { base_success };
+
+    // Natural 20/1 adjustments
+    if roll == 20 { adjusted.upgrade() }
+    else if roll == 1 { adjusted.downgrade() }
+    else { adjusted }
+}
+```
+
+## Character Attributes
+
+### Ability Scores
+Same six abilities as D&D, but different calculation:
+- **STR** (Strength), **DEX** (Dexterity), **CON** (Constitution)
+- **INT** (Intelligence), **WIS** (Wisdom), **CHA** (Charisma)
+
+### Ability Modifier Calculation
+**Same as D&D 5e**: `modifier = floor((score - 10) / 2)`
+
+| Score | Modifier |
+|-------|----------|
+| 1 | -5 |
+| 8-9 | -1 |
+| 10-11 | 0 |
+| 12-13 | +1 |
+| 14-15 | +2 |
+| 16-17 | +3 |
+| 18-19 | +4 |
+| 20+ | +5+ |
+
+### Key Ability by Class
+Each class has a key ability score:
+
+| Class | Key Ability |
+|-------|-------------|
+| Alchemist | INT |
+| Barbarian | STR |
+| Bard | CHA |
+| Champion | STR or DEX |
+| Cleric | WIS |
+| Druid | WIS |
+| Fighter | STR or DEX |
+| Investigator | INT |
+| Magus | STR or DEX |
+| Monk | STR or DEX |
+| Oracle | CHA |
+| Ranger | STR or DEX |
+| Rogue | DEX |
+| Sorcerer | CHA |
+| Summoner | CHA |
+| Swashbuckler | DEX |
+| Witch | INT |
+| Wizard | INT |
+
+## Proficiency System
+
+### Proficiency Ranks
+Five ranks provide increasing bonuses:
+
+| Rank | Bonus | Training Requirements |
+|------|-------|----------------------|
+| Untrained | 0 | - |
+| Trained | +2 + level | Basic training |
+| Expert | +4 + level | Advanced training |
+| Master | +6 + level | Mastery |
+| Legendary | +8 + level | Ultimate mastery |
+
+### Proficiency Bonus Formula
+```rust
+fn proficiency_bonus(level: u8, rank: ProficiencyRank) -> i32 {
+    let rank_bonus = match rank {
+        ProficiencyRank::Untrained => 0,
+        ProficiencyRank::Trained => 2,
+        ProficiencyRank::Expert => 4,
+        ProficiencyRank::Master => 6,
+        ProficiencyRank::Legendary => 8,
+    };
+
+    if rank == ProficiencyRank::Untrained {
+        0  // Untrained doesn't add level
+    } else {
+        rank_bonus + level as i32
+    }
+}
+```
+
+### What Can Be Proficient In
+- **Skills** (16 core skills + Lore)
+- **Weapons** (by category: simple, martial, advanced, specific)
+- **Armor** (unarmored, light, medium, heavy)
+- **Saving Throws** (Fortitude, Reflex, Will)
+- **Perception** (special: used for initiative)
+- **Spells** (spell attacks and DCs)
+- **Class DC** (used for class abilities)
+
+## Skills
+
+### Complete Skill List (16 Skills)
+
+| Skill | Ability | Common Uses |
+|-------|---------|-------------|
+| Acrobatics | DEX | Balance, Tumble Through, Maneuver in Flight |
+| Arcana | INT | Recall Knowledge (arcane), Identify Magic |
+| Athletics | STR | Climb, Swim, Grapple, Shove, Trip, Jump |
+| Crafting | INT | Craft items, Repair, Identify Alchemy |
+| Deception | CHA | Lie, Feint, Create a Diversion |
+| Diplomacy | CHA | Gather Information, Make an Impression, Request |
+| Intimidation | CHA | Coerce, Demoralize |
+| Lore | INT | Recall Knowledge (specific topic) |
+| Medicine | WIS | Treat Wounds, First Aid, Treat Disease |
+| Nature | WIS | Recall Knowledge (nature), Command an Animal |
+| Occultism | INT | Recall Knowledge (occult), Identify Magic |
+| Performance | CHA | Perform |
+| Religion | WIS | Recall Knowledge (religion), Identify Magic |
+| Society | INT | Recall Knowledge (society), Create Forgery, Subsist |
+| Stealth | DEX | Hide, Sneak, Conceal an Object |
+| Survival | WIS | Track, Sense Direction, Subsist |
+| Thievery | DEX | Pick Lock, Pick Pocket, Disable Device |
+
+### Lore Skills
+- Subcategory of INT-based skills
+- Specific topics: "Bardic Lore", "Underworld Lore", "Sailing Lore"
+- Always Trained at minimum
+
+### Key Skill Actions
+- **Recall Knowledge**: Identify creatures, remember facts
+- **Treat Wounds**: 10-minute activity to heal (Medicine)
+- **Demoralize**: Frighten enemies (Intimidation)
+
+## Combat Mechanics
+
+### Three-Action Economy
+Each turn, characters get **3 actions** plus **1 reaction**:
+- Most activities cost 1 action (Strike, Step, Interact)
+- Some cost 2 actions (many spells, special activities)
+- Some cost 3 actions (some powerful abilities)
+
+**Action Types**:
+- **Single Action** (◆): Standard action
+- **Two Actions** (◆◆): Takes 2 of your 3 actions
+- **Three Actions** (◆◆◆): Entire turn
+- **Free Action** (◇): No action cost
+- **Reaction** (⤾): Once per round, triggered
+
+### Multiple Attack Penalty (MAP)
+Subsequent attacks in a turn get penalties:
+
+| Attack | Penalty | With Agile Weapon |
+|--------|---------|-------------------|
+| First | 0 | 0 |
+| Second | -5 | -4 |
+| Third+ | -10 | -8 |
+
+### Attack Roll Formula
+```
+Attack Roll = d20 + ability modifier + proficiency bonus + item bonus
+```
+
+### AC Calculation
+```
+AC = 10 + DEX modifier + proficiency bonus + armor item bonus + armor's DEX cap
+```
+
+### Damage Formula
+```
+Damage = weapon dice + ability modifier + weapon specialization + runes
+```
+
+## Magic System
+
+### Spell Traditions
+Four traditions, each with a defining trait:
+
+| Tradition | Key Ability | Typical Casters |
+|-----------|-------------|-----------------|
+| Arcane | INT | Wizard, Magus, Witch |
+| Divine | WIS/CHA | Cleric, Champion |
+| Occult | CHA/INT | Bard, Psychic |
+| Primal | WIS | Druid, Ranger |
+
+### Spell Slots
+Similar to D&D, with cantrips scaling automatically:
+
+| Level | Cantrip Damage | Spell Levels Available |
+|-------|---------------|------------------------|
+| 1 | 1d4/1d6 | 1st |
+| 3 | 2d4/2d6 | 1st-2nd |
+| 5 | 3d4/3d6 | 1st-3rd |
+| 7 | 4d4/4d6 | 1st-4th |
+| ... | ... | ... |
+| 19 | 10d4/10d6 | 1st-10th |
+
+### Heightening Spells
+Spells can be cast at higher levels for increased effect:
+- **Heightened (+X)**: Scales every X levels
+- **Heightened (Xth)**: Specific bonuses at level X
+
+### Spell DC and Attack
+```
+Spell DC = 10 + spellcasting ability modifier + proficiency bonus + item bonus
+Spell Attack = d20 + spellcasting ability modifier + proficiency bonus + item bonus
+```
+
+### Focus Spells
+- Separate pool (Focus Points, max 3)
+- Refocus activity restores 1 point (10 minutes)
+- Powerful class-specific abilities
+
+## Character Progression
+
+### Leveling (1-20)
+At each level, characters gain:
+- **Hit Points**: Class HP + CON modifier
+- **Proficiency increases** (automatic and chosen)
+- **Feats** (multiple types)
+- **Ability Boosts** (at levels 5, 10, 15, 20)
+- **Skill Increases** (every level from 3+)
+
+### Feat Types
+
+| Feat Type | Gained At |
+|-----------|-----------|
+| Ancestry Feats | 1, 5, 9, 13, 17 |
+| Class Feats | 1, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20 |
+| Skill Feats | 2, 4, 6, 8, 10, 12, 14, 16, 18, 20 |
+| General Feats | 3, 7, 11, 15, 19 |
+
+## Unique Features
+
+### Hero Points
+- Start each session with 1
+- Max of 3
+- Can spend 1 to reroll a check
+- Can spend all to avoid death
+
+### Bulk System
+Encumbrance simplified:
+- Items have Bulk values (L = light, 1, 2, etc.)
+- 10 L items = 1 Bulk
+- **Encumbered**: Carrying 5 + STR mod Bulk
+- **Maximum**: 10 + STR mod Bulk
+
+### Conditions
+Standardized condition system with severity levels:
+- **Clumsy 1-4**: Penalty to DEX-based checks
+- **Drained 1-4**: Penalty to CON-based checks, reduces max HP
+- **Enfeebled 1-4**: Penalty to STR-based checks
+- **Frightened 1-4**: Penalty to all checks
+- **Sickened 1-4**: Penalty to all checks
+- **Stupefied 1-4**: Penalty to INT/WIS/CHA-based checks
+
+### Dying and Wounded
+- **Dying 1-4**: At 0 HP, must make recovery checks
+- **Wounded**: Increases dying value when knocked out
+- **Dying 4**: Character dies
+- **Recovery Check**: DC 10 + dying value
+
+## Integration Considerations
+
+### StatBlock Mapping
+```rust
+pub struct Pf2eStatBlock {
+    // Ability scores (same as D&D)
+    abilities: HashMap<String, i32>,  // STR, DEX, CON, INT, WIS, CHA
+
+    // Proficiency ranks (new)
+    proficiencies: HashMap<String, ProficiencyRank>,
+
+    // Level (critical for calculations)
+    level: u8,
+
+    // Conditions with values
+    conditions: HashMap<String, u8>,
+
+    // Hero Points
+    hero_points: u8,
+
+    // Bulk carried
+    bulk: f32,
+}
+```
+
+### New Types Needed
+```rust
+pub enum ProficiencyRank {
+    Untrained,
+    Trained,
+    Expert,
+    Master,
+    Legendary,
+}
+
+pub enum DegreeOfSuccess {
+    CriticalSuccess,
+    Success,
+    Failure,
+    CriticalFailure,
+}
+```
+
+### Key Differences from D&D 5e
+1. **Proficiency is level-dependent** (level + rank bonus vs flat bonus)
+2. **Four degrees of success** vs binary
+3. **Three actions per turn** vs action/bonus action/movement
+4. **Multiple Attack Penalty** vs flat Extra Attack
+5. **Conditions have numeric values** vs binary conditions
+6. **Heightening spells** vs upcasting
+7. **Focus spells** (separate resource) vs spell slots only


### PR DESCRIPTION
## Summary

This PR implements major character system features including full integration with XP, challenges, and rewards across **all 6 supported game systems**.

### 1. StatThreshold Trigger (Original Scope)
- Implement the StatThreshold trigger type for narrative events based on character stat values
- Add `character_stats` field to `TriggerContext` with helper methods
- Evaluation logic using min/max bounds (inclusive)

### 2. Multi-System Character Sheet Providers
- Complete character sheet schema system supporting 6 TTRPGs
- Dynamic system detection via world's RuleSystemVariant
- WebSocket handlers for character creation and sheet management

### 3. XP & Advancement System Integration
- XP tracking fields (XP_CURRENT, XP_NEXT_LEVEL) in D&D 5e and PF2e sheets
- XP thresholds table for levels 1-20 (D&D 5e) and 1000 XP/level (PF2e)
- Helper functions: xp_for_level, xp_for_next_level, level_from_xp
- Automatic XP_NEXT_LEVEL calculation in derived values

### 4. Challenge Skill Modifier Integration
- `Challenge.check_stat` field for skill-based challenge rolls
- `with_check_stat()` builder method
- Unified `get_numeric_value()` method for cross-system skill lookup
- Works with Number, SkillEntry, DicePool, Percentile, and LadderRating field types

### 5. System-Aware AddReward Effect Executor
- `execute_add_xp_reward_system_aware()` - maps to correct XP field per system
- `execute_add_gold_reward_system_aware()` - maps to correct currency field
- System-specific handling:
  - D&D 5e/PF2e: XP_CURRENT, GP
  - PbtA: XP field
  - Blades: PLAYBOOK_XP, COIN
  - FATE Core/CoC 7e: Flagged for DM (milestone/skill-based advancement)

### 6. Modifiers/Conditions Display (All Systems)
- `SectionType::Modifiers` and `SectionType::Advancement`
- `SchemaFieldType::XpProgress` and `SchemaFieldType::ModifierList`
- System-specific modifiers_section() for each game system:
  - **D&D 5e**: Active conditions, ongoing effects
  - **PF2e**: Conditions, circumstance/status/item bonuses
  - **CoC 7e**: Injuries, temporary insanity, phobias
  - **FATE Core**: Situational aspects, boosts, invokes
  - **Blades**: Harm penalties, devil's bargains, pushing
  - **PbtA**: Debilities, holds, ongoing conditions

### 7. New FieldValue Types for Cross-System Support
- `DicePool { dice, die_type }` - for Blades action ratings
- `Percentile(u8)` - for CoC 7e percentile skills
- `LadderRating(i8)` - for FATE ladder values
- Unified extraction via `get_numeric_value()` method

## Game Systems Implemented

| System | Key Features |
|--------|--------------|
| **D&D 5e** | Ability scores, skills, saves, spellcasting, HP, XP tracking |
| **Pathfinder 2e** | 5 proficiency ranks, degree of success, 17 skills, XP tracking |
| **Call of Cthulhu 7e** | Percentile system, half/fifth values, Sanity/Luck |
| **FATE Core** | Ladder ratings, Aspects, Stress tracks, Consequences |
| **Blades in the Dark** | Action dots, Stress/Trauma, Clocks, Harm |
| **PbtA** | Variants: Apocalypse World, Dungeon World, Monster of the Week |

## Field Types

**Standard:** Number, Text, Select, Checkbox, TextArea
**Specialized:** StatBlock, SkillList, ResourceBar, SpellSlots
**System-specific:** PercentileSkill, LadderRating, DicePool, Clock, ConditionTrack
**Integration:** XpProgress, ModifierList

## Files Changed

- **53 files**, +20,000 lines
- New game systems module with 6 implementations
- WebSocket handler for character sheets + challenges
- Protocol types for character sheet requests
- System-aware XP/reward effect executors
- Challenge skill modifier integration
- Cross-system FieldValue types

## Test Plan

- [x] StatThreshold trigger tests (11 tests)
- [x] TriggerContext stat methods (3 tests)
- [x] Game system provider tests (125 tests)
- [x] D&D 5e XP system tests (5 tests)
- [x] Domain crate tests pass (388 total)
- [x] Engine crate builds successfully
- [x] Multi-system integration verified

## Use Cases

**StatThreshold Triggers:**
- Low HP triggers (`max_value: 10`) - Fire desperation/near-death events
- High stat triggers (`min_value: 15`) - Fire skill-based events
- Stat range triggers (`10 <= reputation <= 20`) - Zone-based narrative

**Character Sheets:**
- Create characters with system-appropriate fields
- Automatic calculation of derived values (modifiers, HP, AC, XP thresholds)
- Validation per system rules

**XP & Rewards (System-Aware):**
- Grant XP rewards from narrative events (AddReward effect)
- Track XP progress toward next level
- System automatically maps to correct XP field
- Narrative systems (FATE, CoC) flag rewards for DM handling

**Currency Rewards (System-Aware):**
- Grant gold/coin rewards from narrative events
- D&D/PF2e: Updates GP field
- Blades: Updates COIN field
- Narrative systems: Flagged for DM handling

**Skill-Based Challenges:**
- Set `check_stat` on challenges (e.g., "ATHLETICS_MOD", "STEALTH_MOD")
- Skill modifiers automatically applied to challenge rolls
- Works across all systems via unified value extraction

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)